### PR TITLE
Migrate tests to JUnit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,12 +242,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>${version.junit}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${version.junit}</version>

--- a/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
@@ -6,14 +6,13 @@
 
 package io.debezium.connector.yugabytedb;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -563,7 +562,7 @@ public final class TestHelper {
 
     public static void executeDDL(String ddlFile, String databaseName) throws Exception {
         URL ddlTestFile = TestHelper.class.getClassLoader().getResource(ddlFile);
-        assertNotNull("Cannot locate " + ddlFile, ddlTestFile);
+        assertNotNull(ddlTestFile, "Cannot locate " + ddlFile);
         String statements = Files.readAllLines(Paths.get(ddlTestFile.toURI()))
                 .stream()
                 .collect(Collectors.joining(System.lineSeparator()));
@@ -574,7 +573,7 @@ public final class TestHelper {
 
     public static void executeDDL(JdbcDatabaseContainer<?> container, String ddlFile) throws Exception {
         URL ddlTestFile = TestHelper.class.getClassLoader().getResource(ddlFile);
-        assertNotNull("Cannot locate " + ddlFile, ddlTestFile);
+        assertNotNull(ddlTestFile, "Cannot locate " + ddlFile);
         String statements = Files.readAllLines(Paths.get(ddlTestFile.toURI()))
                 .stream()
                 .collect(Collectors.joining(System.lineSeparator()));

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBBeforeImageTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBBeforeImageTest.java
@@ -1,7 +1,6 @@
 package io.debezium.connector.yugabytedb;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.sql.SQLException;
@@ -11,15 +10,10 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.YugabyteYSQLContainer;
@@ -34,7 +28,7 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBTestBase {
   private static YugabyteYSQLContainer ybContainer;
   private static String masterAddresses;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws SQLException {
       ybContainer = TestHelper.getYbContainer();
       ybContainer.start();
@@ -46,18 +40,18 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBTestBase {
       TestHelper.dropAllSchemas();
   }
 
-  @Before
+  @BeforeEach
   public void before() {
       initializeConnectorTestFramework();
   }
 
-  @After
+  @AfterEach
   public void after() throws Exception {
       stopConnector();
       TestHelper.executeDDL("drop_tables_and_databases.ddl");
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() throws Exception {
       ybContainer.stop();
   }

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBColocatedTablesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBColocatedTablesTest.java
@@ -4,14 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.sql.SQLException;
 import java.time.Duration;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
 import org.testcontainers.containers.YugabyteYSQLContainer;
 
 import io.debezium.config.Configuration;
@@ -33,7 +28,7 @@ public class YugabyteDBColocatedTablesTest extends YugabyteDBTestBase {
   private final String INSERT_TEST_NO_COLOCATED =
     "INSERT INTO test_no_colocated VALUES (%d, 'not a colocated table');";
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws Exception {
     ybContainer = TestHelper.getYbContainer();
     ybContainer.start();
@@ -44,20 +39,20 @@ public class YugabyteDBColocatedTablesTest extends YugabyteDBTestBase {
     TestHelper.executeDDL("yugabyte_create_tables.ddl");
   }
 
-  @Before
+  @BeforeEach
   public void before() throws Exception {
     initializeConnectorTestFramework();
     TestHelper.dropAllSchemas();
     createTables();
   }
 
-  @After
+  @AfterEach
   public void after() throws Exception {
     stopConnector();
     dropTables();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() throws Exception {
     ybContainer.stop();
   }

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCompleteTypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCompleteTypesTest.java
@@ -7,7 +7,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.log4j.Logger;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 import org.testcontainers.containers.YugabyteYSQLContainer;
 
 import io.debezium.DebeziumException;
@@ -19,7 +19,7 @@ public class YugabyteDBCompleteTypesTest extends YugabyteDBTestBase {
     private final static Logger LOGGER = Logger.getLogger(YugabyteDBCompleteTypesTest.class);
     private static YugabyteYSQLContainer ybContainer;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() throws SQLException {
         ybContainer = TestHelper.getYbContainer();
         ybContainer.start();
@@ -30,18 +30,18 @@ public class YugabyteDBCompleteTypesTest extends YugabyteDBTestBase {
         TestHelper.dropAllSchemas();
     }
 
-    @Before
+    @BeforeEach
     public void before() {
         initializeConnectorTestFramework();
     }
 
-    @After
+    @AfterEach
     public void after() throws Exception {
         stopConnector();
         TestHelper.executeDDL("drop_tables_and_databases.ddl");
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() throws Exception {
         ybContainer.stop();
     }

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConfigTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConfigTest.java
@@ -4,24 +4,21 @@ import java.sql.SQLException;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.log4j.Logger;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.*;
 import org.testcontainers.containers.YugabyteYSQLContainer;
 
 import io.debezium.DebeziumException;
 import io.debezium.config.Configuration;
 import io.debezium.connector.yugabytedb.common.YugabyteDBTestBase;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 public class YugabyteDBConfigTest extends YugabyteDBTestBase {
   private final static Logger LOGGER = Logger.getLogger(YugabyteDBConnectorIT.class);
 
     private static YugabyteYSQLContainer ybContainer;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() throws SQLException {
         ybContainer = TestHelper.getYbContainer();
         ybContainer.start();
@@ -31,19 +28,19 @@ public class YugabyteDBConfigTest extends YugabyteDBTestBase {
         TestHelper.dropAllSchemas();
     }
 
-    @Before
+    @BeforeEach
     public void before() {
         initializeConnectorTestFramework();
     }
 
-    @After
+    @AfterEach
     public void after() throws Exception {
         stopConnector();
         TestHelper.executeDDL("drop_tables_and_databases.ddl");
     }
 
-    @AfterClass
-    public static void afterClass() throws Exception {
+    @AfterAll
+    public static void afterClass() {
         ybContainer.stop();
     }
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorIT.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorIT.java
@@ -4,25 +4,25 @@ import static org.fest.assertions.Assertions.*;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.log4j.Logger;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
 import io.debezium.connector.yugabytedb.common.YugabyteDBTestBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class YugabyteDBConnectorIT extends YugabyteDBTestBase {
     private final static Logger LOGGER = Logger.getLogger(YugabyteDBConnectorIT.class);
 
     private YugabyteDBConnector connector;
 
-    @Before
+    @BeforeEach
     public void before() {
         initializeConnectorTestFramework();
     }
 
-    @After
+    @AfterEach
     public void after() throws Exception {
         stopConnector();
     }
@@ -48,7 +48,7 @@ public class YugabyteDBConnectorIT extends YugabyteDBTestBase {
     }
 
     @Test
-    public void shouldNotStartWithInvalidConfiguration() throws Exception {
+    public void shouldNotStartWithInvalidConfiguration() {
         // use an empty configuration which should be invalid because of the lack of DB connection details
         Configuration config = Configuration.create().build();
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
@@ -1,8 +1,5 @@
 package io.debezium.connector.yugabytedb;
 
-import static org.junit.Assert.*;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import java.sql.SQLException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -17,21 +14,17 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.log4j.Logger;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.*;
 import org.testcontainers.containers.YugabyteYSQLContainer;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.yugabytedb.common.YugabyteDBTestBase;
 import io.debezium.connector.yugabytedb.transforms.YBExtractNewRecordState;
 import io.debezium.transforms.ExtractNewRecordStateConfigDefinition;
-import io.debezium.util.Strings;
 import org.yb.client.YBClient;
 import org.yb.client.YBTable;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Basic unit tests to check the behaviour with YugabyteDB datatypes
@@ -226,7 +219,7 @@ public class YugabyteDBDatatypesTest extends YugabyteDBTestBase {
       fail();
     }
   }
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() throws SQLException {
         ybContainer = TestHelper.getYbContainer();
         ybContainer.start();
@@ -236,19 +229,19 @@ public class YugabyteDBDatatypesTest extends YugabyteDBTestBase {
         TestHelper.dropAllSchemas();
     }
 
-    @Before
+    @BeforeEach
     public void before() {
         initializeConnectorTestFramework();
     }
 
-    @After
+    @AfterEach
     public void after() throws Exception {
         stopConnector();
         TestHelper.executeDDL("drop_tables_and_databases.ddl");
     }
 
-    @AfterClass
-    public static void afterClass() throws Exception {
+    @AfterAll
+    public static void afterClass() {
         ybContainer.stop();
     }
     // This test will just verify that the TestContainers are up and running

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBPartitionTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBPartitionTest.java
@@ -1,16 +1,9 @@
 package io.debezium.connector.yugabytedb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.sql.SQLException;
 import java.util.concurrent.CompletableFuture;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.YugabyteYSQLContainer;
@@ -18,6 +11,9 @@ import org.testcontainers.containers.YugabyteYSQLContainer;
 import io.debezium.config.Configuration;
 import io.debezium.connector.yugabytedb.common.YugabyteDBTestBase;
 import io.debezium.util.Strings;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 /**
@@ -29,7 +25,7 @@ public class YugabyteDBPartitionTest extends YugabyteDBTestBase {
   private final static Logger LOGGER = LoggerFactory.getLogger(YugabyteDBPartitionTest.class);
   private static YugabyteYSQLContainer ybContainer;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws SQLException {
       ybContainer = TestHelper.getYbContainer();
       ybContainer.start();
@@ -40,18 +36,18 @@ public class YugabyteDBPartitionTest extends YugabyteDBTestBase {
       TestHelper.dropAllSchemas();
   }
 
-  @Before
+  @BeforeEach
   public void before() {
       initializeConnectorTestFramework();
   }
 
-  @After
+  @AfterEach
   public void after() throws Exception {
       stopConnector();
       TestHelper.executeDDL("drop_tables_and_databases.ddl");
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() throws Exception {
       ybContainer.stop();
   }

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSchemaEvolutionTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSchemaEvolutionTest.java
@@ -1,9 +1,5 @@
 package io.debezium.connector.yugabytedb;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import java.sql.SQLException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -15,17 +11,15 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.YugabyteYSQLContainer;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.yugabytedb.common.YugabyteDBTestBase;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests to verify that the connector works with schema changes gracefully.
@@ -40,7 +34,7 @@ public class YugabyteDBSchemaEvolutionTest extends YugabyteDBTestBase {
   
   private static YugabyteYSQLContainer ybContainer;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws SQLException {
       String tserverFlags = "cdc_max_stream_intent_records=200";
       ybContainer = TestHelper.getYbContainer(null, tserverFlags);
@@ -52,19 +46,19 @@ public class YugabyteDBSchemaEvolutionTest extends YugabyteDBTestBase {
       TestHelper.dropAllSchemas();
   }
 
-  @Before
+  @BeforeEach
   public void before() {
       initializeConnectorTestFramework();
   }
 
-  @After
+  @AfterEach
   public void after() throws Exception {
       stopConnector();
       TestHelper.executeDDL("drop_tables_and_databases.ddl");
   }
 
-  @AfterClass
-  public static void afterClass() throws Exception {
+  @AfterAll
+  public static void afterClass() {
       ybContainer.stop();
   }
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTabletSplitTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTabletSplitTest.java
@@ -1,7 +1,6 @@
 package io.debezium.connector.yugabytedb;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.sql.SQLException;
 import java.time.Duration;
@@ -14,12 +13,7 @@ import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.data.Struct;
 import org.awaitility.Awaitility;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.YugabyteYSQLContainer;
@@ -40,7 +34,7 @@ public class YugabyteDBTabletSplitTest extends YugabyteDBTestBase {
   private static YugabyteYSQLContainer ybContainer;
   private static String masterAddresses;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws SQLException {
       ybContainer = TestHelper.getYbContainer();
       ybContainer.start();
@@ -52,19 +46,19 @@ public class YugabyteDBTabletSplitTest extends YugabyteDBTestBase {
       TestHelper.dropAllSchemas();
   }
 
-  @Before
+  @BeforeEach
   public void before() {
       initializeConnectorTestFramework();
   }
 
-  @After
+  @AfterEach
   public void after() throws Exception {
       stopConnector();
       TestHelper.executeDDL("drop_tables_and_databases.ddl");
   }
 
-  @AfterClass
-  public static void afterClass() throws Exception {
+  @AfterAll
+  public static void afterClass() {
       ybContainer.stop();
   }
 
@@ -235,7 +229,7 @@ public class YugabyteDBTabletSplitTest extends YugabyteDBTestBase {
     LOGGER.debug("Record key set size: " + recordKeySet.size());
     List<Integer> rList = recordKeySet.stream().collect(Collectors.toList());
     Collections.sort(rList);
-    
+
     assertEquals(recordsCount, recordKeySet.size());
   }
 

--- a/src/test/java/io/debezium/connector/yugabytedb/connection/YugabyteDBConnectionIT.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/connection/YugabyteDBConnectionIT.java
@@ -6,7 +6,7 @@
 
 package io.debezium.connector.yugabytedb.connection;
 
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 
 import io.debezium.util.Testing;
 
@@ -17,7 +17,7 @@ import io.debezium.util.Testing;
  */
 public class YugabyteDBConnectionIT {
 
-    @After
+    @AfterEach
     public void after() {
         Testing.Print.disable();
     }

--- a/src/test/java/io/debezium/connector/yugabytedb/transforms/PGCompatibleTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/transforms/PGCompatibleTest.java
@@ -1,14 +1,12 @@
 package io.debezium.connector.yugabytedb.transforms;
 
 import io.debezium.data.Envelope;
-import io.debezium.transforms.ExtractNewRecordStateConfigDefinition;
-import org.apache.kafka.common.protocol.types.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.source.SourceRecord;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.yb.util.Pair;
 
 import java.time.Instant;
@@ -18,7 +16,6 @@ import java.util.Map;
 
 import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.ADD_HEADERS;
 import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.HANDLE_DELETES;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 
 public class PGCompatibleTest {


### PR DESCRIPTION
This PR migrates all the tests from the junit-vintage-engine (JUnit4) to the junit-jupiter-engine (JUnit5). Additionally, this closes #59 