### PR TITLE
Changing an info log to debug level

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -505,7 +505,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                         offsetContext.getSourceInfo(tabletId)
                                 .updateLastCommit(finalOpid);
 
-                        LOGGER.info("The final opid is " + finalOpid);
+                        LOGGER.debug("The final opid is " + finalOpid);
                         if (snapshotter.shouldSnapshot() && finalOpid.equals(new OpId(-1, -1, "".getBytes(), 0 ,0))) {
                           snapshotCompleted.add(tabletId);
                           LOGGER.info("Stopping the snapshot for the tablet " + tabletId);


### PR DESCRIPTION
A info log line needs to be pushed down to debug level since it will hog up the logs with unnecessary extra lines. This PR aims to make the same change.