### PR TITLE
Add PGCompatible Transform

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/transforms/PGCompatible.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/transforms/PGCompatible.java
@@ -1,0 +1,110 @@
+package io.debezium.connector.yugabytedb.transforms;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yb.util.Pair;
+
+public class PGCompatible<R extends ConnectRecord<R>> implements Transformation<R> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PGCompatible.class);
+
+    @Override
+    public R apply(final R record) {
+        if (record == null || (record.value() != null && !(record.value() instanceof Struct))) {
+            return record;
+        }
+
+        Pair<Schema, Struct> p = getUpdatedValueAndSchema((Struct) record.key());
+        Schema updatedSchemaForKey = p.getFirst();
+        Struct updatedValueForKey = p.getSecond();
+
+        Schema updatedSchemaForValue = null;
+        Struct updatedValueForValue = null;
+        if (record.value() != null) {
+            Pair<Schema, Struct> val = getUpdatedValueAndSchema((Struct) record.value());
+            updatedSchemaForValue = val.getFirst();
+            updatedValueForValue = val.getSecond();
+        }
+
+        return record.newRecord(record.topic(), record.kafkaPartition(), updatedSchemaForKey, updatedValueForKey, updatedSchemaForValue, updatedValueForValue, record.timestamp());
+    }
+
+    @Override
+    public ConfigDef config() {
+        return new ConfigDef();
+    }
+
+    @Override
+    public void close() {
+    }
+
+    private boolean isValueSetStruct(Field field) {
+        return field.schema().fields().size() == 2
+                && (Objects.equals(field.schema().fields().get(0).name(), "value")
+                && Objects.equals(field.schema().fields().get(1).name(), "set"));
+    }
+
+    private Schema makeUpdatedSchema(Schema schema, Struct value) {
+        if (value == null) {
+            return schema;
+        }
+
+        final SchemaBuilder builder = SchemaUtil.copySchemaBasics(schema, SchemaBuilder.struct());
+
+        for (Field field : schema.fields()) {
+            if (field.schema().type() == Type.STRUCT) {
+                if (isValueSetStruct(field) && value.get(field.name()) != null) {
+                    builder.field(field.name(), field.schema().field("value").schema());
+                } else {
+                    builder.field(field.name(), makeUpdatedSchema(field.schema(), (Struct) value.get(field.name())));
+                }
+            } else {
+                builder.field(field.name(), field.schema());
+            }
+        }
+
+        return builder.build();
+    }
+
+    private Struct makeUpdatedValue(Schema updatedSchema, Struct value) {
+        final Struct updatedValue = new Struct(updatedSchema);
+
+        for (Field field : value.schema().fields()) {
+            if (field.schema().type() == Type.STRUCT) {
+                Struct fieldValue = (Struct) value.get(field);
+                if (isValueSetStruct(field) && fieldValue != null) {
+                    updatedValue.put(field.name(), fieldValue.get("value"));
+                } else if (fieldValue != null) {
+                    updatedValue.put(field.name(), makeUpdatedValue(updatedSchema.field(field.name()).schema(), fieldValue));
+                }
+            } else {
+                updatedValue.put(field.name(), value.get(field));
+            }
+        }
+
+        return updatedValue;
+    }
+
+    public Pair<Schema, Struct> getUpdatedValueAndSchema(Struct value) {
+        Schema updatedSchema = makeUpdatedSchema(value.schema(), value);
+
+        LOGGER.debug("Updated schema as json: " + io.debezium.data.SchemaUtil.asString(value.schema()));
+
+        return new org.yb.util.Pair<>(updatedSchema, makeUpdatedValue(updatedSchema, value));
+    }
+
+    @Override
+    public void configure(Map<String, ?> map) {
+
+    }
+}

