### PR TITLE
[#181] Log test names with each test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <protobuf.output.directory>${project.basedir}/generated-sources</protobuf.output.directory>
 
         <!-- Test -->
-        <version.junit>5.9.0</version.junit>
+        <version.junit>5.9.2</version.junit>
 
         <!-- Deploy -->
         <version.s3.wagon>0.1.3</version.s3.wagon>

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBBeforeImageTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBBeforeImageTest.java
@@ -14,14 +14,11 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
 
 public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
-  private final static Logger LOGGER = LoggerFactory.getLogger(YugabyteDBPartitionTest.class);
   private final String formatInsertString =
       "INSERT INTO t1 VALUES (%d, 'Vaibhav', 'Kushwaha', 12.345);";
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCompleteTypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCompleteTypesTest.java
@@ -7,7 +7,6 @@ import java.util.concurrent.CompletableFuture;
 
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
 import org.apache.kafka.connect.source.SourceRecord;
-import org.apache.log4j.Logger;
 import org.junit.jupiter.api.*;
 
 import io.debezium.DebeziumException;
@@ -15,8 +14,6 @@ import io.debezium.config.Configuration;
 import io.debezium.util.Strings;
 
 public class YugabyteDBCompleteTypesTest extends YugabyteDBContainerTestBase {
-    private final static Logger LOGGER = Logger.getLogger(YugabyteDBCompleteTypesTest.class);
-
     @BeforeAll
     public static void beforeClass() throws SQLException {
         initializeYBContainer();

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConfigTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConfigTest.java
@@ -3,7 +3,6 @@ package io.debezium.connector.yugabytedb;
 import java.sql.SQLException;
 import java.util.concurrent.CompletableFuture;
 
-import org.apache.log4j.Logger;
 import org.junit.jupiter.api.*;
 
 import io.debezium.DebeziumException;
@@ -13,7 +12,6 @@ import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
-  private final static Logger LOGGER = Logger.getLogger(YugabyteDBConnectorIT.class);
 
     @BeforeAll
     public static void beforeClass() throws SQLException {

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorIT.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorIT.java
@@ -3,7 +3,6 @@ package io.debezium.connector.yugabytedb;
 import static org.fest.assertions.Assertions.*;
 
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.log4j.Logger;
 
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
@@ -13,7 +12,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class YugabyteDBConnectorIT extends YugabyteDBContainerTestBase {
-    private final static Logger LOGGER = Logger.getLogger(YugabyteDBConnectorIT.class);
 
     private YugabyteDBConnector connector;
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
@@ -12,7 +12,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
-import org.apache.log4j.Logger;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
 import org.junit.jupiter.api.*;
@@ -30,8 +29,6 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 
 public class YugabyteDBDatatypesTest extends YugabyteDBContainerTestBase {
-    private final static Logger LOGGER = Logger.getLogger(YugabyteDBDatatypesTest.class);
-
     private static final String INSERT_STMT = "INSERT INTO s1.a (aa) VALUES (1);" +
             "INSERT INTO s2.a (aa) VALUES (1);";
     private static final String CREATE_TABLES_STMT = "DROP SCHEMA IF EXISTS s1 CASCADE;" +

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBPartitionTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBPartitionTest.java
@@ -4,9 +4,6 @@ import java.sql.SQLException;
 import java.util.concurrent.CompletableFuture;
 
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.YugabyteYSQLContainer;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
@@ -22,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
  */
 public class YugabyteDBPartitionTest extends YugabyteDBContainerTestBase {
-  private final static Logger LOGGER = LoggerFactory.getLogger(YugabyteDBPartitionTest.class);
 
   @BeforeAll
   public static void beforeClass() throws SQLException {

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSchemaEvolutionTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSchemaEvolutionTest.java
@@ -13,9 +13,6 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.YugabyteYSQLContainer;
 
 import io.debezium.config.Configuration;
 
@@ -27,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
  */
 public class YugabyteDBSchemaEvolutionTest extends YugabyteDBContainerTestBase {
-  private final static Logger LOGGER = LoggerFactory.getLogger(YugabyteDBSchemaEvolutionTest.class);
   
   // Keeping the id part as a string only so that it is easier to use generate_series as well.
   private final String insertFormatString = "INSERT INTO t1 VALUES (%s, 'name_value');";

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -6,9 +6,6 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.YugabyteYSQLContainer;
 import org.yb.client.YBClient;
 import org.yb.client.YBTable;
 
@@ -22,7 +19,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
-    private final static Logger LOGGER = LoggerFactory.getLogger(YugabyteDBSnapshotTest.class);
 
     @BeforeAll
     public static void beforeClass() throws SQLException {

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTabletSplitTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTabletSplitTest.java
@@ -14,9 +14,6 @@ import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.Struct;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.YugabyteYSQLContainer;
 import org.yb.client.GetTabletListToPollForCDCResponse;
 import org.yb.client.YBClient;
 import org.yb.client.YBTable;
@@ -30,7 +27,7 @@ import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
  * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
  */
 public class YugabyteDBTabletSplitTest extends YugabyteDBContainerTestBase {
-  private final static Logger LOGGER = LoggerFactory.getLogger(YugabyteDBPartitionTest.class);
+
   private static String masterAddresses;
 
   @BeforeAll

--- a/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
@@ -1,7 +1,12 @@
 package io.debezium.connector.yugabytedb.common;
 
+import io.debezium.connector.yugabytedb.rules.YugabyteDBLogTestName;
 import io.debezium.embedded.AbstractConnectorTest;
 import org.awaitility.Awaitility;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.YugabyteYSQLContainer;
 
 import java.time.Duration;
@@ -11,7 +16,9 @@ import java.time.Duration;
  *
  * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
  */
+@ExtendWith(YugabyteDBLogTestName.class)
 public class TestBaseClass extends AbstractConnectorTest {
+    public Logger LOGGER = LoggerFactory.getLogger(getClass());
     protected static YugabyteYSQLContainer ybContainer;
 
     protected void awaitUntilConnectorIsReady() throws Exception {

--- a/src/test/java/io/debezium/connector/yugabytedb/rules/YugabyteDBLogTestName.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/rules/YugabyteDBLogTestName.java
@@ -1,0 +1,36 @@
+package io.debezium.connector.yugabytedb.rules;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test annotation to make sure that we are logging the proper test name before and after each test.
+ *
+ * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
+ */
+public class YugabyteDBLogTestName implements BeforeEachCallback, AfterEachCallback {
+    private final Logger LOGGER = LoggerFactory.getLogger(getClass());
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        if (extensionContext.getTestClass().isPresent()
+                && extensionContext.getTestMethod().isPresent()) {
+            LOGGER.info("Starting test {}#{}",
+                        extensionContext.getTestClass().get().getSimpleName(),
+                        extensionContext.getTestMethod().get().getName());
+        }
+    }
+
+    @Override
+    public void afterEach(ExtensionContext extensionContext) throws Exception {
+        if (extensionContext.getTestClass().isPresent()
+                && extensionContext.getTestMethod().isPresent()) {
+            LOGGER.info("Finished test {}#{}",
+                        extensionContext.getTestClass().get().getSimpleName(),
+                        extensionContext.getTestMethod().get().getName());
+        }
+    }
+}

--- a/src/test/java/io/debezium/connector/yugabytedb/rules/YugabyteDBLogTestName.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/rules/YugabyteDBLogTestName.java
@@ -7,7 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Test annotation to make sure that we are logging the proper test name before and after each test.
+ * Test extension to make sure that we are logging the proper test name before and after each test.
  *
  * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
  */


### PR DESCRIPTION
Log test names at the start of every test in order to make debugging easier in case of failures by figuring out the exact test name from the log files.

Closes #181 