### PR TITLE
[#111] Replacing metronome with Awaitility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,6 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.easytesting</groupId>

--- a/src/main/java/io/debezium/connector/yugabytedb/YBClientUtils.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YBClientUtils.java
@@ -1,5 +1,6 @@
 package io.debezium.connector.yugabytedb;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -10,6 +11,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yb.client.AsyncYBClient;
@@ -282,4 +284,15 @@ public class YBClientUtils {
 
     return cdcStreamInfo.getOptions().get("record_type").equals(CDCRecordType.ALL.name());
   }
+
+  /**
+   * @param millisecondsToPause milliseconds to pause for
+   * @throws InterruptedException when the sleep is interrupted
+   */
+  public static void pauseForMillis(long millisecondsToPause) throws InterruptedException {
+    Awaitility.await()
+        .pollDelay(Duration.ofMillis(millisecondsToPause))
+        .atMost(Duration.ofMillis(millisecondsToPause + 10))
+        .until(() -> { return true; });
+}
 }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -44,7 +44,7 @@ import io.debezium.util.Strings;
 /**
  * Class to help processing the snapshot in YugabyteDB.
  *
- * @author Suranjan Kumar
+ * @author Suranjan Kumar, Vaibhav Kushwaha
  */
 
 public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeEventSource<YBPartition, YugabyteDBOffsetContext> {
@@ -327,8 +327,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
               for (Pair<String, String> tableIdToTabletId : tableToTabletForSnapshot) {
                 // Pause for the specified duration before asking for a new set of snapshot records from the server
                 LOGGER.debug("Pausing for {} milliseconds before polling further", connectorConfig.cdcPollIntervalms());
-                final Metronome pollIntervalMetronome = Metronome.parker(Duration.ofMillis(connectorConfig.cdcPollIntervalms()), Clock.SYSTEM);
-                pollIntervalMetronome.pause();
+                YBClientUtils.pauseForMillis(connectorConfig.cdcPollIntervalms());
 
                 String tableId = tableIdToTabletId.getKey();
                 YBTable table = tableIdToTable.get(tableId);
@@ -504,13 +503,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                        this.connectorConfig.connectorRetryDelayMs(), e.getMessage());
           LOGGER.debug("Stacktrace: ", e);
 
-          try {
-            final Metronome retryMetronome = Metronome.parker(Duration.ofMillis(connectorConfig.connectorRetryDelayMs()), Clock.SYSTEM);
-            retryMetronome.pause();
-          } catch (InterruptedException ie) {
-            LOGGER.warn("Connector retry sleep interrupted by exception: {}", ie);
-            Thread.currentThread().interrupt();
-          }
+          YBClientUtils.pauseForMillis(this.connectorConfig.connectorRetryDelayMs());
         }
       }
     


### PR DESCRIPTION
This PR will replace the instances of metronome with `Awaitility` since metronome initialization causes too many objects to be created and will slow down execution as well.