### PR TITLE
Kill all tasks when we catch InterruptedException, minor logging changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.kafka>3.3.1</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>
-        <version.ybclient>0.8.34-20221128.060633-1</version.ybclient>
+        <version.ybclient>0.8.33.3-SNAPSHOT</version.ybclient>
         <version.gson>2.8.9</version.gson>
 
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.kafka>3.3.1</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>
-        <version.ybclient>0.8.33.3-SNAPSHOT</version.ybclient>
+        <version.ybclient>0.8.34-20221128.060633-1</version.ybclient>
         <version.gson>2.8.9</version.gson>
 
         <!--

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorTask.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorTask.java
@@ -144,7 +144,7 @@ public class YugabyteDBConnectorTask
                                                                       connectorConfig);
 
         LoggingContext.PreviousContext previousContext = taskContext
-                .configureLoggingContext(CONTEXT_NAME + "_" + taskId);
+                .configureLoggingContext(CONTEXT_NAME + "|" + taskId);
         try {
             // Print out the server information
             // CDCSDK Get the table,

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorTask.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorTask.java
@@ -134,17 +134,17 @@ public class YugabyteDBConnectorTask
         this.taskContext = new YugabyteDBTaskContext(connectorConfig, schema, topicSelector, taskId);
 
         // Get the tablet ids and load the offsets
-        final Offsets<YBPartition, YugabyteDBOffsetContext> previousOffsets = 
+        final Offsets<YBPartition, YugabyteDBOffsetContext> previousOffsets =
             getPreviousOffsetsFromProviderAndLoader(
                 new YBPartition.Provider(connectorConfig),
                 new YugabyteDBOffsetContext.Loader(connectorConfig));
         final Clock clock = Clock.system();
 
-        YugabyteDBOffsetContext context = new YugabyteDBOffsetContext(previousOffsets, 
+        YugabyteDBOffsetContext context = new YugabyteDBOffsetContext(previousOffsets,
                                                                       connectorConfig);
 
         LoggingContext.PreviousContext previousContext = taskContext
-                .configureLoggingContext(CONTEXT_NAME);
+                .configureLoggingContext(CONTEXT_NAME + "_" + taskId);
         try {
             // Print out the server information
             // CDCSDK Get the table,

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -250,13 +250,13 @@ public class YugabyteDBStreamingChangeEventSource implements
             YBTable table = this.syncClient.openTableByUUID(tId);
             tableIdToTable.put(tId, table);
 
-            GetTabletListToPollForCDCResponse resp = 
+            GetTabletListToPollForCDCResponse resp =
                 this.syncClient.getTabletListToPollForCdc(table, streamId, tId);
             tabletListResponse.put(tId, resp);
         }
 
         LOGGER.debug("The init tabletSourceInfo before updating is " + offsetContext.getTabletSourceInfo());
-        
+
         // Initialize the offsetContext and other supporting flags
         Map<String, Boolean> schemaNeeded = new HashMap<>();
         for (Pair<String, String> entry : tabletPairList) {
@@ -272,8 +272,8 @@ public class YugabyteDBStreamingChangeEventSource implements
             offsetContext.initSourceInfo(tabletId, this.connectorConfig);
         }
 
-        // This will contain the tablet ID mapped to the number of records it has seen 
-        // in the transactional block. Note that the entry will be created only when 
+        // This will contain the tablet ID mapped to the number of records it has seen
+        // in the transactional block. Note that the entry will be created only when
         // a BEGIN block is encountered.
         Map<String, Integer> recordsInTransactionalBlock = new HashMap<>();
 
@@ -305,6 +305,7 @@ public class YugabyteDBStreamingChangeEventSource implements
         LOGGER.info("Beginning to poll the changes from the server");
 
         short retryCount = 0;
+        String curTabletId = "";
         while (context.isRunning() && retryCount <= connectorConfig.maxConnectorRetries()) {
             try {
                 while (context.isRunning() && (offsetContext.getStreamingStoppingLsn() == null ||
@@ -321,6 +322,7 @@ public class YugabyteDBStreamingChangeEventSource implements
 
                     for (Pair<String, String> entry : tabletPairList) {
                         final String tabletId = entry.getValue();
+                        curTabletId = entry.getValue();
                         YBPartition part = new YBPartition(tabletId);
 
                       OpId cp = offsetContext.lsn(tabletId);
@@ -332,10 +334,12 @@ public class YugabyteDBStreamingChangeEventSource implements
 
                       // Check again if the thread has been interrupted.
                       if (!context.isRunning()) {
+                        LOGGER.warn("Error while trying to get the changes from the server for tablet: {}",
+                        tabletId);
                         LOGGER.info("Connector has been stopped");
                         break;
                       }
-                      
+
                       GetChangesResponse response = null;
                       try {
                         response = this.syncClient.getChangesCDCSDK(
@@ -494,8 +498,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                                 }
                             } catch (InterruptedException ie) {
                                 ie.printStackTrace();
-                            } catch (SQLException se) {
-                                se.printStackTrace();
+                                Thread.currentThread().interrupt();
                             }
                         }
 
@@ -527,13 +530,13 @@ public class YugabyteDBStreamingChangeEventSource implements
                 ++retryCount;
                 // If the retry limit is exceeded, log an error with a description and throw the exception.
                 if (retryCount > connectorConfig.maxConnectorRetries()) {
-                    LOGGER.error("Too many errors while trying to get the changes from server. All {} retries failed.", connectorConfig.maxConnectorRetries());
+                    LOGGER.error("Too many errors while trying to get the changes from server for tablet: {}. All {} retries failed.", curTabletId, connectorConfig.maxConnectorRetries());
                     throw e;
                 }
 
                 // If there are retries left, perform them after the specified delay.
-                LOGGER.warn("Error while trying to get the changes from the server; will attempt retry {} of {} after {} milli-seconds. Exception message: {}",
-                        retryCount, connectorConfig.maxConnectorRetries(), connectorConfig.connectorRetryDelayMs(), e.getMessage());
+                LOGGER.warn("Error while trying to get the changes from the server fir tablet: {}; will attempt retry {} of {} after {} milli-seconds. Exception message: {}",
+                        curTabletId, retryCount, connectorConfig.maxConnectorRetries(), connectorConfig.connectorRetryDelayMs(), e.getMessage());
                 LOGGER.debug("Stacktrace", e);
 
                 try {
@@ -732,7 +735,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                                          OpId.from(pair.getCdcSdkCheckpoint()));
 
             LOGGER.info("Initialized offset context for tablet {} with OpId {}", tabletId, OpId.from(pair.getCdcSdkCheckpoint()));
-            
+
             // Add the flag to indicate that we do not need the schema from this tablet again.
             schemaNeeded.put(tabletId, Boolean.FALSE);
         }
@@ -749,7 +752,7 @@ public class YugabyteDBStreamingChangeEventSource implements
 
         Pair<String, String> entryToBeDeleted = getEntryToDelete(tabletPairList, splitTabletId);
         Objects.requireNonNull(entryToBeDeleted);
-        
+
         String tableId = entryToBeDeleted.getKey();
 
         // Remove the entry with the tablet which has been split.
@@ -757,7 +760,7 @@ public class YugabyteDBStreamingChangeEventSource implements
 
         // Remove the corresponding entry to indicate that we don't need the schema now.
         schemaNeeded.remove(entryToBeDeleted.getValue());
-        
+
         // Log a warning if the element cannot be removed from the list.
         if (!removeSuccessful) {
             LOGGER.warn("Failed to remove the entry table {} - tablet {} from tablet pair list after split, will try once again", entryToBeDeleted.getKey(), entryToBeDeleted.getValue());
@@ -775,7 +778,7 @@ public class YugabyteDBStreamingChangeEventSource implements
               streamId,
               tableId,
               splitTabletId);
-        
+
         if (getTabletListResponse.getTabletCheckpointPairListSize() > 2) {
             LOGGER.warn("Found more than 2 tablets (got {}) for the parent tablet {}",
                         getTabletListResponse.getTabletCheckpointPairListSize(), splitTabletId);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -495,7 +495,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                                     maybeWarnAboutGrowingWalBacklog(dispatched);
                                 }
                             } catch (InterruptedException ie) {
-                                ie.printStackTrace();
+                                LOGGER.error("Interrupted exception while processing change records", ie);
                                 Thread.currentThread().interrupt();
                             }
                         }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -334,8 +334,6 @@ public class YugabyteDBStreamingChangeEventSource implements
 
                       // Check again if the thread has been interrupted.
                       if (!context.isRunning()) {
-                        LOGGER.warn("Error while trying to get the changes from the server for tablet: {}",
-                        tabletId);
                         LOGGER.info("Connector has been stopped");
                         break;
                       }
@@ -535,7 +533,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                 }
 
                 // If there are retries left, perform them after the specified delay.
-                LOGGER.warn("Error while trying to get the changes from the server fir tablet: {}; will attempt retry {} of {} after {} milli-seconds. Exception message: {}",
+                LOGGER.warn("Error while trying to get the changes from the server for tablet: {}; will attempt retry {} of {} after {} milli-seconds. Exception message: {}",
                         curTabletId, retryCount, connectorConfig.maxConnectorRetries(), connectorConfig.connectorRetryDelayMs(), e.getMessage());
                 LOGGER.debug("Stacktrace", e);
 


### PR DESCRIPTION
Previously, when we caught a  InterruptedException exception in the method: getChanges2
We were simply printing the stack trace and moving on. Now if one of the task in the execution service throws an 'InterruptedException' , we will kill all the tasks. 

Also adding minor logging changes: 
1. Every log from a task will also pint the task_id as part of the context
2. When we encounter an exception through 'GetChanges', we will also print the tablet causing the exception