### PR TITLE
Upgrade base image to be in sync with latest Debezium release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@
 #  - JDBC Sink Connector v10.2.5
 #  - YugabyteDB JDBC Driver v42.3.5-yb-1
 #  - MySql JDBC Driver v8.0.21
-FROM quay.io/yugabyte/connect-base-yb:0.2
+#  - PostgreSQL JDBC Driver v42.4.1
+FROM quay.io/yugabyte/connect-base-yb:0.3
 
 # Create the directories for the connectors to be placed into
 ENV KAFKA_CONNECT_YB_DIR=$KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-yugabytedb


### PR DESCRIPTION
Upgraded the Dockerfile to use a base image which is created using the latest Debezium release `debezium/connect:1.9.5.Final`.