### PR TITLE
[#76] Only restart if the newly found table is a part of the include list

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -511,7 +511,7 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
     protected static final int DEFAULT_MAX_CONNECTOR_RETRIES = 5;
     protected static final long DEFAULT_CONNECTOR_RETRY_DELAY_MS = 60000;
     protected static final boolean DEFAULT_LIMIT_ONE_POLL_PER_ITERATION = false;
-    protected static final long DEFAULT_NEW_TABLE_POLL_INTERVAL_MS = 5 * 60 * 1000L;
+    protected static final long DEFAULT_NEW_TABLE_POLL_INTERVAL_MS = 5000L;
 
     @Override
     public JdbcConfiguration getJdbcConfig() {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -511,7 +511,7 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
     protected static final int DEFAULT_MAX_CONNECTOR_RETRIES = 5;
     protected static final long DEFAULT_CONNECTOR_RETRY_DELAY_MS = 60000;
     protected static final boolean DEFAULT_LIMIT_ONE_POLL_PER_ITERATION = false;
-    protected static final long DEFAULT_NEW_TABLE_POLL_INTERVAL_MS = 5000L;
+    protected static final long DEFAULT_NEW_TABLE_POLL_INTERVAL_MS = 5 * 60 * 1000L;
 
     @Override
     public JdbcConfiguration getJdbcConfig() {


### PR DESCRIPTION
The objective of this PR is to add the logic where if the new table poller thread sees a new table, it also verifies if the table is a part of the include list - if it is, only then signal the reconfiguration.

Additionally, this PR closes issue #76.