### PR TITLE
Check if connector has been stopped in ChangeEventSource. 

### DIFF
--- a/.github/workflows/sanity-workflow.yml
+++ b/.github/workflows/sanity-workflow.yml
@@ -21,4 +21,4 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Sanity Test that code compiles and tests pass.
-        run: mvn clean install -Pquick
+        run: mvn clean test

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -374,7 +374,7 @@ public class YugabyteDBStreamingChangeEventSource implements
 
                         // GetChangesResponse response = getChangeResponse(offsetContext);
                         LOGGER.debug("Going to fetch for tablet " + tabletId + " from OpId " + cp + " " +
-                                "table " + table.getName());
+                                "table " + table.getName() + " Running:", context.isRunning());
 
                         GetChangesResponse response = this.syncClient.getChangesCDCSDK(
                                 table, streamId, tabletId,

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -374,7 +374,7 @@ public class YugabyteDBStreamingChangeEventSource implements
 
                         // GetChangesResponse response = getChangeResponse(offsetContext);
                         LOGGER.debug("Going to fetch for tablet " + tabletId + " from OpId " + cp + " " +
-                                "table " + table.getName() + " Running:", context.isRunning());
+                                "table " + table.getName() + " Running:" + context.isRunning());
 
                         GetChangesResponse response = this.syncClient.getChangesCDCSDK(
                                 table, streamId, tabletId,

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -357,7 +357,7 @@ public class YugabyteDBStreamingChangeEventSource implements
         bootstrapTabletWithRetry(tabletPairList);
 
         short retryCount = 0;
-        while (retryCount <= connectorConfig.maxConnectorRetries()) {
+        while (context.isRunning() && retryCount <= connectorConfig.maxConnectorRetries()) {
             try {
                 while (context.isRunning() && (offsetContext.getStreamingStoppingLsn() == null ||
                         (lastCompletelyProcessedLsn.compareTo(offsetContext.getStreamingStoppingLsn()) < 0))) {
@@ -375,6 +375,12 @@ public class YugabyteDBStreamingChangeEventSource implements
                         // GetChangesResponse response = getChangeResponse(offsetContext);
                         LOGGER.debug("Going to fetch for tablet " + tabletId + " from OpId " + cp + " " +
                                 "table " + table.getName() + " Running:" + context.isRunning());
+
+                        // Check again if the thread has been interrupted.
+                        if (!context.isRunning()) {
+                            LOGGER.info("Connector has been stopped");
+                            break;
+                        }
 
                         GetChangesResponse response = this.syncClient.getChangesCDCSDK(
                                 table, streamId, tabletId,


### PR DESCRIPTION
Improve responsiveness of shutdown by checking for `isRunning` function in the loop that probes all tablets.
`mvn test` has become faster and now finishes in 2 minutes.

Run `mvn test` as part of workflows. 

Fix #16 