### PR TITLE
[#82] Support for publishing before image of the row

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeRecordEmitter.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeRecordEmitter.java
@@ -48,6 +48,8 @@ public class YugabyteDBChangeRecordEmitter extends RelationalChangeRecordEmitter
     private final YugabyteDBConnection connection;
     private final TableId tableId;
 
+    private boolean shouldSendBeforeImage = false;
+
     private final String pgSchemaName;
 
     public YugabyteDBChangeRecordEmitter(YBPartition partition, OffsetContext offset, Clock clock,
@@ -82,6 +84,26 @@ public class YugabyteDBChangeRecordEmitter extends RelationalChangeRecordEmitter
 
         this.tableId = tableId;
         Objects.requireNonNull(this.tableId);
+    }
+
+    public YugabyteDBChangeRecordEmitter(YBPartition partition, OffsetContext offset, Clock clock,
+                                         YugabyteDBConnectorConfig connectorConfig,
+                                         YugabyteDBSchema schema, YugabyteDBConnection connection,
+                                         TableId tableId, ReplicationMessage message, String pgSchemaName,
+                                         boolean shouldSendBeforeImage) {
+        super(partition, offset, clock);
+
+        this.schema = schema;
+        this.message = message;
+        this.connectorConfig = connectorConfig;
+        this.connection = connection;
+
+        this.pgSchemaName = pgSchemaName;
+
+        this.tableId = tableId;
+        Objects.requireNonNull(this.tableId);
+
+        this.shouldSendBeforeImage = shouldSendBeforeImage;
     }
 
     @Override
@@ -127,6 +149,9 @@ public class YugabyteDBChangeRecordEmitter extends RelationalChangeRecordEmitter
                 // return columnValues(message.getOldTupleList(), tableId, true,
                 // message.hasTypeMetadata(), true, true);
                 case UPDATE:
+                    if (!shouldSendBeforeImage) {
+                        return null;
+                    }
                 default:
                     return columnValues(message.getOldTupleList(), tableId, true,
                             message.hasTypeMetadata(), false, true);
@@ -187,6 +212,7 @@ public class YugabyteDBChangeRecordEmitter extends RelationalChangeRecordEmitter
         if (columns == null || columns.isEmpty()) {
             return null;
         }
+
         final Table table = schema.tableFor(tableId);
         if (table == null) {
             schema.dumpTableId();

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeRecordEmitter.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeRecordEmitter.java
@@ -122,12 +122,11 @@ public class YugabyteDBChangeRecordEmitter extends RelationalChangeRecordEmitter
             switch (getOperation()) {
                 case CREATE:
                     return null;
-                case UPDATE:
-                    return null;
                 case READ:
                     return null;
                 // return columnValues(message.getOldTupleList(), tableId, true,
                 // message.hasTypeMetadata(), true, true);
+                case UPDATE:
                 default:
                     return columnValues(message.getOldTupleList(), tableId, true,
                             message.hasTypeMetadata(), false, true);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
@@ -128,6 +128,15 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
             streamIdValue = results.get(YugabyteDBConnectorConfig.STREAM_ID.name()).value().toString();
         }
 
+        boolean sendBeforeImage = false;
+        try {
+            sendBeforeImage = YBClientUtils.isBeforeImageEnabled(this.yugabyteDBConnectorConfig);
+            LOGGER.info("Before image status: {}", sendBeforeImage);
+        } catch (Exception e) {
+            LOGGER.error("Error while trying to get before image status", e);
+            throw new DebeziumException(e);
+        }
+
         LOGGER.debug("The streamid being used is " + streamIdValue);
 
         int numGroups = Math.min(this.tabletIds.size(), maxTasks);
@@ -155,6 +164,7 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
             taskProps.put(YugabyteDBConnectorConfig.NAME_TO_TYPE.toString(), serializedNameToType);
             taskProps.put(YugabyteDBConnectorConfig.OID_TO_TYPE.toString(), serializedOidToType);
             taskProps.put(YugabyteDBConnectorConfig.STREAM_ID.toString(), streamIdValue);
+            taskProps.put(YugabyteDBConnectorConfig.SEND_BEFORE_IMAGE.toString(), String.valueOf(sendBeforeImage));
             taskConfigs.add(taskProps);
         }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.config.ConfigValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.DebeziumException;
 import io.debezium.config.ConfigDefinition;
 import io.debezium.config.Configuration;
 import io.debezium.config.EnumeratedValue;
@@ -52,6 +53,8 @@ import io.debezium.util.Strings;
 public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(YugabyteDBConnectorConfig.class);
+
+    private Boolean sendBeforeImage = null;
 
     /**
      * The set of predefined HStoreHandlingMode options or aliases

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.config.ConfigValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.debezium.DebeziumException;
 import io.debezium.config.ConfigDefinition;
 import io.debezium.config.Configuration;
 import io.debezium.config.EnumeratedValue;
@@ -53,8 +52,6 @@ import io.debezium.util.Strings;
 public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(YugabyteDBConnectorConfig.class);
-
-    private Boolean sendBeforeImage = null;
 
     /**
      * The set of predefined HStoreHandlingMode options or aliases

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -542,6 +542,11 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
             .withValidation(Field::isInteger)
             .withInvisibleRecommender();
 
+    protected static final Field SEND_BEFORE_IMAGE = Field.create("yugabytedb.send.before.image")
+            .withDescription("Internal use only")
+            .withValidation(Field::isBoolean)
+            .withInvisibleRecommender();
+
     public static final Field TABLET_LIST = Field.create(TASK_CONFIG_PREFIX + "tabletlist")
             .withDisplayName("YugabyteDB Tablet LIST for a Task")
             .withType(ConfigDef.Type.STRING)

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorTask.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorTask.java
@@ -131,7 +131,8 @@ public class YugabyteDBConnectorTask
                 valueConverterBuilder.build(yugabyteDBTypeRegistry));
 
         String taskId = config.getString(YugabyteDBConnectorConfig.TASK_ID.toString());
-        this.taskContext = new YugabyteDBTaskContext(connectorConfig, schema, topicSelector, taskId);
+        boolean sendBeforeImage = config.getBoolean(YugabyteDBConnectorConfig.SEND_BEFORE_IMAGE.toString());
+        this.taskContext = new YugabyteDBTaskContext(connectorConfig, schema, topicSelector, taskId, sendBeforeImage);
 
         // Get the tablet ids and load the offsets
         final Offsets<YBPartition, YugabyteDBOffsetContext> previousOffsets = 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -244,9 +244,6 @@ public class YugabyteDBStreamingChangeEventSource implements
 
         LOGGER.info("Using DB stream ID: " + streamId);
 
-        boolean shouldSendBeforeImage = YBClientUtils.isBeforeImageEnabled(connectorConfig);
-        LOGGER.info("Before image enabled for task {}: {}", taskContext.getTaskId(), shouldSendBeforeImage);
-
         Set<String> tIds = tabletPairList.stream().map(pair -> pair.getLeft()).collect(Collectors.toSet());
         for (String tId : tIds) {
             LOGGER.debug("Table UUID: " + tIds);
@@ -487,7 +484,7 @@ public class YugabyteDBStreamingChangeEventSource implements
 
                                     boolean dispatched = message.getOperation() != Operation.NOOP
                                             && dispatcher.dispatchDataChangeEvent(part, tableId, new YugabyteDBChangeRecordEmitter(part, offsetContext, clock, connectorConfig,
-                                                    schema, connection, tableId, message, pgSchemaNameInRecord, shouldSendBeforeImage));
+                                                    schema, connection, tableId, message, pgSchemaNameInRecord, taskContext.isBeforeImageEnabled()));
 
                                     if (recordsInTransactionalBlock.containsKey(tabletId)) {
                                         recordsInTransactionalBlock.merge(tabletId, 1, Integer::sum);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -244,6 +244,9 @@ public class YugabyteDBStreamingChangeEventSource implements
 
         LOGGER.info("Using DB stream ID: " + streamId);
 
+        boolean shouldSendBeforeImage = YBClientUtils.isBeforeImageEnabled(connectorConfig);
+        LOGGER.info("Before image enabled for task {}: {}", taskContext.getTaskId(), shouldSendBeforeImage);
+
         Set<String> tIds = tabletPairList.stream().map(pair -> pair.getLeft()).collect(Collectors.toSet());
         for (String tId : tIds) {
             LOGGER.debug("Table UUID: " + tIds);
@@ -484,7 +487,7 @@ public class YugabyteDBStreamingChangeEventSource implements
 
                                     boolean dispatched = message.getOperation() != Operation.NOOP
                                             && dispatcher.dispatchDataChangeEvent(part, tableId, new YugabyteDBChangeRecordEmitter(part, offsetContext, clock, connectorConfig,
-                                                    schema, connection, tableId, message, pgSchemaNameInRecord));
+                                                    schema, connection, tableId, message, pgSchemaNameInRecord, shouldSendBeforeImage));
 
                                     if (recordsInTransactionalBlock.containsKey(tabletId)) {
                                         recordsInTransactionalBlock.merge(tabletId, 1, Integer::sum);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBTaskContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBTaskContext.java
@@ -34,13 +34,17 @@ public class YugabyteDBTaskContext extends CdcSourceTaskContext {
     private final TopicSelector<TableId> topicSelector;
     private final YugabyteDBSchema schema;
 
+    private final boolean sendBeforeImage;
+
     protected YugabyteDBTaskContext(YugabyteDBConnectorConfig config, YugabyteDBSchema schema,
-                                    TopicSelector<TableId> topicSelector, String taskId) {
+                                    TopicSelector<TableId> topicSelector, String taskId,
+                                    boolean sendBeforeImage) {
         super(config.getContextName(), config.getLogicalName(), taskId, Collections::emptySet);
         this.config = config;
         this.topicSelector = topicSelector;
         assert schema != null;
         this.schema = schema;
+        this.sendBeforeImage = sendBeforeImage;
     }
 
     protected TopicSelector<TableId> topicSelector() {
@@ -53,6 +57,10 @@ public class YugabyteDBTaskContext extends CdcSourceTaskContext {
 
     protected YugabyteDBConnectorConfig config() {
         return config;
+    }
+
+    protected boolean isBeforeImageEnabled() {
+        return this.sendBeforeImage;
     }
 
     protected void refreshSchema(YugabyteDBConnection connection,

--- a/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
@@ -296,6 +296,11 @@ public final class TestHelper {
         }
     }
 
+    public static void initDB(String initDdlFile) throws Exception {
+        dropAllSchemas();
+        executeDDL(initDdlFile);
+    }
+
     public static void insertData() throws SQLException {
         String[] insertStmts = {
                 "INSERT INTO t1 VALUES (1, 'Vaibhav', 'Kushwaha', 30);",
@@ -454,7 +459,8 @@ public final class TestHelper {
         return null;
     }
 
-    public static String getNewDbStreamId(String namespaceName, String tableName) throws Exception {
+    public static String getNewDbStreamId(String namespaceName, String tableName,
+                                          boolean withBeforeImage) throws Exception {
         YBClient syncClient = getYbClient(MASTER_ADDRESS);
 
         YBTable placeholderTable = getYbTable(syncClient, tableName);
@@ -466,12 +472,17 @@ public final class TestHelper {
         String dbStreamId;
         try {
             dbStreamId = syncClient.createCDCStream(placeholderTable, namespaceName,
-                                                           "PROTO", "IMPLICIT").getStreamId();
+                                                    "PROTO", "IMPLICIT",
+                                                    withBeforeImage ? "ALL" : null).getStreamId();
         } finally {
             syncClient.close();
         }
 
         return dbStreamId;
+    }
+
+    public static String getNewDbStreamId(String namespaceName, String tableName) throws Exception {
+        return getNewDbStreamId(namespaceName, tableName, false);
     }
 
     public static JdbcConfiguration.Builder defaultJdbcConfigBuilder() {

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBBeforeImageTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBBeforeImageTest.java
@@ -1,0 +1,345 @@
+package io.debezium.connector.yugabytedb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.YugabyteYSQLContainer;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.yugabytedb.common.YugabyteDBTestBase;
+
+public class YugabyteDBBeforeImageTest extends YugabyteDBTestBase {
+  private final static Logger LOGGER = LoggerFactory.getLogger(YugabyteDBPartitionTest.class);
+  private final String formatInsertString =
+      "INSERT INTO t1 VALUES (%d, 'Vaibhav', 'Kushwaha', 12.345);";
+  private static YugabyteYSQLContainer ybContainer;
+  private static String masterAddresses;
+
+  @BeforeClass
+  public static void beforeClass() throws SQLException {
+      ybContainer = TestHelper.getYbContainer();
+      ybContainer.start();
+
+      TestHelper.setContainerHostPort(ybContainer.getHost(), ybContainer.getMappedPort(5433));
+      TestHelper.setMasterAddress(ybContainer.getHost() + ":" + ybContainer.getMappedPort(7100));
+      masterAddresses = ybContainer.getHost() + ":" + ybContainer.getMappedPort(7100);
+
+      TestHelper.dropAllSchemas();
+  }
+
+  @Before
+  public void before() {
+      initializeConnectorTestFramework();
+  }
+
+  @After
+  public void after() throws Exception {
+      stopConnector();
+      TestHelper.executeDDL("drop_tables_and_databases.ddl");
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+      ybContainer.stop();
+  }
+
+  @Test
+  public void isBeforeGettingPublished() throws Exception {
+      TestHelper.initDB("yugabyte_create_tables.ddl");
+
+      String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", true /* withBeforeImage */);
+      Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
+      start(YugabyteDBConnector.class, configBuilder.build());
+
+      awaitUntilConnectorIsReady();
+
+      // Insert a record and update it.
+      TestHelper.execute(String.format(formatInsertString, 1));
+      TestHelper.execute("UPDATE t1 SET first_name='VKVK', hours=56.78 where id = 1;");
+
+      // Consume the records and verify that the records should have the relevant information.
+      List<SourceRecord> records = new ArrayList<>();
+      CompletableFuture.runAsync(() -> getRecords(records, 2, 20000)).get();
+
+      // The first record is an insert record with before image as null.
+      SourceRecord insertRecord = records.get(0);
+      assertValueField(insertRecord, "before", null);
+      assertAfterImage(insertRecord, 1, "Vaibhav", "Kushwaha", 12.345);
+
+      // The second record will be an update record having a before image.
+      SourceRecord updateRecord = records.get(1);
+      assertBeforeImage(updateRecord, 1, "Vaibhav", "Kushwaha", 12.345);
+      assertAfterImage(updateRecord, 1, "VKVK", "Kushwaha", 56.78);
+  }
+
+  @Test
+  public void consecutiveSingleShardTransactions() throws Exception {
+      TestHelper.initDB("yugabyte_create_tables.ddl");
+
+      String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", true /* withBeforeImage */);
+      Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
+      start(YugabyteDBConnector.class, configBuilder.build());
+
+      awaitUntilConnectorIsReady();
+
+      // Insert a record and update it.
+      TestHelper.execute(String.format(formatInsertString, 1));
+      TestHelper.execute("UPDATE t1 SET last_name='some_last_name' where id = 1;");
+      TestHelper.execute("UPDATE t1 SET first_name='V', last_name='K', hours=0.05 where id = 1;");
+
+      // Consume the records and verify that the records should have the relevant information.
+      List<SourceRecord> records = new ArrayList<>();
+      CompletableFuture.runAsync(() -> getRecords(records, 3, 20000)).get();
+
+      // The first record is an insert record with before image as null.
+      SourceRecord insertRecord = records.get(0);
+      assertValueField(insertRecord, "before", null);
+      assertAfterImage(insertRecord, 1, "Vaibhav", "Kushwaha", 12.345);
+
+      // The second record will be an update record having a before image.
+      SourceRecord updateRecord = records.get(1);
+      assertBeforeImage(updateRecord, 1, "Vaibhav", "Kushwaha", 12.345);
+      assertAfterImage(updateRecord, 1, "Vaibhav", "some_last_name", 12.345);
+
+      // The third record will be an update record too.
+      SourceRecord updateRecord2 = records.get(2);
+      assertBeforeImage(updateRecord2, 1, "Vaibhav", "some_last_name", 12.345);
+      assertAfterImage(updateRecord2, 1, "V", "K", 0.05);
+  }
+
+  @Test
+  public void multiShardTransactions() throws Exception {
+    TestHelper.initDB("yugabyte_create_tables.ddl");
+
+    String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", true /* withBeforeImage */);
+    Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
+    start(YugabyteDBConnector.class, configBuilder.build());
+
+    awaitUntilConnectorIsReady();
+
+    // Perform operations on the table
+    TestHelper.execute("BEGIN; " + String.format(formatInsertString, 1) + " COMMIT;");
+    TestHelper.execute("BEGIN; " + String.format(formatInsertString, 2) + " COMMIT;");
+    TestHelper.execute("BEGIN; UPDATE t1 SET hours=98.765 where id = 1; COMMIT;");
+    TestHelper.execute("BEGIN; UPDATE t1 SET first_name='first_name_12345' where id = 2; COMMIT;");
+    TestHelper.execute("DELETE from t1 WHERE id = 1;");
+    TestHelper.execute("DELETE from t1 WHERE id = 2;");
+
+    // The above statements will generate 8 records:
+    // INSERT + INSERT + UPDATE + UPDATE + DELETE + TOMBSTONE + DELETE + TOMBSTONE.
+    int totalRecordsToConsume = 8;
+
+    // Consume the records and verify that the records should have the relevant information.
+    List<SourceRecord> records = new ArrayList<>();
+    CompletableFuture.runAsync(() -> getRecords(records, totalRecordsToConsume, 20000)).get();
+
+    // The first and second records will be insert records with before image as null.
+    SourceRecord record0 = records.get(0);
+    assertValueField(record0, "before", null);
+    assertAfterImage(record0, 1, "Vaibhav", "Kushwaha", 12.345);
+
+    SourceRecord record1 = records.get(1);
+    assertValueField(record1, "before", null);
+    assertAfterImage(record1, 2, "Vaibhav", "Kushwaha", 12.345);
+
+    // The third and fourth records will be update records.
+    SourceRecord record2 = records.get(2);
+    assertBeforeImage(record2, 1, "Vaibhav", "Kushwaha", 12.345);
+    assertAfterImage(record2, 1, "Vaibhav", "Kushwaha", 98.765);
+
+    SourceRecord record3 = records.get(3);
+    assertBeforeImage(record3, 2, "Vaibhav", "Kushwaha", 12.345);
+    assertAfterImage(record3, 2, "first_name_12345", "Kushwaha", 12.345);
+
+    // For deletes, we will be getting 4 records i.e. DELETE+TOMBSTONE+DELETE+TOMBSTONE.
+    SourceRecord record4 = records.get(4);
+    assertBeforeImage(record4, 1, "Vaibhav", "Kushwaha", 98.765);
+    assertValueField(record4, "after", null); // Delete records have null after field.
+
+    assertTombstone(records.get(5));
+
+    SourceRecord record6 = records.get(6);
+    assertBeforeImage(record6, 2, "first_name_12345", "Kushwaha", 12.345);
+    assertValueField(record6, "after", null); // Delete records have null after field.
+
+    assertTombstone(records.get(7));
+  }
+
+  @Test
+  public void updateWithNullValues() throws Exception {
+    TestHelper.initDB("yugabyte_create_tables.ddl");
+
+    String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", true /* withBeforeImage */);
+    Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
+    start(YugabyteDBConnector.class, configBuilder.build());
+
+    awaitUntilConnectorIsReady();
+
+    // Insert a record and update it.
+    TestHelper.execute(String.format(formatInsertString, 1));
+    TestHelper.execute("UPDATE t1 SET last_name=null, hours=null where id = 1;");
+
+    // Consume the records and verify that the records should have the relevant information.
+    List<SourceRecord> records = new ArrayList<>();
+    CompletableFuture.runAsync(() -> getRecords(records, 2, 20000)).get();
+
+    // The first record is an insert record with before image as null.
+    SourceRecord insertRecord = records.get(0);
+    assertValueField(insertRecord, "before", null);
+    assertAfterImage(insertRecord, 1, "Vaibhav", "Kushwaha", 12.345);
+
+    // The second record will be an update record having a before image.
+    SourceRecord updateRecord = records.get(1);
+    assertBeforeImage(updateRecord, 1, "Vaibhav", "Kushwaha", 12.345);
+    assertAfterImage(updateRecord, 1, "Vaibhav", null, null);
+  }
+
+  @Test
+  public void modifyPrimaryKey() throws Exception {
+    // NOTE: The modification of primary key will not lead to any different behaviour, it will
+    // simply give us two records, DELETE + INSERT.
+
+    TestHelper.initDB("yugabyte_create_tables.ddl");
+
+    String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", true /* withBeforeImage */);
+    Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
+    start(YugabyteDBConnector.class, configBuilder.build());
+
+    awaitUntilConnectorIsReady();
+
+    // Insert a record and update it.
+    TestHelper.execute(String.format(formatInsertString, 1));
+    TestHelper.execute("UPDATE t1 SET last_name='some_last_name', hours=98.765 where id = 1;");
+    TestHelper.execute("UPDATE t1 SET id = 404 WHERE id = 1;");
+
+    // Consume the records and verify that the records should have the relevant information.
+    List<SourceRecord> records = new ArrayList<>();
+    CompletableFuture.runAsync(() -> getRecords(records, 5, 20000)).get();
+
+    // The first record is an insert record with before image as null.
+    SourceRecord record0 = records.get(0);
+    assertValueField(record0, "before", null);
+    assertAfterImage(record0, 1, "Vaibhav", "Kushwaha", 12.345);
+
+    // The second record will be an update record having a before image.
+    SourceRecord record1 = records.get(1);
+    assertBeforeImage(record1, 1, "Vaibhav", "Kushwaha", 12.345);
+    assertAfterImage(record1, 1, "Vaibhav", "some_last_name", 98.765);
+
+    // For updating the primary key, we will get a delete record along with a tombstone and one
+    // insert record.
+    SourceRecord record2 = records.get(2);
+    assertBeforeImage(record2, 1, "Vaibhav", "some_last_name", 98.765);
+    assertValueField(record2, "after", null);
+
+    assertTombstone(records.get(3));
+
+    SourceRecord record4 = records.get(4);
+    assertValueField(record4, "before", null);
+    assertAfterImage(record4, 404, "Vaibhav", "some_last_name", 98.765);
+  }
+
+  @Test
+  public void operationsOnTableWithDefaultValues() throws Exception {
+    TestHelper.initDB("yugabyte_create_tables.ddl");
+
+    // Create a table with default values.
+    TestHelper.execute("CREATE TABLE table_with_defaults (id INT PRIMARY KEY, first_name TEXT"
+                       + " DEFAULT 'first_name_d', last_name VARCHAR(40) DEFAULT 'last_name_d',"
+                       + " hours DOUBLE PRECISION DEFAULT 12.345);");
+
+    String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "table_with_defaults",
+                                                    true /* withBeforeImage */);
+    Configuration.Builder configBuilder =
+        TestHelper.getConfigBuilder("public.table_with_defaults", dbStreamId);
+    start(YugabyteDBConnector.class, configBuilder.build());
+
+    awaitUntilConnectorIsReady();
+
+    TestHelper.execute("INSERT INTO table_with_defaults VALUES (1);");
+    TestHelper.execute(
+        "UPDATE table_with_defaults SET first_name='updated_first_name' WHERE id = 1");
+    TestHelper.execute("UPDATE table_with_defaults SET first_name='updated_first_name_2',"
+                       + " last_name='updated_last_name', hours=98.765 WHERE id = 1");
+
+    // Consume the records and verify that the records should have the relevant information.
+    List<SourceRecord> records = new ArrayList<>();
+    CompletableFuture.runAsync(() -> getRecords(records, 3, 20000)).get();
+
+    // The first record is an insert record with before image as null.
+    SourceRecord record0 = records.get(0);
+    assertValueField(record0, "before", null);
+    assertAfterImage(record0, 1, "first_name_d", "last_name_d", 12.345);
+
+    // The second and third records will be update records having a before image.
+    SourceRecord record1 = records.get(1);
+    assertBeforeImage(record1, 1, "first_name_d", "last_name_d", 12.345);
+    assertAfterImage(record1, 1, "updated_first_name", "last_name_d", 12.345);
+
+    SourceRecord record2 = records.get(2);
+    assertBeforeImage(record2, 1, "updated_first_name", "last_name_d", 12.345);
+    assertAfterImage(record2, 1, "updated_first_name_2", "updated_last_name", 98.765);
+  }
+
+  private void assertBeforeImage(SourceRecord record, Integer id, String firstName, String lastName,
+                                 Double hours) {
+      assertValueField(record, "before/id/value", id);
+      assertValueField(record, "before/first_name/value", firstName);
+      assertValueField(record, "before/last_name/value", lastName);
+      assertValueField(record, "before/hours/value", hours);
+  }
+
+  private void assertAfterImage(SourceRecord record, Integer id, String firstName, String lastName,
+                                Double hours) {
+      assertValueField(record, "after/id/value", id);
+      assertValueField(record, "after/first_name/value", firstName);
+      assertValueField(record, "after/last_name/value", lastName);
+      assertValueField(record, "after/hours/value", hours);
+  }
+
+  private void getRecords(List<SourceRecord> records, long totalRecordsToConsume,
+                          long milliSecondsToWait) {
+      AtomicLong totalConsumedRecords = new AtomicLong();
+      long seconds = milliSecondsToWait / 1000;
+      try {
+          Awaitility.await()
+              .atMost(Duration.ofSeconds(seconds))
+              .until(() -> {
+                  int consumed = super.consumeAvailableRecords(record -> {
+                      LOGGER.debug("The record being consumed is " + record);
+                      records.add(record);
+                  });
+                  if (consumed > 0) {
+                      totalConsumedRecords.addAndGet(consumed);
+                      LOGGER.debug("Consumed " + totalConsumedRecords + " records");
+                  }
+
+                  return totalConsumedRecords.get() == totalRecordsToConsume;
+              });
+      } catch (ConditionTimeoutException exception) {
+          fail("Failed to consume " + totalRecordsToConsume + " records in " + seconds + " seconds",
+               exception);
+      }
+
+      assertEquals(totalRecordsToConsume, totalConsumedRecords.get());
+  }
+}


### PR DESCRIPTION
The changes introduced in this PR are all towards processing the before image of the row. Before this PR, when encountered an `UPDATE` op, and the function `getOldColumnValues()` was being called, we simply returned a `null` value assuming that since we are not even publishing the old value in our change record from server side, why even bother processing it.

With the latest changes on server side made to enable old image / before image of the changed row, we now publish them with the change records from the server and in that case, when we call `getOldColumnValues()`, the function should be able to process the messages properly in case of an update operation and hence the change in the mentioned function.

Now, as an optimization for the default cases, where the stream ID is not configured to stream before images, we have added a boolean which will be set while streaming to tell the change record emitter whether it needs to process the records for before image or not.

Additionally, this PR closes #82 