### PR TITLE
Updating protobuf-java dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
         <!-- Dependency Versions -->
         <version.postgresql.driver>42.4.2</version.postgresql.driver>
-        <version.com.google.protobuf>3.21.5</version.com.google.protobuf>
+        <version.com.google.protobuf>3.21.7</version.com.google.protobuf>
         <version.kafka>3.2.1</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>


### PR DESCRIPTION
This PR is to update a dependency to a version which had the patch containing the fixes for a vulnerability raised by [Dependabot](https://github.com/yugabyte/debezium-connector-yugabytedb/security/dependabot/9).