### PR TITLE
Log GetChanges request at 5 minutes intervals

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -512,6 +512,7 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
     protected static final long DEFAULT_CONNECTOR_RETRY_DELAY_MS = 60000;
     protected static final boolean DEFAULT_LIMIT_ONE_POLL_PER_ITERATION = false;
     protected static final long DEFAULT_NEW_TABLE_POLL_INTERVAL_MS = 5 * 60 * 1000L;
+    protected static final long DEFAULT_LOG_GET_CHANGES_INTERVAL_MS = 5 * 60 * 1000L;
 
     @Override
     public JdbcConfiguration getJdbcConfig() {
@@ -868,6 +869,21 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
             .withValidation(Field::isNonNegativeLong)
             .withDescription("Interval at which the poller thread should poll to check if there are any new tables added to the stream");
 
+    public static final Field LOG_GET_CHANGES = Field.create("log.get.changes")
+            .withDisplayName("Whether to log GetChanges request at intervals")
+            .withImportance(Importance.LOW)
+            .withType(Type.BOOLEAN)
+            .withDefault(true)
+            .withValidation(Field::isBoolean)
+            .withDescription("Whether we want the connector to log at regular intervals that it is calling GetChanges RPC on the server side");
+
+    public static final Field LOG_GET_CHANGES_INTERVAL_MS = Field.create("log.get.changes.interval.ms")
+            .withDisplayName("Interval to log GetChanges request in milliseconds")
+            .withImportance(Importance.LOW)
+            .withType(Type.LONG)
+            .withDefault(DEFAULT_LOG_GET_CHANGES_INTERVAL_MS)
+            .withValidation(Field::isNonNegativeLong);
+
     public static final Field SNAPSHOT_MODE_CLASS = Field.create("snapshot.custom.class")
             .withDisplayName("Snapshot Mode Custom Class")
             .withType(Type.STRING)
@@ -1103,6 +1119,14 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
         return getConfig().getLong(CONNECTOR_RETRY_DELAY_MS);
     }
 
+    public boolean logGetChanges() {
+        return getConfig().getBoolean(LOG_GET_CHANGES);
+    }
+
+    public long logGetChangesIntervalMs() {
+        return getConfig().getLong(LOG_GET_CHANGES_INTERVAL_MS);
+    }
+
     public String sslRootCert() {
         return getConfig().getString(SSL_ROOT_CERT);
     }
@@ -1223,7 +1247,9 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
                     TCP_KEEPALIVE,
                     MAX_NUM_TABLETS,
                     AUTO_ADD_NEW_TABLES,
-                    NEW_TABLE_POLL_INTERVAL_MS)
+                    NEW_TABLE_POLL_INTERVAL_MS,
+                    LOG_GET_CHANGES,
+                    LOG_GET_CHANGES_INTERVAL_MS)
             .events(
                     INCLUDE_UNKNOWN_DATATYPES)
             .connector(

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -370,7 +370,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
 
                 OpId cp = previousOffset.snapshotLSN(tabletId);
 
-                if (LOGGER.isDebugEnabled()|| System.currentTimeMillis() >= (lastLoggedTimeForGetChanges + 300_000)) {
+                if (LOGGER.isDebugEnabled() || System.currentTimeMillis() >= (lastLoggedTimeForGetChanges + 300_000)) {
                   LOGGER.info("Requesting changes for tablet {} from OpId {} for table {}",
                               tabletId, cp, table.getName());
                   lastLoggedTimeForGetChanges = System.currentTimeMillis();

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -370,7 +370,8 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
 
                 OpId cp = previousOffset.snapshotLSN(tabletId);
 
-                if (LOGGER.isDebugEnabled() || System.currentTimeMillis() >= (lastLoggedTimeForGetChanges + 300_000)) {
+                if (LOGGER.isDebugEnabled()
+                    || (connectorConfig.logGetChanges() && System.currentTimeMillis() >= (lastLoggedTimeForGetChanges + connectorConfig.logGetChangesIntervalMs()))) {
                   LOGGER.info("Requesting changes for tablet {} from OpId {} for table {}",
                               tabletId, cp, table.getName());
                   lastLoggedTimeForGetChanges = System.currentTimeMillis();

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -305,6 +305,10 @@ public class YugabyteDBStreamingChangeEventSource implements
         LOGGER.info("Beginning to poll the changes from the server");
 
         short retryCount = 0;
+
+        // Helper internal variable to log GetChanges request at regular intervals.
+        long lastLoggedTimeForGetChanges = System.currentTimeMillis();
+
         while (context.isRunning() && retryCount <= connectorConfig.maxConnectorRetries()) {
             try {
                 while (context.isRunning() && (offsetContext.getStreamingStoppingLsn() == null ||
@@ -327,8 +331,11 @@ public class YugabyteDBStreamingChangeEventSource implements
 
                       YBTable table = tableIdToTable.get(entry.getKey());
 
-                      LOGGER.debug("Going to fetch for tablet " + tabletId + " from OpId " + cp + " " +
-                        "table " + table.getName() + " Running:" + context.isRunning());
+                      if (LOGGER.isDebugEnabled()|| System.currentTimeMillis() >= (lastLoggedTimeForGetChanges + 300_000)) {
+                        LOGGER.info("Requesting changes for tablet {} from OpId {} for table {}",
+                                    tabletId, cp, table.getName());
+                        lastLoggedTimeForGetChanges = System.currentTimeMillis();
+                      }
 
                       // Check again if the thread has been interrupted.
                       if (!context.isRunning()) {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -331,7 +331,7 @@ public class YugabyteDBStreamingChangeEventSource implements
 
                       YBTable table = tableIdToTable.get(entry.getKey());
 
-                      if (LOGGER.isDebugEnabled()|| System.currentTimeMillis() >= (lastLoggedTimeForGetChanges + 300_000)) {
+                      if (LOGGER.isDebugEnabled() || System.currentTimeMillis() >= (lastLoggedTimeForGetChanges + 300_000)) {
                         LOGGER.info("Requesting changes for tablet {} from OpId {} for table {}",
                                     tabletId, cp, table.getName());
                         lastLoggedTimeForGetChanges = System.currentTimeMillis();

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -331,7 +331,8 @@ public class YugabyteDBStreamingChangeEventSource implements
 
                       YBTable table = tableIdToTable.get(entry.getKey());
 
-                      if (LOGGER.isDebugEnabled() || System.currentTimeMillis() >= (lastLoggedTimeForGetChanges + 300_000)) {
+                      if (LOGGER.isDebugEnabled()
+                          || (connectorConfig.logGetChanges() && System.currentTimeMillis() >= (lastLoggedTimeForGetChanges + connectorConfig.logGetChangesIntervalMs()))) {
                         LOGGER.info("Requesting changes for tablet {} from OpId {} for table {}",
                                     tabletId, cp, table.getName());
                         lastLoggedTimeForGetChanges = System.currentTimeMillis();


### PR DESCRIPTION
This PR adds the change so that the connector also logs the `GetChanges` requests at regular intervals so that we know that the tasks are active and requesting for changes actively.