--- a/src/test/java/io/debezium/connector/yugabytedb/transforms/PGCompatibleTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/transforms/PGCompatibleTest.java
@@ -1,0 +1,155 @@
+package io.debezium.connector.yugabytedb.transforms;
+
+import io.debezium.data.Envelope;
+import io.debezium.transforms.ExtractNewRecordStateConfigDefinition;
+import org.apache.kafka.common.protocol.types.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+import org.yb.util.Pair;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.ADD_HEADERS;
+import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.HANDLE_DELETES;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+public class PGCompatibleTest {
+    final Schema idSchema =  SchemaBuilder.struct()
+            .field("value", Schema.INT64_SCHEMA)
+            .field("set", Schema.BOOLEAN_SCHEMA);
+
+    final Schema nameSchema =  SchemaBuilder.struct()
+            .field("value", Schema.STRING_SCHEMA)
+            .field("set", Schema.BOOLEAN_SCHEMA);
+
+    final Schema keySchema = SchemaBuilder.struct()
+            .field("id", idSchema)
+            .build();
+
+    final Schema valueSchema = SchemaBuilder.struct()
+            .field("id", idSchema)
+            .field("name", nameSchema)
+            .build();
+
+    final Schema sourceSchema = SchemaBuilder.struct()
+            .field("lsn", Schema.INT32_SCHEMA)
+            .field("ts_ms", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("op", Schema.STRING_SCHEMA)
+            .build();
+
+    final Envelope envelope = Envelope.defineSchema()
+            .withName("dummy.Envelope")
+            .withRecord(valueSchema)
+            .withSource(sourceSchema)
+            .build();
+
+    private Struct createIdStruct() {
+        final Struct id = new Struct(idSchema);
+        id.put("value", (long) 1L);
+        id.put("set", true);
+
+        return id;
+    }
+
+    private Struct createNameStruct() {
+        final Struct name = new Struct(nameSchema);
+        name.put("value", "yb");
+        name.put("set", true);
+        return name;
+    }
+
+    private Struct createValue() {
+        final Struct value = new Struct(valueSchema);
+        value.put("id", createIdStruct());
+        value.put("name", createNameStruct());
+
+        return value;
+    }
+
+    @Test
+    public void testSingleLevelStruct() {
+        try (final PGCompatible<SourceRecord> transform = new PGCompatible<>()) {
+            final Pair<Schema, Struct> unwrapped = transform.getUpdatedValueAndSchema(createValue());
+            assert(((Struct) unwrapped.getSecond()).getInt64("id") == 1);
+            assert(((Struct) unwrapped.getSecond()).getString("name").equals("yb"));
+
+        }
+    }
+
+    private Struct createPayload() {
+        final Struct source = new Struct(sourceSchema);
+        source.put("lsn", 1234);
+        source.put("ts_ms", 12836);
+        source.put("op", "c");
+        return envelope.create(createValue(), source, Instant.now());
+    }
+
+    @Test
+    public void testPayload() {
+        try (final PGCompatible<SourceRecord> transform = new PGCompatible<>()) {
+            final Pair<Schema, Struct> unwrapped = transform.getUpdatedValueAndSchema(createPayload());
+            Schema valueSchema = unwrapped.getFirst();
+
+            assert(valueSchema.type() == Schema.Type.STRUCT);
+            assert(valueSchema.fields().size() == 6);
+            assert(valueSchema.field("op").schema().type() == Schema.Type.STRING);
+
+            Schema afterSchema = valueSchema.field("after").schema();
+            assert (afterSchema.type() == Schema.Type.STRUCT);
+            assert (afterSchema.fields().size() == 2);
+            assert (afterSchema.field("id").schema().type() == Schema.Type.INT64);
+            assert (afterSchema.field("name").schema().type() == Schema.Type.STRING);
+
+            Struct after = ((Struct) unwrapped.getSecond()).getStruct("after");
+            assert(after.getInt64("id") == 1);
+            assert(after.getString("name").equals("yb"));
+        }
+    }
+
+    private SourceRecord createCreateRecord() {
+        final Struct key = new Struct(keySchema);
+        key.put("id", createIdStruct());
+
+        final Struct payload = createPayload();
+        return new SourceRecord(new HashMap<>(), new HashMap<>(), "dummy", keySchema, key, envelope.schema(), payload);
+    }
+
+    private String getSourceRecordHeaderByKey(SourceRecord record, String headerKey) {
+        Iterator<Header> operationHeader = record.headers().allWithName(headerKey);
+        if (!operationHeader.hasNext()) {
+            return null;
+        }
+
+        Object value = operationHeader.next().value();
+
+        return value != null ? value.toString() : null;
+    }
+
+
+    @Test
+    public void testHandleCreateRewrite() {
+        try (final PGCompatible<SourceRecord> transform = new PGCompatible<>()) {
+            final Map<String, String> props = new HashMap<>();
+            props.put(HANDLE_DELETES.name(), "rewrite");
+            props.put(ADD_HEADERS.name(), "op");
+            transform.configure(props);
+
+            final SourceRecord createRecord = createCreateRecord();
+            final SourceRecord unwrapped = transform.apply(createRecord);
+            assert(((Struct) unwrapped.value()).getString("__deleted").equals("false"));
+            assert(((Struct) unwrapped.value()).getInt64("id") == 1);
+            assert(((Struct) unwrapped.value()).getString("name").equals("yb"));
+            assert(unwrapped.headers().size() == 1);
+            String headerValue = getSourceRecordHeaderByKey(unwrapped, ExtractNewRecordStateConfigDefinition.DEBEZIUM_OPERATION_HEADER_KEY);
+            assert(headerValue.equals(Envelope.Operation.CREATE.code()));
+        }
+    }
+}

--- a/src/test/java/io/debezium/connector/yugabytedb/transforms/PGCompatibleTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/transforms/PGCompatibleTest.java
@@ -144,11 +144,11 @@ public class PGCompatibleTest {
 
             final SourceRecord createRecord = createCreateRecord();
             final SourceRecord unwrapped = transform.apply(createRecord);
-            assert(((Struct) unwrapped.value()).getInt64("id") == 1);
-            assert(((Struct) unwrapped.value()).getString("name").equals("yb"));
-            assert(unwrapped.headers().size() == 1);
-            String headerValue = getSourceRecordHeaderByKey(unwrapped, ExtractNewRecordStateConfigDefinition.DEBEZIUM_OPERATION_HEADER_KEY);
-            assert(headerValue.equals(Envelope.Operation.CREATE.code()));
+            Struct after = ((Struct) unwrapped.value()).getStruct("after");
+            assert (after.getInt64("id") == 1);
+            assert (after.getString("name").equals("yb"));
+
+            assert (((Struct) unwrapped.value()).getString("op") == "c");
         }
     }
 }

--- a/src/test/java/io/debezium/connector/yugabytedb/transforms/PGCompatibleTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/transforms/PGCompatibleTest.java
@@ -144,7 +144,6 @@ public class PGCompatibleTest {
 
             final SourceRecord createRecord = createCreateRecord();
             final SourceRecord unwrapped = transform.apply(createRecord);
-            assert(((Struct) unwrapped.value()).getString("__deleted").equals("false"));
             assert(((Struct) unwrapped.value()).getInt64("id") == 1);
             assert(((Struct) unwrapped.value()).getString("name").equals("yb"));
             assert(unwrapped.headers().size() == 1);


### PR DESCRIPTION
Implement a transform to make the event compatible with Postgres CDC Record Structure. 
It collapses `value` and `set` in a column record structure.