### PR TITLE
Snapshot bootstrap phase changes

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -263,6 +263,19 @@ public class YugabyteDBOffsetContext implements OffsetContext {
                 : sourceInfo.lsn();
     }
 
+    /**
+     * If a previous OpId is null then we want the server to send the snapshot from the
+     * beginning. Requesting from the term -1, index -1 and empty key would indicate
+     * the server that a snapshot needs to be taken and the write ID as -1 tells that we are
+     * in the snapshot mode and snapshot time 0 signifies that we are bootstrapping
+     * the snapshot flow.
+     * <p>
+     * In short, we are telling the server to decide an appropriate checkpoint till which the
+     * snapshot needs to be taken and send it as a response back to the connector.
+     *
+     * @param tabletId the tablet UUID
+     * @return {@link OpId} from which we need to read the snapshot from the server
+     */
     OpId snapshotLSN(String tabletId) {
       // get the sourceInfo of the tablet
       SourceInfo sourceInfo = getSourceInfo(tabletId);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -266,7 +266,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
     OpId snapshotLSN(String tabletId) {
       // get the sourceInfo of the tablet
       SourceInfo sourceInfo = getSourceInfo(tabletId);
-      return sourceInfo.lsn() == null ? new OpId(-1, -1, "".getBytes(), -1, -1)
+      return sourceInfo.lsn() == null ? new OpId(-1, -1, "".getBytes(), -1, 0)
         : sourceInfo.lsn();
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -214,7 +214,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                                       this.connectorConfig.streamId(), 
                                       tableId /* tableId */, 
                                       tabletId /* tabletId */, 
-                                      -1 /* term */, -1 /* index */, 
+                                      0 /* term */, 0 /* index */,
                                       false /* initialCheckpoint */, false /* bootstrap */);
         }
 
@@ -339,27 +339,6 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                  // Check if snapshot is completed here, if it is, then break out of the loop
                 if (snapshotCompletedTablets.size() == tableToTabletForSnapshot.size()) {
                     LOGGER.info("Snapshot completed for all the tablets");
-                    // Commit checkpoints for all tablets to make them ready for streaming changes
-//                    for (Pair<String, String> entry : tableToTabletIds) {
-//                      try {
-//                        // Only checkpoint in case this is the first time snapshot has been
-//                        // completed, otherwise we will end up setting the checkpoint to 0,0 even
-//                        // for tablets for which snapshot has been completed in a previous run
-//                        // of the connector
-//                        if (!snapshotCompletedPreviously.contains(entry.getValue())) {
-//                          YBClientUtils.setCheckpoint(this.syncClient,
-//                                                      this.connectorConfig.streamId(),
-//                                                      entry.getKey() /* tableId */,
-//                                                      entry.getValue() /* tabletId */,
-//                                                      0 /* term */, 0 /* index */,
-//                                                      true /* initialCheckpoint */,
-//                                                      true /* bootstrap */);
-//                        }
-//                      } catch (Exception e) {
-//                        throw new DebeziumException(e);
-//                      }
-//                    }
-
                     return SnapshotResult.completed(previousOffset);
                 }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -466,8 +466,10 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                 LOGGER.debug("Final OpId is {}", finalOpId);
                 
                 previousOffset.getSourceInfo(tabletId).updateLastCommit(finalOpId);
-                
-                if (finalOpId.equals(new OpId(-1, -1, "".getBytes(), 0, 0))) {
+
+                if (Arrays.equals(finalOpId.getKey(), "".getBytes())
+                        && finalOpId.getWrite_id() == 0
+                        && finalOpId.getTime() == 0) {
                     // This will mark the snapshot completed for the tablet
                     snapshotCompletedTablets.add(tabletId);
                     LOGGER.info("Snapshot completed for tablet {} belonging to table {} ({})", 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -446,9 +446,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                 
                 previousOffset.getSourceInfo(tabletId).updateLastCommit(finalOpId);
 
-                if (Arrays.equals(finalOpId.getKey(), "".getBytes())
-                        && finalOpId.getWrite_id() == 0
-                        && finalOpId.getTime() == 0) {
+                if (isSnapshotComplete(finalOpId)) {
                     // This will mark the snapshot completed for the tablet
                     snapshotCompletedTablets.add(tabletId);
                     LOGGER.info("Snapshot completed for tablet {} belonging to table {} ({})", 
@@ -498,6 +496,18 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
       // If the flow comes at this stage then it either failed or was aborted by 
       // some user interruption
       return SnapshotResult.aborted();
+    }
+
+    /**
+     * Check if the passed OpId matches the conditions which signify that the snapshot has
+     * been complete.
+     *
+     * @param opId the {@link OpId} to check for
+     * @return true if the passed {@link OpId} means snapshot is complete, false otherwise
+     */
+    private boolean isSnapshotComplete(OpId opId) {
+        return Arrays.equals(opId.getKey(), "".getBytes()) && opId.getWrite_id() == 0
+                && opId.getTime() == 0;
     }
 
     protected Stream<TableId> getDataCollectionsToBeSnapshotted(Set<TableId> allDataCollections) {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -340,25 +340,25 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                 if (snapshotCompletedTablets.size() == tableToTabletForSnapshot.size()) {
                     LOGGER.info("Snapshot completed for all the tablets");
                     // Commit checkpoints for all tablets to make them ready for streaming changes
-                    for (Pair<String, String> entry : tableToTabletIds) {
-                      try {
-                        // Only checkpoint in case this is the first time snapshot has been 
-                        // completed, otherwise we will end up setting the checkpoint to 0,0 even
-                        // for tablets for which snapshot has been completed in a previous run
-                        // of the connector
-                        if (!snapshotCompletedPreviously.contains(entry.getValue())) {
-                          YBClientUtils.setCheckpoint(this.syncClient, 
-                                                      this.connectorConfig.streamId(),
-                                                      entry.getKey() /* tableId */,
-                                                      entry.getValue() /* tabletId */,
-                                                      0 /* term */, 0 /* index */,
-                                                      true /* initialCheckpoint */, 
-                                                      true /* bootstrap */);
-                        }
-                      } catch (Exception e) {
-                        throw new DebeziumException(e);
-                      }
-                    }
+//                    for (Pair<String, String> entry : tableToTabletIds) {
+//                      try {
+//                        // Only checkpoint in case this is the first time snapshot has been
+//                        // completed, otherwise we will end up setting the checkpoint to 0,0 even
+//                        // for tablets for which snapshot has been completed in a previous run
+//                        // of the connector
+//                        if (!snapshotCompletedPreviously.contains(entry.getValue())) {
+//                          YBClientUtils.setCheckpoint(this.syncClient,
+//                                                      this.connectorConfig.streamId(),
+//                                                      entry.getKey() /* tableId */,
+//                                                      entry.getValue() /* tabletId */,
+//                                                      0 /* term */, 0 /* index */,
+//                                                      true /* initialCheckpoint */,
+//                                                      true /* bootstrap */);
+//                        }
+//                      } catch (Exception e) {
+//                        throw new DebeziumException(e);
+//                      }
+//                    }
 
                     return SnapshotResult.completed(previousOffset);
                 }


### PR DESCRIPTION
This PR includes these changes:
1. Before starting the snapshot, set the checkpoint with `0,0` instead of `-1,-1`
2. For confirming whether the snapshot is completed, only check for the `key`, `write_id` and `snapshotTime`
3. The first GetChanges call to request the snapshot has the `snapshotTime` set to 0

This closes https://github.com/yugabyte/yugabyte-db/issues/15514