### PR TITLE
[#75] Increase default polling interval for new table poller thread

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -511,7 +511,7 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
     protected static final int DEFAULT_MAX_CONNECTOR_RETRIES = 5;
     protected static final long DEFAULT_CONNECTOR_RETRY_DELAY_MS = 60000;
     protected static final boolean DEFAULT_LIMIT_ONE_POLL_PER_ITERATION = false;
-    protected static final long DEFAULT_NEW_TABLE_POLL_INTERVAL_MS = 5000L;
+    protected static final long DEFAULT_NEW_TABLE_POLL_INTERVAL_MS = 5 * 60 * 1000L;
 
     @Override
     public JdbcConfiguration getJdbcConfig() {


### PR DESCRIPTION
This PR closes issue #75 by changing the default polling interval at which the thread polls to check if there are any new tables added to the stream.