### PR TITLE
Fix for intermittent test failures

### DIFF
--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCompleteTypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCompleteTypesTest.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.log4j.Logger;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -42,6 +43,11 @@ public class YugabyteDBCompleteTypesTest extends AbstractConnectorTest {
     public void after() throws Exception {
         stopConnector();
         TestHelper.executeDDL("drop_tables_and_databases.ddl");
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        ybContainer.stop();
     }
 
     private void consumeRecords(long recordsCount) {

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorIT.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorIT.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.log4j.Logger;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -44,6 +45,11 @@ public class YugabyteDBConnectorIT extends AbstractConnectorTest {
     public void after() throws Exception {
         stopConnector();
         TestHelper.executeDDL("drop_tables_and_databases.ddl");
+    }
+
+    @AfterClass
+    public void afterClass() throws Exception {
+        ybContainer.stop();
     }
 
     private void validateFieldDef(Field expected) {

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
@@ -10,6 +10,7 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.log4j.Logger;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -136,6 +137,11 @@ public class YugabyteDBDatatypesTest extends AbstractConnectorTest {
     public void after() throws Exception {
         stopConnector();
         TestHelper.executeDDL("drop_tables_and_databases.ddl");
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        ybContainer.stop();
     }
 
     // This test will just verify that the TestContainers are up and running


### PR DESCRIPTION
The ideal behaviour in case of TestContainers was when the test for a file are completed, the container should get cleaned up. However, in some cases, it was noticed that the cleanup is slow and the execution of the next test file begins before the container is cleaned up which leads to a situation where a new container fails to initialize.

This PR has the diff to fix the test failure issue.