### PR TITLE
Request schema from the server once we start polling for child tablets

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeRecordEmitter.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeRecordEmitter.java
@@ -284,9 +284,6 @@ public class YugabyteDBChangeRecordEmitter extends RelationalChangeRecordEmitter
         try {
             // Using another implementation of refresh() to take into picture the schema information too.
             LOGGER.debug("Refreshing schema for the table {}", tableId);
-            if (schema.getSchemaPBForTablet(tableId, tabletId) == null) {
-                LOGGER.info("getSchemaPBForTablet returned null for tablet {}", tabletId);
-            }
             schema.refresh(connection, tableId,
                            connectorConfig.skipRefreshSchemaOnMissingToastableData(),
                            schema.getSchemaPBForTablet(tableId, tabletId), tabletId);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeRecordEmitter.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeRecordEmitter.java
@@ -284,6 +284,9 @@ public class YugabyteDBChangeRecordEmitter extends RelationalChangeRecordEmitter
         try {
             // Using another implementation of refresh() to take into picture the schema information too.
             LOGGER.debug("Refreshing schema for the table {}", tableId);
+            if (schema.getSchemaPBForTablet(tableId, tabletId) == null) {
+                LOGGER.info("getSchemaPBForTablet returned null for tablet {}", tabletId);
+            }
             schema.refresh(connection, tableId,
                            connectorConfig.skipRefreshSchemaOnMissingToastableData(),
                            schema.getSchemaPBForTablet(tableId, tabletId), tabletId);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSchema.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSchema.java
@@ -120,7 +120,7 @@ public class YugabyteDBSchema extends RelationalDatabaseSchema {
                                              String schemaName,
                                              String tabletId) {
         String lookupKey = getLookupKey(tableId, tabletId);
-        if (cdcsdkSchemaPB == null) {
+        if (tabletIdToCdcsdkSchemaPB.get(lookupKey) == null || cdcsdkSchemaPB == null) {
             tabletIdToCdcsdkSchemaPB.put(lookupKey, schemaPB);
         }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSchema.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSchema.java
@@ -120,7 +120,7 @@ public class YugabyteDBSchema extends RelationalDatabaseSchema {
                                              String schemaName,
                                              String tabletId) {
         String lookupKey = getLookupKey(tableId, tabletId);
-        if (tabletIdToCdcsdkSchemaPB.get(lookupKey) == null || cdcsdkSchemaPB == null) {
+        if (!tabletIdToCdcsdkSchemaPB.containsKey(lookupKey) || cdcsdkSchemaPB == null) {
             tabletIdToCdcsdkSchemaPB.put(lookupKey, schemaPB);
         }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSchema.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSchema.java
@@ -369,6 +369,9 @@ public class YugabyteDBSchema extends RelationalDatabaseSchema {
     protected void refresh(YugabyteDBConnection connection, TableId tableId,
                            boolean refreshToastableColumns, CdcService.CDCSDKSchemaPB schemaPB,
                            String tabletId) throws SQLException {
+        if (schemaPB == null) {
+            LOGGER.info("Schema is null for tablet {}", tableId);
+        }
         readSchemaWithTablet(null /* dummy object */, null, tableId.schema(), tableId::equals,
                              null, true, schemaPB, tableId, tabletId);
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSchema.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSchema.java
@@ -221,10 +221,6 @@ public class YugabyteDBSchema extends RelationalDatabaseSchema {
                            TableId tableId, String tabletId) {
         Map<TableId, List<Column>> columnsByTable = new HashMap<>();
 
-        if (schemaPB == null) {
-            LOGGER.info("schemaPB is null in readSchemaWithTablet for tablet {} at line 225", tabletId);
-        }
-
         // Find regular and materialized views as they cannot be snapshotted
         final Set<TableId> tableIds = new HashSet<>();
         if (tableFilter == null || tableFilter.isIncluded(tableId)) {
@@ -373,9 +369,6 @@ public class YugabyteDBSchema extends RelationalDatabaseSchema {
     protected void refresh(YugabyteDBConnection connection, TableId tableId,
                            boolean refreshToastableColumns, CdcService.CDCSDKSchemaPB schemaPB,
                            String tabletId) throws SQLException {
-        if (schemaPB == null) {
-            LOGGER.info("schemaPB is null for tablet {}", tableId);
-        }
         readSchemaWithTablet(null /* dummy object */, null, tableId.schema(), tableId::equals,
                              null, true, schemaPB, tableId, tabletId);
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSchema.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSchema.java
@@ -221,6 +221,10 @@ public class YugabyteDBSchema extends RelationalDatabaseSchema {
                            TableId tableId, String tabletId) {
         Map<TableId, List<Column>> columnsByTable = new HashMap<>();
 
+        if (schemaPB == null) {
+            LOGGER.info("schemaPB is null in readSchemaWithTablet for tablet {} at line 225", tabletId);
+        }
+
         // Find regular and materialized views as they cannot be snapshotted
         final Set<TableId> tableIds = new HashSet<>();
         if (tableFilter == null || tableFilter.isIncluded(tableId)) {
@@ -370,7 +374,7 @@ public class YugabyteDBSchema extends RelationalDatabaseSchema {
                            boolean refreshToastableColumns, CdcService.CDCSDKSchemaPB schemaPB,
                            String tabletId) throws SQLException {
         if (schemaPB == null) {
-            LOGGER.info("Schema is null for tablet {}", tableId);
+            LOGGER.info("schemaPB is null for tablet {}", tableId);
         }
         readSchemaWithTablet(null /* dummy object */, null, tableId.schema(), tableId::equals,
                              null, true, schemaPB, tableId, tabletId);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -345,11 +345,11 @@ public class YugabyteDBStreamingChangeEventSource implements
                       }
 
                       GetChangesResponse response = null;
-                      
+
                       if (schemaNeeded.get(tabletId)) {
                         LOGGER.info("Requesting schema for tablet: {}", tabletId);
                       }
-                      
+
                       try {
                         response = this.syncClient.getChangesCDCSDK(
                             table, streamId, tabletId, cp.getTerm(), cp.getIndex(), cp.getKey(),
@@ -756,7 +756,7 @@ public class YugabyteDBStreamingChangeEventSource implements
 
             LOGGER.info("Initialized offset context for tablet {} with OpId {}", tabletId, OpId.from(pair.getCdcSdkCheckpoint()));
 
-            // Add the flag to indicate that we need the schema for the new tablets so that we can get it registered.
+            // Add the flag to indicate that we need the schema for the new tablets so that the schema can be registered.
             schemaNeeded.put(tabletId, Boolean.TRUE);
         }
     }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -345,6 +345,11 @@ public class YugabyteDBStreamingChangeEventSource implements
                       }
 
                       GetChangesResponse response = null;
+                      
+                      if (schemaNeeded.get(tabletId)) {
+                        LOGGER.info("Requesting schema for tablet: {}", tabletId);
+                      }
+                      
                       try {
                         response = this.syncClient.getChangesCDCSDK(
                             table, streamId, tabletId, cp.getTerm(), cp.getIndex(), cp.getKey(),
@@ -751,8 +756,8 @@ public class YugabyteDBStreamingChangeEventSource implements
 
             LOGGER.info("Initialized offset context for tablet {} with OpId {}", tabletId, OpId.from(pair.getCdcSdkCheckpoint()));
 
-            // Add the flag to indicate that we do not need the schema from this tablet again.
-            schemaNeeded.put(tabletId, Boolean.FALSE);
+            // Add the flag to indicate that we need the schema for the new tablets so that we can get it registered.
+            schemaNeeded.put(tabletId, Boolean.TRUE);
         }
     }
 


### PR DESCRIPTION
After a tablet has been split, we need to explicitly mention the flag in the GetChanges call so that the server sends the schema for the child tablet and we register it for further processing. This PR implements the same.