### PR TITLE
Implementing the transition from snapshot to streaming

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -326,8 +326,8 @@ public class YugabyteDBStreamingChangeEventSource implements
                         LOGGER.debug("Snapshot completed for all the tablets! Stopping.");
                         if (!snapshotter.shouldStream()) {
                             // This block will be executed in case of initial_only mode
-                            LOGGER.info("Snapshot completed for initial_only mode, you can stop the connector now");
-                            break;
+                            LOGGER.info("Snapshot completed for initial_only mode, stopping the connector now");
+                            return;
                         }
                       }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/snapshot/InitialOnlySnapshotter.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/snapshot/InitialOnlySnapshotter.java
@@ -31,15 +31,15 @@ public class InitialOnlySnapshotter extends QueryingSnapshotter {
     @Override
     public boolean shouldSnapshot() {
         if (sourceInfo == null) {
-            LOGGER.info("Taking initial snapshot for new datasource");
+            LOGGER.debug("Taking initial snapshot for new datasource");
             return true;
         }
         else if (sourceInfo.snapshotInEffect()) {
-            LOGGER.info("Found previous incomplete snapshot");
+            LOGGER.debug("Found previous incomplete snapshot");
             return true;
         }
         else {
-            LOGGER.info("Previous initial snapshot completed, no snapshot will be performed");
+            LOGGER.debug("Previous initial snapshot completed, no snapshot will be performed");
             return false;
         }
     }

--- a/src/main/java/io/debezium/connector/yugabytedb/snapshot/InitialSnapshotter.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/snapshot/InitialSnapshotter.java
@@ -31,15 +31,15 @@ public class InitialSnapshotter extends QueryingSnapshotter {
     @Override
     public boolean shouldSnapshot() {
         if (sourceInfo == null) {
-            LOGGER.info("Taking initial snapshot for new datasource");
+            LOGGER.debug("Taking initial snapshot for new datasource");
             return true;
         }
         else if (sourceInfo.snapshotInEffect()) {
-            LOGGER.info("Found previous incomplete snapshot");
+            LOGGER.debug("Found previous incomplete snapshot");
             return true;
         }
         else {
-            LOGGER.info(
+            LOGGER.debug(
                     "Previous snapshot has completed successfully, streaming logical changes from last known position");
             return false;
         }


### PR DESCRIPTION
With this change, the user would not need to change the snapshot mode from `initial` to `never` in order to further stream the changes.

Now, if the connector is deployed with `snapshot.mode=initial`, it would first take the snapshot and then would automatically switch to streaming new changes in the source database.