### PR TITLE
Add support for creating uber jars as a part of the build itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The YugabyteDB connector can also be used as a library without Kafka or Kafka Co
   2. Build the jar files using maven
       
       ```sh
-      mvn clean verify -Dquick
+      mvn clean package -Dquick
       ```
 
   3. Create a custom folder for the custom-connector
@@ -30,7 +30,7 @@ The YugabyteDB connector can also be used as a library without Kafka or Kafka Co
   4. Copy the debezium-connector-yugabytedb2 jar to the custom-connector directory
       
       ```sh
-      cp debezium-connector-yugabytedb2/target/debezium-connector-yugabytedb-1.3.2-BETA.jar ~/custom-connector/
+      cp target/debezium-connector-yugabytedb-1.7.0.8-SNAPSHOT.jar ~/custom-connector/
       ```
 
   5. Navigate to the directory you created
@@ -60,7 +60,7 @@ The YugabyteDB connector can also be used as a library without Kafka or Kafka Co
       # Deploy Kafka Connect yugabytedb
       RUN mkdir $KAFKA_CONNECT_YB_DIR && cd $KAFKA_CONNECT_YB_DIR
 
-      COPY debezium-connector-yugabytedb-1.3.2-BETA.jar \
+      COPY debezium-connector-yugabytedb-1.7.0.8-SNAPSHOT.jar \
       $KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-yugabytedb/
 
       COPY kafka-connect-jdbc-10.2.5.jar $KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-yugabytedb

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <version.surefire.plugin>3.0.0-M3</version.surefire.plugin>
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
+        <version.assembly.plugin>3.1.1</version.assembly.plugin>
         <version.release.plugin>3.0.0-M5</version.release.plugin>
         <version.site.plugin>3.7.1</version.site.plugin>
         <version.resources.plugin>3.1.0</version.resources.plugin>
@@ -286,6 +287,26 @@
            </extension>
         </extensions>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
This PR introduces the following diff:
- Addition of the maven assembly plugin to enable building of fat/uber jar for the `debezium-connector-yugabytedb`
- Modification of instructions to create a docker image