### PR TITLE
[#148] Ignore DDL records while adding to merger

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDbConsistentStreaming.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDbConsistentStreaming.java
@@ -202,7 +202,7 @@ public class YugabyteDbConsistentStreaming extends YugabyteDBStreamingChangeEven
                                     .getCdcSdkProtoRecordsList()) {
                                 CdcService.RowMessage.Op op = record.getRowMessage().getOp();
 
-                                if (!schemaNeeded.get(tabletId) && record.getRowMessage().getOp() == CdcService.RowMessage.Op.DDL) {
+                                if (record.getRowMessage().getOp() == CdcService.RowMessage.Op.DDL) {
                                     YbProtoReplicationMessage ybMessage = new YbProtoReplicationMessage(record.getRowMessage(), this.yugabyteDBTypeRegistry);
                                     dispatchMessage(offsetContext, schemaNeeded, recordsInTransactionalBlock,
                                             beginCountForTablet, tabletId, new YBPartition(tabletId),

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDbConsistentStreaming.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDbConsistentStreaming.java
@@ -202,11 +202,18 @@ public class YugabyteDbConsistentStreaming extends YugabyteDBStreamingChangeEven
                                     .getCdcSdkProtoRecordsList()) {
                                 CdcService.RowMessage.Op op = record.getRowMessage().getOp();
 
-                                merger.addMessage(new Message.Builder()
-                                        .setRecord(record)
-                                        .setTabletId(tabletId)
-                                        .setSnapshotTime(response.getSnapshotTime())
-                                        .build());
+                                if (!schemaNeeded.get(tabletId) && record.getRowMessage().getOp() == CdcService.RowMessage.Op.DDL) {
+                                    YbProtoReplicationMessage ybMessage = new YbProtoReplicationMessage(record.getRowMessage(), this.yugabyteDBTypeRegistry);
+                                    dispatchMessage(offsetContext, schemaNeeded, recordsInTransactionalBlock,
+                                            beginCountForTablet, tabletId, new YBPartition(tabletId),
+                                            response.getSnapshotTime(), record, record.getRowMessage(), ybMessage);
+                                } else {
+                                    merger.addMessage(new Message.Builder()
+                                            .setRecord(record)
+                                            .setTabletId(tabletId)
+                                            .setSnapshotTime(response.getSnapshotTime())
+                                            .build());
+                                }
                                 OpId finalOpid = new OpId(
                                         response.getTerm(),
                                         response.getIndex(),

--- a/src/main/java/io/debezium/connector/yugabytedb/consistent/Merger.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/consistent/Merger.java
@@ -36,6 +36,8 @@ public class Merger {
      * @see Message
      */
     public synchronized void addMessage(Message message) {
+        assert message.record.getRowMessage().getOp() != CdcService.RowMessage.Op.DDL;
+
         setTabletSafeTime(message.tablet, message.commitTime);
         if (message.record.getRowMessage().getOp() == CdcService.RowMessage.Op.SAFEPOINT) {
             LOGGER.debug("Received safe point message {}", message);


### PR DESCRIPTION
This PR adds the diff which will directly get the DDL records dispatched and not let them get added to the merger.