### PR TITLE
Fix YBExtractNewRecordState transform to not drop non-Struct fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,11 @@
             <version>${version.kafka}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-transforms</artifactId>
+            <version>${version.kafka}</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${version.org.slf4j}</version>

--- a/src/main/java/io/debezium/connector/yugabytedb/transforms/YBExtractNewRecordState.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/transforms/YBExtractNewRecordState.java
@@ -115,6 +115,7 @@ public class YBExtractNewRecordState<R extends ConnectRecord<R>> extends Extract
                 }
             }
             else {
+                updatedValue.put(field.name(), value.get(field));
             }
         }
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
@@ -273,7 +273,6 @@ public class YugabyteDBDatatypesTest extends YugabyteDBTestBase {
     public void testRecordDeleteFieldWithYBExtractNewRecordState() throws Exception {
         TestHelper.dropAllSchemas();
         TestHelper.executeDDL("yugabyte_create_tables.ddl");
-        Thread.sleep(1000);
 
         YBExtractNewRecordState<SourceRecord> transformation = new YBExtractNewRecordState<>();
 
@@ -285,21 +284,20 @@ public class YugabyteDBDatatypesTest extends YugabyteDBTestBase {
         String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
         start(YugabyteDBConnector.class, configBuilder.build());
-        assertConnectorIsRunning();
         final long rowsCount = 1;
 
-        Thread.sleep(3000);
+        awaitUntilConnectorIsReady();
 
         // insert rows in the table t1 with values <some-pk, 'Vaibhav', 'Kushwaha', 30>
         insertRecords(rowsCount);
         // update rows in the table t1 where id is <some-pk>
         updateRecords(rowsCount);
-        // delete rown in the table t1 where id is <some-pk>
+        // delete rows in the table t1 where id is <some-pk>
         deleteRecords(rowsCount);
 
         // We have called 'insert', 'update' and 'delete' on each row. Thus we expect (rowsCount * 3) number of recrods
-        final long recrodsCount = rowsCount * 3;
-        CompletableFuture.runAsync(() -> verifyDeletedFieldPresentInValue(recrodsCount, transformation))
+        final long recordsCount = rowsCount * 3;
+        CompletableFuture.runAsync(() -> verifyDeletedFieldPresentInValue(recordsCount, transformation))
                 .exceptionally(throwable -> {
                     throw new RuntimeException(throwable);
                 }).get();

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
@@ -4,12 +4,14 @@ import static org.junit.Assert.*;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.log4j.Logger;
-import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -19,6 +21,8 @@ import org.testcontainers.containers.YugabyteYSQLContainer;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.yugabytedb.common.YugabyteDBTestBase;
+import io.debezium.connector.yugabytedb.transforms.YBExtractNewRecordState;
+import io.debezium.transforms.ExtractNewRecordStateConfigDefinition;
 import io.debezium.util.Strings;
 
 /**
@@ -66,6 +70,28 @@ public class YugabyteDBDatatypesTest extends YugabyteDBTestBase {
         }).get();
     }
 
+    private void updateRecords(long numOfRowsToBeUpdated) throws Exception {
+        String formatUpdateString = "UPDATE t1 SET hours = 10 WHERE id = %d";
+        CompletableFuture.runAsync(() -> {
+            for (int i = 0; i < numOfRowsToBeUpdated; i++) {
+                TestHelper.execute(String.format(formatUpdateString, i));
+            }
+        }).exceptionally(throwable -> {
+            throw new RuntimeException(throwable);
+        }).get();
+    }
+
+    private void deleteRecords(long numOfRowsToBeDeleted) throws Exception {
+        String formatDeleteString = "DELETE FROM t1 WHERE id = %d;";
+        CompletableFuture.runAsync(() -> {
+            for (int i = 0; i < numOfRowsToBeDeleted; i++) {
+                TestHelper.execute(String.format(formatDeleteString, i));
+            }
+        }).exceptionally(throwable -> {
+            throw new RuntimeException(throwable);
+        }).get();
+    }
+
     private void insertRecordsInSchema(long numOfRowsToBeInserted) throws Exception {
         String formatInsertString = "INSERT INTO test_schema.table_in_schema VALUES (%d, 'Vaibhav', 'Kushwaha', 30);";
         CompletableFuture.runAsync(() -> {
@@ -75,6 +101,34 @@ public class YugabyteDBDatatypesTest extends YugabyteDBTestBase {
         }).exceptionally(throwable -> {
             throw new RuntimeException(throwable);
         }).get();
+    }
+
+    private void verifyDeletedFieldPresentInValue(long recordsCount, YBExtractNewRecordState<SourceRecord> transformation) {
+        int totalConsumedRecords = 0;
+        long start = System.currentTimeMillis();
+        List<SourceRecord> records = new ArrayList<>();
+        while (totalConsumedRecords < recordsCount) {
+            int consumed = super.consumeAvailableRecords(record -> {
+                LOGGER.debug("The record being consumed is " + record);
+                records.add(record);
+            });
+            if (consumed > 0) {
+                totalConsumedRecords += consumed;
+                LOGGER.debug("Consumed " + totalConsumedRecords + " records");
+            }
+        }
+        LOGGER.info("Total duration to consume " + recordsCount + " records: " + Strings.duration(System.currentTimeMillis() - start));
+
+        for (int i = 0; i < recordsCount; ++i) {
+            SourceRecord transformedRecrod = transformation.apply(records.get(i));
+            Struct transformedRecrodValue = (Struct) transformedRecrod.value();
+            Object deleteFieldValue = transformedRecrodValue.get("__deleted");
+            if (deleteFieldValue == null) {
+                throw new RuntimeException("Required field: '__deleted', dropped from value of source record");
+            }
+
+            LOGGER.debug("'__deleted' field's value in source recrod: " + deleteFieldValue.toString());
+        }
     }
 
     private void verifyPrimaryKeyOnly(long recordsCount) {
@@ -213,6 +267,44 @@ public class YugabyteDBDatatypesTest extends YugabyteDBTestBase {
                 .exceptionally(throwable -> {
                     throw new RuntimeException(throwable);
                 }).get();
+    }
+
+    @Test
+    public void testRecordDeleteFieldWithYBExtractNewRecordState() throws Exception {
+        TestHelper.dropAllSchemas();
+        TestHelper.executeDDL("yugabyte_create_tables.ddl");
+        Thread.sleep(1000);
+
+        YBExtractNewRecordState<SourceRecord> transformation = new YBExtractNewRecordState<>();
+
+        Map<String, Object> configs = new HashMap<String, Object>();
+        configs.put(ExtractNewRecordStateConfigDefinition.DROP_TOMBSTONES.toString(), "false");
+        configs.put(ExtractNewRecordStateConfigDefinition.HANDLE_DELETES.toString(), "rewrite");
+        transformation.configure(configs);
+
+        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
+        Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
+        start(YugabyteDBConnector.class, configBuilder.build());
+        assertConnectorIsRunning();
+        final long rowsCount = 1;
+
+        Thread.sleep(3000);
+
+        // insert rows in the table t1 with values <some-pk, 'Vaibhav', 'Kushwaha', 30>
+        insertRecords(rowsCount);
+        // update rows in the table t1 where id is <some-pk>
+        updateRecords(rowsCount);
+        // delete rown in the table t1 where id is <some-pk>
+        deleteRecords(rowsCount);
+
+        // We have called 'insert', 'update' and 'delete' on each row. Thus we expect (rowsCount * 3) number of recrods
+        final long recrodsCount = rowsCount * 3;
+        CompletableFuture.runAsync(() -> verifyDeletedFieldPresentInValue(recrodsCount, transformation))
+                .exceptionally(throwable -> {
+                    throw new RuntimeException(throwable);
+                }).get();
+
+        transformation.close();
     }
 
     @Test


### PR DESCRIPTION
The "YBExtractNewRecordState" transform was interfering with the below two configurations: 
```
delete.handling.mode=rewrite
drop.tombstones=false
```
By dropping the field "__deleted" from the source record. 
This change rectifies the behaviour of "YBExtractNewRecordState". 
Specifically, now YBExtractNewRecordState will not drop non-Struct fields from the source recrod.