### PR TITLE
Test additions and improvements

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
@@ -115,6 +115,7 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
         Map<String, ConfigValue> results = validateAllFields(config);
 
         validateTServerConnection(results, config);
+        
         String streamIdValue = this.yugabyteDBConnectorConfig.streamId();
         LOGGER.debug("The streamid in config is" + this.yugabyteDBConnectorConfig.streamId());
 
@@ -280,7 +281,6 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
         }
 
         // Do a get and check if the streamid exists.
-        // TODO: Suranjan check the db stream info and verify if the tableIds are present
         // TODO: Find out where to do validation for table whitelist
         String streamId = yugabyteDBConnectorConfig.streamId();
         final ConfigValue streamIdConfig = configValues.get(YugabyteDBConnectorConfig.STREAM_ID.name());
@@ -399,13 +399,10 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
                 }
             }
         }
-        catch (DebeziumException de) {
+        catch (Exception e) {
             // We are ultimately throwing this exception since this will be thrown while initializing the connector
             // and at this point if this exception is thrown, we should not proceed forward with the connector.
-            throw de;
-        }
-        catch (Exception e) {
-            e.printStackTrace();
+            throw new DebeziumException(e);
         }
         return tIds;
     }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -599,13 +599,6 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
             .withImportance(Importance.LOW)
             .withDefault(false);
 
-    public static final Field AUTO_CREATE_STREAM = Field.create("auto.create.stream")
-            .withDisplayName("Specify whether to create a stream by default")
-            .withType(Type.BOOLEAN)
-            .withImportance(Importance.LOW)
-            .withDefault(false)
-            .withDescription("This will be enabled for testing purposes only, if set to true, the connector will create a DB stream ID");
-
     public static final Field CHAR_SET = Field.create(TASK_CONFIG_PREFIX + "charset")
             .withDisplayName("YugabyteDB charset")
             .withType(ConfigDef.Type.STRING)
@@ -1018,10 +1011,6 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
         return getConfig().getString(STREAM_ID);
     };
 
-    public boolean autoCreateStream() {
-        return getConfig().getBoolean(AUTO_CREATE_STREAM);
-    }
-
     public boolean ignoreExceptions() {
         return getConfig().getBoolean(IGNORE_EXCEPTIONS);
     }
@@ -1160,8 +1149,7 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
                     SSL_SOCKET_FACTORY,
                     STATUS_UPDATE_INTERVAL_MS,
                     TCP_KEEPALIVE,
-                    MAX_NUM_TABLETS,
-                    AUTO_CREATE_STREAM)
+                    MAX_NUM_TABLETS)
             .events(
                     INCLUDE_UNKNOWN_DATATYPES,
                     DatabaseHeartbeatImpl.HEARTBEAT_ACTION_QUERY)

--- a/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
@@ -296,14 +296,19 @@ public final class TestHelper {
         }
     }
 
-    protected static Configuration.Builder getConfigBuilder(String fullTablenameWithSchema, String dbStreamId) throws Exception {
+    protected static Configuration.Builder getConfigBuilder(String fullTableNameWithSchema, String dbStreamId) throws Exception {
+        return getConfigBuilder("yugabyte", fullTableNameWithSchema, dbStreamId);
+    }
+
+    protected static Configuration.Builder getConfigBuilder(String namespaceName, String fullTableNameWithSchema, String dbStreamId) throws Exception {
         return TestHelper.defaultConfig()
+                .with(YugabyteDBConnectorConfig.DATABASE_NAME, namespaceName)
                 .with(YugabyteDBConnectorConfig.HOSTNAME, CONTAINER_YSQL_HOST) // this field is required as of now
                 .with(YugabyteDBConnectorConfig.PORT, CONTAINER_YSQL_PORT)
                 .with(YugabyteDBConnectorConfig.SNAPSHOT_MODE, YugabyteDBConnectorConfig.SnapshotMode.NEVER.getValue())
                 .with(YugabyteDBConnectorConfig.DELETE_STREAM_ON_STOP, Boolean.TRUE)
                 .with(YugabyteDBConnectorConfig.MASTER_ADDRESSES, CONTAINER_YSQL_HOST + ":" + CONTAINER_MASTER_PORT)
-                .with(YugabyteDBConnectorConfig.TABLE_INCLUDE_LIST, fullTablenameWithSchema)
+                .with(YugabyteDBConnectorConfig.TABLE_INCLUDE_LIST, fullTableNameWithSchema)
                 .with(YugabyteDBConnectorConfig.STREAM_ID, dbStreamId);
     }
 

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 # Root logger option
-log4j.rootLogger=DEBUG, stdout, file
+log4j.rootLogger=INFO, stdout, file
 
 # Direct log messages to stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 # Root logger option
-log4j.rootLogger=INFO, stdout, file
+log4j.rootLogger=OFF, stdout, file
 
 # Direct log messages to stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender


### PR DESCRIPTION
This PR aims at increasing test coverage by adding unit test cases to validate the connector configuration, basically to provide a sanity test scenario. Additionally, the following changes are there as well:
* Addition of test to verify proper error message in case a null or empty stream ID is provided --> #6 
* Addition of test to verify the exception thrown and error message in case an empty `table.include.list` is provided --> #17 
* Removal of the configuration which allowed the connector to automatically create a DB stream ID