### PR TITLE
Updating the base image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@
 #  - JDBC Sink Connector v10.2.5
 #  - YugabyteDB JDBC Driver v42.3.5-yb-1
 #  - MySql JDBC Driver v8.0.21
-FROM quay.io/yugabyte/connect-base-yb:0.2
+#  - PostgreSQL JDBC Driver v42.4.1
+FROM quay.io/yugabyte/connect-base-yb:0.2.1
 
 # Create the directories for the connectors to be placed into
 ENV KAFKA_CONNECT_YB_DIR=$KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-yugabytedb


### PR DESCRIPTION
The updated base image out of which we are now creating our custom image will now have the PostgreSQL JDBC Driver as well to assist in replication to a Postgres sink using the JDBC Sink Connector.

Additionally, this PR also closes issue #43 