### PR TITLE
Change Dockerfile to download the required dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@
 
 # The base image is derived from debezium/connect:1.7 and contains the following drivers
 # and connectors prepopulated:
-#  - JDBC Sink Connector v10.2.5
+#  - JDBC Sink Connector v10.6.0
 #  - YugabyteDB JDBC Driver v42.3.5-yb-1
-#  - MySql JDBC Driver v8.0.21
-#  - PostgreSQL JDBC Driver v42.4.1
-FROM quay.io/yugabyte/connect-base-yb:0.3
+#  - MySql JDBC Driver v8.0.31
+#  - PostgreSQL JDBC Driver v42.5.1
+FROM quay.io/yugabyte/connect-base-yb:0.4
 
 # Create the directories for the connectors to be placed into
 ENV KAFKA_CONNECT_YB_DIR=$KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-yugabytedb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,7 @@
 # On your terminal, run the following to build the image:
-#  - mvn clean package -Dquick
+# mvn clean package -Dquick
 
-# The base image is derived from debezium/connect:1.7 and contains the following drivers
-# and connectors prepopulated:
-#  - JDBC Sink Connector v10.6.0
-#  - YugabyteDB JDBC Driver v42.3.5-yb-1
-#  - MySql JDBC Driver v8.0.31
-#  - PostgreSQL JDBC Driver v42.5.1
-FROM quay.io/yugabyte/connect-base-yb:0.4
+FROM debezium/connect:1.9.5.Final
 
 # Create the directories for the connectors to be placed into
 ENV KAFKA_CONNECT_YB_DIR=$KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-yugabytedb
@@ -18,6 +12,12 @@ COPY target/debezium-connector-yugabytedb-*.jar $KAFKA_CONNECT_YB_DIR/
 
 # Set the TLS version to be used by Kafka processes
 ENV KAFKA_OPTS="-Djdk.tls.client.protocols=TLSv1.2"
+
+# Add the required jar files to be packaged with the base connector
+RUN cd $KAFKA_CONNECT_YB_DIR && curl -so kafka-connect-jdbc-10.6.0.jar https://packages.confluent.io/maven/io/confluent/kafka-connect-jdbc/10.6.0/kafka-connect-jdbc-10.6.0.jar
+RUN cd $KAFKA_CONNECT_YB_DIR && curl -so jdbc-yugabytedb-42.3.5-yb-1.jar https://repo1.maven.org/maven2/com/yugabyte/jdbc-yugabytedb/42.3.5-yb-1/jdbc-yugabytedb-42.3.5-yb-1.jar
+RUN cd $KAFKA_CONNECT_YB_DIR && curl -so mysql-connector-java-8.0.31.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.31/mysql-connector-java-8.0.31.jar
+RUN cd $KAFKA_CONNECT_YB_DIR && curl -so postgresql-42.5.1.jar https://repo1.maven.org/maven2/org/postgresql/postgresql/42.5.1/postgresql-42.5.1.jar
 
 # Add Jmx agent and metrics pattern file to expose the metrics info
 RUN mkdir /kafka/etc && cd /kafka/etc && curl -so jmx_prometheus_javaagent-0.17.2.jar https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.17.2/jmx_prometheus_javaagent-0.17.2.jar


### PR DESCRIPTION
Before this, we used a base image with all the required dependencies (jars) which can then be used further by the image. This PR modifies the Dockerfile so that the process now downloads the jar files directly to the image while building. This PR closes #131 