### PR TITLE
[#111] Refactored the order of logic to handle tablet split

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -783,6 +783,10 @@ public class YugabyteDBStreamingChangeEventSource implements
         if (getTabletListResponse.getTabletCheckpointPairListSize() != 2) {
             LOGGER.warn("Found {} tablets for the parent tablet {}",
                         getTabletListResponse.getTabletCheckpointPairListSize(), splitTabletId);
+            throw new Exception("Found unexpected ("
+                                + getTabletListResponse.getTabletCheckpointPairListSize()
+                                + ") number of tablets while trying to fetch the children of parent "
+                                + splitTabletId);
         }
 
         // Remove the entry with the tablet which has been split.

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -770,6 +770,21 @@ public class YugabyteDBStreamingChangeEventSource implements
 
         String tableId = entryToBeDeleted.getKey();
 
+        // Get the child tablets and add them to the polling list.
+        GetTabletListToPollForCDCResponse getTabletListResponse =
+          this.syncClient.getTabletListToPollForCdc(
+              this.syncClient.openTableByUUID(tableId),
+              streamId,
+              tableId,
+              splitTabletId);
+        
+        Objects.requireNonNull(getTabletListResponse);
+
+        if (getTabletListResponse.getTabletCheckpointPairListSize() != 2) {
+            LOGGER.warn("Found {} tablets for the parent tablet {}",
+                        getTabletListResponse.getTabletCheckpointPairListSize(), splitTabletId);
+        }
+
         // Remove the entry with the tablet which has been split.
         boolean removeSuccessful = tabletPairList.remove(entryToBeDeleted);
 
@@ -784,19 +799,6 @@ public class YugabyteDBStreamingChangeEventSource implements
                 String exceptionMessageFormat = "Failed to remove the entry table {} - tablet {} from the tablet pair list after split";
                 throw new RuntimeException(String.format(exceptionMessageFormat, entryToBeDeleted.getKey(), entryToBeDeleted.getValue()));
             }
-        }
-
-        // Get the child tablets and add them to the polling list.
-        GetTabletListToPollForCDCResponse getTabletListResponse =
-          this.syncClient.getTabletListToPollForCdc(
-              this.syncClient.openTableByUUID(tableId),
-              streamId,
-              tableId,
-              splitTabletId);
-
-        if (getTabletListResponse.getTabletCheckpointPairListSize() > 2) {
-            LOGGER.warn("Found more than 2 tablets (got {}) for the parent tablet {}",
-                        getTabletListResponse.getTabletCheckpointPairListSize(), splitTabletId);
         }
 
         for (TabletCheckpointPair pair : getTabletListResponse.getTabletCheckpointPairList()) {


### PR DESCRIPTION
This PR reorders the logic in which tablet split is handled.

Before this, we were handling tablet split in the order:
1. Remove parent tablet from polling list
2. Get child tablets and add them to the list

In case step 2 failed and we went for a retry, we will not be left with the parent tablet in the list since it has been removed. So the order has changed now to:
1. Get child tablets for the parent
2. Remove the parent tablet from polling list

This will ensure that if the API to fetch child tablet fails for some reasons, we are not left with no option to get the parent further.