### PR TITLE
Adding task ID to logging context

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeEventSourceCoordinator.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeEventSourceCoordinator.java
@@ -99,7 +99,8 @@ public class YugabyteDBChangeEventSourceCoordinator extends ChangeEventSourceCoo
             LOGGER.info("YBPartition is {} and YugabyteDBOffsetContext while snapshot is {}",
                         partition, previousOffset);
 
-            previousLogContext.set(taskContext.configureLoggingContext("snapshot", partition));
+            previousLogContext.set(taskContext.configureLoggingContext(
+                String.format("snapshot|%s", taskContext.getTaskId()), partition));
             SnapshotResult<YugabyteDBOffsetContext> snapshotResult =
                 doSnapshot(snapshotSource, context, partition, previousOffset);
 
@@ -108,7 +109,8 @@ public class YugabyteDBChangeEventSourceCoordinator extends ChangeEventSourceCoo
             }
         }
 
-        previousLogContext.set(taskContext.configureLoggingContext("streaming"));
+        previousLogContext.set(taskContext.configureLoggingContext(
+            String.format("streaming|%s", taskContext.getTaskId())));
 
         for (Map.Entry<YBPartition, YugabyteDBOffsetContext> entry :
                 streamingOffsets.getOffsets().entrySet()) {
@@ -126,7 +128,8 @@ public class YugabyteDBChangeEventSourceCoordinator extends ChangeEventSourceCoo
                 LOGGER.info("YBPartition is {} and YugabyteDBOffsetContext while streaming is {}",
                             partition, previousOffset);
 
-                previousLogContext.set(taskContext.configureLoggingContext("streaming", partition));
+                previousLogContext.set(taskContext.configureLoggingContext(
+                    String.format("streaming|%s", taskContext.getTaskId()), partition));
 
                 if (context.isRunning()) {
                     streamEvents(context, partition, previousOffset);


### PR DESCRIPTION
This PR has the changes to include the task ID in the logging context as well. So now the full logging context would look similar to:
```
YugabyteDB|dbserver1|snapshot|0
YugabyteDB|dbserver1|snapshot|1
YugabyteDB|dbserver1|snapshot|2
...
YugabyteDB|dbserver1|streaming|0
YugabyteDB|dbserver1|streaming|1
YugabyteDB|dbserver1|streaming|2
```