### PR TITLE
Do not run consistency related tests against stable YB build

### DIFF
--- a/.github/workflows/sanity-workflow.yml
+++ b/.github/workflows/sanity-workflow.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Sanity Test that code compiles and tests pass.
         env:
           YB_DOCKER_IMAGE: ${{ secrets.YB_DOCKER_IMAGE }}
-        run: mvn clean test -Dtest=!YugabyteDBColocatedTablesTest#shouldWorkWithMixOfColocatedAndNonColocatedTables,!YugabyteDBDatatypesTest#testEnumValue
+        run: mvn clean test -Dtest=!YugabyteDBColocatedTablesTest#shouldWorkWithMixOfColocatedAndNonColocatedTables,!YugabyteDBDatatypesTest#testEnumValue,!YugabyteDBStreamConsistencyTest,!MergerTest,!MessageTest
       - name: Flaky test i.e. YugabyteDBDatatypesTest#testEnumValue
         env:
           YB_DOCKER_IMAGE: ${{ secrets.YB_DOCKER_IMAGE }}


### PR DESCRIPTION
This PR adds the consistency related tests to the list of tests **NOT** to be run against the stable builds (currently 2.16) of YugabyteDB since the server side changes required for them are not present in the relevant 2.16 build being used for testing.