### PR TITLE
Fix for connector crash while deploying

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -1198,8 +1198,7 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
                     TCP_KEEPALIVE,
                     MAX_NUM_TABLETS)
             .events(
-                    INCLUDE_UNKNOWN_DATATYPES,
-                    DatabaseHeartbeatImpl.HEARTBEAT_ACTION_QUERY)
+                    INCLUDE_UNKNOWN_DATATYPES)
             .connector(
                     SNAPSHOT_MODE,
                     SNAPSHOT_MODE_CLASS,


### PR DESCRIPTION
After upgrade to debezium version `1.9.5.Final`, it was observed that the connector was not being deployed and threw error:

```
the config 'heartbeat.action.query' have been defined twice.
```

This PR contains a fix for the above mentioned issue.