### PR TITLE
[#194] Store OpIds and offset contexts against a lookup key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>io.debezium</groupId>
     <artifactId>debezium-connector-yugabytedb</artifactId>
     <name>YugabyteDB Source Connector</name>
-    <version>1.9.5.y.18</version>
+    <version>1.9.5.y.19-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>

--- a/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
@@ -44,8 +44,6 @@ public final class SourceInfo extends BaseSourceInfo {
     private Instant timestamp;
     private String schemaName;
     private String tableName;
-    private String tabletId;
-    private String tableUUID;
 
     protected SourceInfo(YugabyteDBConnectorConfig connectorConfig) {
         super(connectorConfig);
@@ -71,7 +69,7 @@ public final class SourceInfo extends BaseSourceInfo {
      * @param xmin the xmin of the slot, may be null
      * @return this instance
      */
-    protected SourceInfo update(String tableUUID, String tabletId, OpId lsn, Instant commitTime, String txId,
+    protected SourceInfo update(YBPartition partition, OpId lsn, Instant commitTime, String txId,
                                 TableId tableId,
                                 Long xmin) {
         this.lsn = lsn;
@@ -86,8 +84,6 @@ public final class SourceInfo extends BaseSourceInfo {
         if (tableId != null && tableId.table() != null) {
             this.tableName = tableId.table();
         }
-        this.tableUUID = tableUUID;
-        this.tabletId = tabletId;
         return this;
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
@@ -45,6 +45,7 @@ public final class SourceInfo extends BaseSourceInfo {
     private String schemaName;
     private String tableName;
     private String tabletId;
+    private String tableUUID;
 
     protected SourceInfo(YugabyteDBConnectorConfig connectorConfig) {
         super(connectorConfig);
@@ -70,7 +71,7 @@ public final class SourceInfo extends BaseSourceInfo {
      * @param xmin the xmin of the slot, may be null
      * @return this instance
      */
-    protected SourceInfo update(String tabletId, OpId lsn, Instant commitTime, String txId,
+    protected SourceInfo update(String tableUUID, String tabletId, OpId lsn, Instant commitTime, String txId,
                                 TableId tableId,
                                 Long xmin) {
         this.lsn = lsn;
@@ -85,6 +86,7 @@ public final class SourceInfo extends BaseSourceInfo {
         if (tableId != null && tableId.table() != null) {
             this.tableName = tableId.table();
         }
+        this.tableUUID = tableUUID;
         this.tabletId = tabletId;
         return this;
     }

--- a/src/main/java/io/debezium/connector/yugabytedb/YBPartition.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YBPartition.java
@@ -25,9 +25,20 @@ public class YBPartition implements Partition {
     private final String tabletId;
     private final String tableId;
 
+    private boolean colocated;
+
     public YBPartition(String tableId, String tabletId) {
         this.tableId = tableId;
         this.tabletId = tabletId;
+
+        // By default, assume that the table is not colocated.
+        this.colocated = false;
+    }
+
+    public YBPartition(String tableId, String tabletId, boolean isTableColocated) {
+        this.tableId = tableId;
+        this.tabletId = tabletId;
+        this.colocated = isTableColocated;
     }
 
     @Override
@@ -44,11 +55,32 @@ public class YBPartition implements Partition {
     }
 
     /**
-     * @return the ID of this partition in the format {@code tableId.tabletId}, this is essentially
-     * the same thing as using {@code p.getTableId() + "." + p.getTabletId()}
+     * @return the ID of this partition in the format {@code tableId.tabletId} (if table is
+     * colocated) or {@code tabletId} (if table is not colocated)
      */
     public String getId() {
-        return this.tableId + "." + this.tabletId;
+        if (!isTableColocated()) {
+            return getTabletId();
+        }
+
+        return getFullPartitionName();
+    }
+
+    /**
+     * Get the full ID of this partition identified by {@code tableId.tabletId} - this will be used
+     * to form the metric names.
+     * @return
+     */
+    public String getFullPartitionName() {
+        return getTableId() + "." + getTabletId();
+    }
+
+    public boolean isTableColocated() {
+        return this.colocated;
+    }
+
+    public void markTableAsColocated() {
+        this.colocated = true;
     }
 
     @Override
@@ -66,7 +98,7 @@ public class YBPartition implements Partition {
 
     @Override
     public int hashCode() {
-        return getId().hashCode();
+        return getFullPartitionName().hashCode();
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeEventSourceCoordinator.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeEventSourceCoordinator.java
@@ -109,6 +109,12 @@ public class YugabyteDBChangeEventSourceCoordinator extends ChangeEventSourceCoo
 
             if (snapshotResult.isCompletedOrSkipped()) {
                 streamingOffsets.getOffsets().put(partition, snapshotResult.getOffset());
+
+                // Further down the processing unit, we are retrieving all the partitions even
+                // though we pass just one at this level, so in case the snapshot gets completed
+                // for one, it would be safe to break out of this loop to avoid processing things
+                // again.
+                break;
             }
         }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeRecordEmitter.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeRecordEmitter.java
@@ -49,13 +49,14 @@ public class YugabyteDBChangeRecordEmitter extends RelationalChangeRecordEmitter
 
     private final String pgSchemaName;
     private final String tabletId;
+    private final String tableUUID;
     private final YugabyteDBOffsetContext offsetContext;
 
     public YugabyteDBChangeRecordEmitter(YBPartition partition, YugabyteDBOffsetContext offset, Clock clock,
                                          YugabyteDBConnectorConfig connectorConfig,
                                          YugabyteDBSchema schema, YugabyteDBConnection connection,
                                          TableId tableId, ReplicationMessage message, String pgSchemaName,
-                                         String tabletId, boolean shouldSendBeforeImage) {
+                                         String tableUUID, String tabletId, boolean shouldSendBeforeImage) {
         super(partition, offset, clock);
 
         this.schema = schema;
@@ -69,6 +70,7 @@ public class YugabyteDBChangeRecordEmitter extends RelationalChangeRecordEmitter
         Objects.requireNonNull(this.tableId);
 
         this.tabletId = tabletId;
+        this.tableUUID = tableUUID;
 
         this.shouldSendBeforeImage = shouldSendBeforeImage;
 
@@ -101,7 +103,7 @@ public class YugabyteDBChangeRecordEmitter extends RelationalChangeRecordEmitter
 
     @Override
     protected void emitTruncateRecord(Receiver receiver, TableSchema tableSchema) throws InterruptedException {
-        Struct envelope = tableSchema.getEnvelopeSchema().truncate(offsetContext.getSourceInfoForTablet(tabletId), getClock().currentTimeAsInstant());
+        Struct envelope = tableSchema.getEnvelopeSchema().truncate(offsetContext.getSourceInfoForTablet(tableUUID, tabletId), getClock().currentTimeAsInstant());
         receiver.changeRecord(getPartition(), tableSchema, Operation.TRUNCATE, null, envelope, getOffset(), null);
     }
 
@@ -311,11 +313,11 @@ public class YugabyteDBChangeRecordEmitter extends RelationalChangeRecordEmitter
         Object[] newColumnValues = getNewColumnValues();
         Struct newKey = tableSchema.keyFromColumnData(newColumnValues);
         Struct newValue = tableSchema.valueFromColumnData(newColumnValues);
-        Struct envelope = tableSchema.getEnvelopeSchema().create(newValue, offsetContext.getSourceInfoForTablet(tabletId), getClock().currentTimeAsInstant());
+        Struct envelope = tableSchema.getEnvelopeSchema().create(newValue, offsetContext.getSourceInfoForTablet(tableUUID, tabletId), getClock().currentTimeAsInstant());
 
         if (skipEmptyMessages() && (newColumnValues == null || newColumnValues.length == 0)) {
             // This case can be hit on UPDATE / DELETE when there's no primary key defined while using certain decoders
-            LOGGER.warn("no new values found for table '{}' from create message at '{}'; skipping record", tableSchema, offsetContext.getSourceInfoForTablet(tabletId));
+            LOGGER.warn("no new values found for table '{}' from create message at '{}'; skipping record", tableSchema, offsetContext.getSourceInfoForTablet(tableUUID, tabletId));
             return;
         }
         receiver.changeRecord(getPartition(), tableSchema, Operation.CREATE, newKey, envelope, getOffset(), null);
@@ -326,7 +328,7 @@ public class YugabyteDBChangeRecordEmitter extends RelationalChangeRecordEmitter
         Object[] newColumnValues = getNewColumnValues();
         Struct newKey = tableSchema.keyFromColumnData(newColumnValues);
         Struct newValue = tableSchema.valueFromColumnData(newColumnValues);
-        Struct envelope = tableSchema.getEnvelopeSchema().read(newValue, offsetContext.getSourceInfoForTablet(tabletId), getClock().currentTimeAsInstant());
+        Struct envelope = tableSchema.getEnvelopeSchema().read(newValue, offsetContext.getSourceInfoForTablet(tableUUID, tabletId), getClock().currentTimeAsInstant());
 
         receiver.changeRecord(getPartition(), tableSchema, Operation.READ, newKey, envelope, getOffset(), null);
     }
@@ -352,7 +354,7 @@ public class YugabyteDBChangeRecordEmitter extends RelationalChangeRecordEmitter
         // some configurations does not provide old values in case of updates
         // in this case we handle all updates as regular ones
         if (oldKey == null || Objects.equals(oldKey, newKey)) {
-            Struct envelope = tableSchema.getEnvelopeSchema().update(oldValue, newValue, offsetContext.getSourceInfoForTablet(getPartition().getTabletId()), getClock().currentTimeAsInstant());
+            Struct envelope = tableSchema.getEnvelopeSchema().update(oldValue, newValue, offsetContext.getSourceInfoForTablet(tableUUID, getPartition().getTabletId()), getClock().currentTimeAsInstant());
             receiver.changeRecord(getPartition(), tableSchema, Operation.UPDATE, newKey, envelope, getOffset(), null);
         }
         // PK update -> emit as delete and re-insert with new key
@@ -360,13 +362,13 @@ public class YugabyteDBChangeRecordEmitter extends RelationalChangeRecordEmitter
             ConnectHeaders headers = new ConnectHeaders();
             headers.add(PK_UPDATE_NEWKEY_FIELD, newKey, tableSchema.keySchema());
 
-            Struct envelope = tableSchema.getEnvelopeSchema().delete(oldValue, offsetContext.getSourceInfoForTablet(tabletId), getClock().currentTimeAsInstant());
+            Struct envelope = tableSchema.getEnvelopeSchema().delete(oldValue, offsetContext.getSourceInfoForTablet(tableUUID, tabletId), getClock().currentTimeAsInstant());
             receiver.changeRecord(getPartition(), tableSchema, Operation.DELETE, oldKey, envelope, getOffset(), headers);
 
             headers = new ConnectHeaders();
             headers.add(PK_UPDATE_OLDKEY_FIELD, oldKey, tableSchema.keySchema());
 
-            envelope = tableSchema.getEnvelopeSchema().create(newValue, offsetContext.getSourceInfoForTablet(tabletId), getClock().currentTimeAsInstant());
+            envelope = tableSchema.getEnvelopeSchema().create(newValue, offsetContext.getSourceInfoForTablet(tableUUID, tabletId), getClock().currentTimeAsInstant());
             receiver.changeRecord(getPartition(), tableSchema, Operation.CREATE, newKey, envelope, getOffset(), headers);
         }
     }
@@ -378,11 +380,11 @@ public class YugabyteDBChangeRecordEmitter extends RelationalChangeRecordEmitter
         Struct oldValue = tableSchema.valueFromColumnData(oldColumnValues);
 
         if (skipEmptyMessages() && (oldColumnValues == null || oldColumnValues.length == 0)) {
-            LOGGER.warn("no old values found for table '{}' from delete message at '{}'; skipping record", tableSchema, offsetContext.getSourceInfoForTablet(tabletId));
+            LOGGER.warn("no old values found for table '{}' from delete message at '{}'; skipping record", tableSchema, offsetContext.getSourceInfoForTablet(tableUUID, tabletId));
             return;
         }
 
-        Struct envelope = tableSchema.getEnvelopeSchema().delete(oldValue, offsetContext.getSourceInfoForTablet(tabletId), getClock().currentTimeAsInstant());
+        Struct envelope = tableSchema.getEnvelopeSchema().delete(oldValue, offsetContext.getSourceInfoForTablet(tableUUID, tabletId), getClock().currentTimeAsInstant());
         receiver.changeRecord(getPartition(), tableSchema, Operation.DELETE, oldKey, envelope, getOffset(), null);
     }
 }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
@@ -11,12 +11,12 @@ import java.nio.charset.Charset;
 import java.sql.SQLException;
 import java.util.*;
 
+import io.debezium.connector.yugabytedb.util.YugabyteDBConnectorUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.connector.Task;
-import org.apache.kafka.connect.util.ConnectorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yb.cdc.CdcService.TabletCheckpointPair;
@@ -145,7 +145,7 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
         int numGroups = Math.min(this.tabletIds.size(), maxTasks);
         LOGGER.debug("The tabletIds size are " + tabletIds.size() + " maxTasks" + maxTasks);
 
-        List<List<Pair<String, String>>> tabletIdsGrouped = ConnectorUtils.groupPartitions(this.tabletIds, numGroups);
+        List<List<Pair<String, String>>> tabletIdsGrouped = YugabyteDBConnectorUtils.groupPartitionsSmartly(this.tabletIds, numGroups);
         LOGGER.debug("The grouped tabletIds are " + tabletIdsGrouped.size());
         List<Map<String, String>> taskConfigs = new ArrayList<>(tabletIdsGrouped.size());
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -368,7 +368,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                   break;
                 }
                 
-                GetChangesResponse resp = this.syncClient.getChangesCDCSDK(table, 
+                GetChangesResponse resp = this.syncClient.getChangesCDCSDK(table,
                     connectorConfig.streamId(), tabletId, cp.getTerm(), cp.getIndex(), cp.getKey(),
                     cp.getWrite_id(), cp.getTime(), schemaNeeded.get(tableUUID + "." + tabletId),
                     taskContext.shouldEnableExplicitCheckpointing() ? tabletToExplicitCheckpoint.get(tableUUID + "." + tabletId) : null);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -363,7 +363,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                       || tabletsWaitingForCallback.contains(part.getId())) {
                   // Before continuing, check if the tablets waiting for callback have been updated in case of explicit checkpointing.
                   if (taskContext.shouldEnableExplicitCheckpointing()) {
-                    doSnapshotCompletionCheck(tabletId, snapshotCompletedTablets, tabletsWaitingForCallback);
+                    doSnapshotCompletionCheck(part, snapshotCompletedTablets, tabletsWaitingForCallback);
                   }
                   continue;
                 }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -519,8 +519,8 @@ public class YugabyteDBStreamingChangeEventSource implements
                                             && dispatcher.dispatchDataChangeEvent(part, tableId, new YugabyteDBChangeRecordEmitter(part, offsetContext, clock, connectorConfig,
                                                     schema, connection, tableId, message, pgSchemaNameInRecord, tabletId, taskContext.isBeforeImageEnabled()));
 
-                                    if (recordsInTransactionalBlock.containsKey(entry.getKey() + "." + tabletId)) {
-                                        recordsInTransactionalBlock.merge(entry.getKey() + "." + tabletId, 1, Integer::sum);
+                                    if (recordsInTransactionalBlock.containsKey(part.getId())) {
+                                        recordsInTransactionalBlock.merge(part.getId(), 1, Integer::sum);
                                     }
 
                                     maybeWarnAboutGrowingWalBacklog(dispatched);
@@ -787,7 +787,7 @@ public class YugabyteDBStreamingChangeEventSource implements
             LOGGER.info("Initialized offset context for tablet {} with OpId {}", tabletId, OpId.from(pair.getCdcSdkCheckpoint()));
 
             // Add the flag to indicate that we need the schema for the new tablets so that the schema can be registered.
-            schemaNeeded.put(tableId + "." + tabletId, Boolean.TRUE);
+            schemaNeeded.put(p.getId(), Boolean.TRUE);
         }
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -224,8 +224,6 @@ public class YugabyteDBStreamingChangeEventSource implements
                              YugabyteDBOffsetContext offsetContext,
                              boolean previousOffsetPresent)
             throws Exception {
-        LOGGER.debug("The offset is " + offsetContext.getOffset());
-
         LOGGER.info("Processing messages");
 
         String tabletList = this.connectorConfig.getConfig().getString(YugabyteDBConnectorConfig.TABLET_LIST);
@@ -275,8 +273,11 @@ public class YugabyteDBStreamingChangeEventSource implements
                 opId = YugabyteDBOffsetContext.streamingStartLsn();
             }
 
-            offsetContext.initSourceInfo(entry.getKey(), entry.getValue(), this.connectorConfig, opId);
-            schemaNeeded.put(entry.getKey() + "." + entry.getValue(), Boolean.TRUE);
+            // For streaming, we do not want any colocated information and want to process the tables
+            // based on just their tablet IDs - pass false as the 'colocated' flag to enforce the same.
+            YBPartition p = new YBPartition(entry.getKey(), entry.getValue(), false /* colocated */);
+            offsetContext.initSourceInfo(p, this.connectorConfig, opId);
+            schemaNeeded.put(p.getId(), Boolean.TRUE);
         }
 
         // This will contain the tablet ID mapped to the number of records it has seen
@@ -332,9 +333,9 @@ public class YugabyteDBStreamingChangeEventSource implements
                     for (Pair<String, String> entry : tabletPairList) {
                         final String tabletId = entry.getValue();
                         curTabletId = entry.getValue();
-                        YBPartition part = new YBPartition(entry.getKey() /* tableId */, tabletId);
+                        YBPartition part = new YBPartition(entry.getKey() /* tableId */, tabletId, false /* colocated */);
 
-                      OpId cp = offsetContext.lsn(entry.getKey() /* tableUUID */, tabletId);
+                      OpId cp = offsetContext.lsn(part);
 
                       YBTable table = tableIdToTable.get(entry.getKey());
 
@@ -353,15 +354,15 @@ public class YugabyteDBStreamingChangeEventSource implements
 
                       GetChangesResponse response = null;
 
-                      if (schemaNeeded.get(entry.getKey() + "." + tabletId)) {
+                      if (schemaNeeded.get(part.getId())) {
                         LOGGER.debug("Requesting schema for tablet: {}", tabletId);
                       }
 
                       try {
                         response = this.syncClient.getChangesCDCSDK(
                             table, streamId, tabletId, cp.getTerm(), cp.getIndex(), cp.getKey(),
-                            cp.getWrite_id(), cp.getTime(), schemaNeeded.get(entry.getKey() + "." + tabletId),
-                            taskContext.shouldEnableExplicitCheckpointing() ? tabletToExplicitCheckpoint.get(entry.getKey() + "." + tabletId) : null);
+                            cp.getWrite_id(), cp.getTime(), schemaNeeded.get(part.getId()),
+                            taskContext.shouldEnableExplicitCheckpointing() ? tabletToExplicitCheckpoint.get(part.getId()) : null);
                       } catch (CDCErrorException cdcException) {
                         // Check if exception indicates a tablet split.
                         LOGGER.debug("Code received in CDCErrorException: {}", cdcException.getCDCError().getCode());
@@ -418,62 +419,61 @@ public class YugabyteDBStreamingChangeEventSource implements
                                         if (message.getOperation() == Operation.BEGIN) {
                                             LOGGER.debug("LSN in case of BEGIN is " + lsn);
 
-                                            recordsInTransactionalBlock.put(entry.getKey() + "." + tabletId, 0);
-                                            beginCountForTablet.merge(entry.getKey() + "." + tabletId, 1, Integer::sum);
+                                            recordsInTransactionalBlock.put(part.getId(), 0);
+                                            beginCountForTablet.merge(part.getId(), 1, Integer::sum);
                                         }
                                         if (message.getOperation() == Operation.COMMIT) {
                                             LOGGER.debug("LSN in case of COMMIT is " + lsn);
-                                            offsetContext.updateWalPosition(entry.getKey(), tabletId, lsn, lastCompletelyProcessedLsn, message.getCommitTime(),
+                                            offsetContext.updateWalPosition(part, lsn, lastCompletelyProcessedLsn, message.getCommitTime(),
                                                     String.valueOf(message.getTransactionId()), null, null/* taskContext.getSlotXmin(connection) */);
                                             commitMessage(part, offsetContext, lsn);
 
-                                            if (recordsInTransactionalBlock.containsKey(entry.getKey() + "." + tabletId)) {
-                                                if (recordsInTransactionalBlock.get(entry.getKey() + "." + tabletId) == 0) {
+                                            if (recordsInTransactionalBlock.containsKey(part.getId())) {
+                                                if (recordsInTransactionalBlock.get(part.getId()) == 0) {
                                                     LOGGER.debug("Records in the transactional block of transaction: {}, with LSN: {}, for tablet {} are 0",
-                                                                message.getTransactionId(), lsn, entry.getKey() + "." + tabletId);
+                                                                message.getTransactionId(), lsn, part.getId());
                                                 } else {
                                                     LOGGER.debug("Records in the transactional block transaction: {}, with LSN: {}, for tablet {}: {}",
-                                                                 message.getTransactionId(), lsn, entry.getKey() + "." + tabletId, recordsInTransactionalBlock.get(entry.getKey() + "." + tabletId));
+                                                                 message.getTransactionId(), lsn, part.getId(), recordsInTransactionalBlock.get(part.getId()));
                                                 }
-                                            } else if (beginCountForTablet.get(entry.getKey() + "." + tabletId).intValue() == 0) {
+                                            } else if (beginCountForTablet.get(part.getId()).intValue() == 0) {
                                                 throw new DebeziumException("COMMIT record encountered without a preceding BEGIN record");
                                             }
 
-                                            recordsInTransactionalBlock.remove(entry.getKey() + "." + tabletId);
-                                            beginCountForTablet.merge(entry.getKey() + "." + tabletId, -1, Integer::sum);
+                                            recordsInTransactionalBlock.remove(part.getId());
+                                            beginCountForTablet.merge(part.getId(), -1, Integer::sum);
                                         }
                                         continue;
                                     }
 
                                     if (message.getOperation() == Operation.BEGIN) {
                                         LOGGER.debug("LSN in case of BEGIN is " + lsn);
-                                        dispatcher.dispatchTransactionStartedEvent(part,
-                                                message.getTransactionId(), offsetContext);
+                                        dispatcher.dispatchTransactionStartedEvent(part, message.getTransactionId(), offsetContext);
 
-                                        recordsInTransactionalBlock.put(entry.getKey() + "." + tabletId, 0);
-                                        beginCountForTablet.merge(entry.getKey() + "." + tabletId, 1, Integer::sum);
+                                        recordsInTransactionalBlock.put(part.getId(), 0);
+                                        beginCountForTablet.merge(part.getId(), 1, Integer::sum);
                                     }
                                     else if (message.getOperation() == Operation.COMMIT) {
                                         LOGGER.debug("LSN in case of COMMIT is " + lsn);
-                                        offsetContext.updateWalPosition(entry.getKey(), tabletId, lsn, lastCompletelyProcessedLsn, message.getCommitTime(),
+                                        offsetContext.updateWalPosition(part, lsn, lastCompletelyProcessedLsn, message.getCommitTime(),
                                                 String.valueOf(message.getTransactionId()), null, null/* taskContext.getSlotXmin(connection) */);
                                         commitMessage(part, offsetContext, lsn);
                                         dispatcher.dispatchTransactionCommittedEvent(part, offsetContext);
 
-                                        if (recordsInTransactionalBlock.containsKey(entry.getKey() + "." + tabletId)) {
-                                            if (recordsInTransactionalBlock.get(entry.getKey() + "." + tabletId) == 0) {
+                                        if (recordsInTransactionalBlock.containsKey(part.getId())) {
+                                            if (recordsInTransactionalBlock.get(part.getId()) == 0) {
                                                 LOGGER.debug("Records in the transactional block of transaction: {}, with LSN: {}, for tablet {} are 0",
-                                                            message.getTransactionId(), lsn, entry.getKey() + "." + tabletId);
+                                                            message.getTransactionId(), lsn, part.getId());
                                             } else {
                                                 LOGGER.debug("Records in the transactional block transaction: {}, with LSN: {}, for tablet {}: {}",
-                                                             message.getTransactionId(), lsn, entry.getKey() + "." + tabletId, recordsInTransactionalBlock.get(entry.getKey() + "." + tabletId));
+                                                             message.getTransactionId(), lsn, part.getId(), recordsInTransactionalBlock.get(part.getId()));
                                             }
-                                        } else if (beginCountForTablet.get(entry.getKey() + "." + tabletId).intValue() == 0) {
+                                        } else if (beginCountForTablet.get(part.getId()).intValue() == 0) {
                                             throw new DebeziumException("COMMIT record encountered without a preceding BEGIN record");
                                         }
 
-                                        recordsInTransactionalBlock.remove(entry.getKey() + "." + tabletId);
-                                        beginCountForTablet.merge(entry.getKey() + "." + tabletId, -1, Integer::sum);
+                                        recordsInTransactionalBlock.remove(part.getId());
+                                        beginCountForTablet.merge(part.getId(), -1, Integer::sum);
                                     }
                                     maybeWarnAboutGrowingWalBacklog(true);
                                 }
@@ -482,7 +482,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                                             + " the table is " + message.getTable());
 
                                     // If a DDL message is received for a tablet, we do not need its schema again
-                                    schemaNeeded.put(tabletId, Boolean.FALSE);
+                                    schemaNeeded.put(part.getId(), Boolean.FALSE);
 
                                     TableId tableId = null;
                                     if (message.getOperation() != Operation.NOOP) {
@@ -512,12 +512,12 @@ public class YugabyteDBStreamingChangeEventSource implements
                                     // If you need to print the received record, change debug level to info
                                     LOGGER.debug("Received DML record {}", record);
 
-                                    offsetContext.updateWalPosition(entry.getKey(), tabletId, lsn, lastCompletelyProcessedLsn, message.getCommitTime(),
+                                    offsetContext.updateWalPosition(part, lsn, lastCompletelyProcessedLsn, message.getCommitTime(),
                                             String.valueOf(message.getTransactionId()), tableId, null/* taskContext.getSlotXmin(connection) */);
 
                                     boolean dispatched = message.getOperation() != Operation.NOOP
                                             && dispatcher.dispatchDataChangeEvent(part, tableId, new YugabyteDBChangeRecordEmitter(part, offsetContext, clock, connectorConfig,
-                                                    schema, connection, tableId, message, pgSchemaNameInRecord, entry.getKey() /* tableUUID */, tabletId, taskContext.isBeforeImageEnabled()));
+                                                    schema, connection, tableId, message, pgSchemaNameInRecord, tabletId, taskContext.isBeforeImageEnabled()));
 
                                     if (recordsInTransactionalBlock.containsKey(entry.getKey() + "." + tabletId)) {
                                         recordsInTransactionalBlock.merge(entry.getKey() + "." + tabletId, 1, Integer::sum);
@@ -546,8 +546,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                                 response.getKey(),
                                 response.getWriteId(),
                                 response.getSnapshotTime());
-                        offsetContext.getSourceInfo(entry.getKey() /* tableId */, tabletId)
-                                .updateLastCommit(finalOpid);
+                        offsetContext.getSourceInfo(part).updateLastCommit(finalOpid);
 
                         LOGGER.debug("The final opid is " + finalOpid);
                     }
@@ -772,14 +771,17 @@ public class YugabyteDBStreamingChangeEventSource implements
                                        YugabyteDBOffsetContext offsetContext,
                                        Map<String, Boolean> schemaNeeded) {
         String tabletId = pair.getTabletLocations().getTabletId().toStringUtf8();
-        ImmutablePair<String, String> p =
+        ImmutablePair<String, String> tableTabletPair =
           new ImmutablePair<String, String>(tableId, tabletId);
 
-        if (!tabletPairList.contains(p)) {
-            tabletPairList.add(p);
+        if (!tabletPairList.contains(tableTabletPair)) {
+            tabletPairList.add(tableTabletPair);
 
-            offsetContext.initSourceInfo(tableId, tabletId,
-                                         this.connectorConfig,
+            // This flow will be executed in case of tablet split only and since tablet split
+            // is not possible on colocated tables, it is safe to assume that the tablets here
+            // would be all non-colocated.
+            YBPartition p = new YBPartition(tableId, tabletId, false /* colocated */);
+            offsetContext.initSourceInfo(p, this.connectorConfig,
                                          OpId.from(pair.getCdcSdkCheckpoint()));
 
             LOGGER.info("Initialized offset context for tablet {} with OpId {}", tabletId, OpId.from(pair.getCdcSdkCheckpoint()));

--- a/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBSnapshotTaskMetrics.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBSnapshotTaskMetrics.java
@@ -34,7 +34,7 @@ public class YugabyteDBSnapshotTaskMetrics extends AbstractYugabyteDBTaskMetrics
                                 "server", taskContext.getConnectorName(),
                                 "task", taskId,
                                 "context", "snapshot",
-                                "partition", partition.getId()),
+                                "partition", partition.getFullPartitionName()),
                         metadataProvider), connectorConfig, taskId);
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBSnapshotTaskMetrics.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBSnapshotTaskMetrics.java
@@ -34,7 +34,7 @@ public class YugabyteDBSnapshotTaskMetrics extends AbstractYugabyteDBTaskMetrics
                                 "server", taskContext.getConnectorName(),
                                 "task", taskId,
                                 "context", "snapshot",
-                                "tablet", partition.getTabletId()),
+                                "partition", partition.getId()),
                         metadataProvider), connectorConfig, taskId);
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBStreamingTaskMetrics.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBStreamingTaskMetrics.java
@@ -36,7 +36,7 @@ public class YugabyteDBStreamingTaskMetrics extends AbstractYugabyteDBTaskMetric
                         "server", taskContext.getConnectorName(),
                         "task", taskId,
                         "context", "streaming",
-                        "tablet", partition.getTabletId()),
+                        "partition", partition.getId()),
                     metadataProvider), connectorConfig, taskId);
         connectionMeter = new ConnectionMeter();
     }

--- a/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBStreamingTaskMetrics.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBStreamingTaskMetrics.java
@@ -36,7 +36,7 @@ public class YugabyteDBStreamingTaskMetrics extends AbstractYugabyteDBTaskMetric
                         "server", taskContext.getConnectorName(),
                         "task", taskId,
                         "context", "streaming",
-                        "partition", partition.getId()),
+                        "partition", partition.getFullPartitionName()),
                     metadataProvider), connectorConfig, taskId);
         connectionMeter = new ConnectionMeter();
     }

--- a/src/main/java/io/debezium/connector/yugabytedb/util/YugabyteDBConnectorUtils.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/util/YugabyteDBConnectorUtils.java
@@ -1,0 +1,113 @@
+package io.debezium.connector.yugabytedb.util;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Utility functions to assist across various stages of flow in the connector.
+ *
+ * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
+ */
+public class YugabyteDBConnectorUtils {
+	public static <T> void groupPartitions(List<T> elements, int numGroups, List<List<T>> result) {
+		if (numGroups <= 0)
+			throw new IllegalArgumentException("Number of groups must be positive.");
+
+		List<List<T>> res = new ArrayList<>(numGroups);
+
+		// Each group has either n+1 or n raw partitions
+		int perGroup = elements.size() / numGroups;
+		int leftover = elements.size() - (numGroups * perGroup);
+
+		int assigned = 0;
+		for (int group = 0; group < numGroups; group++) {
+			if (assigned == elements.size()) {
+				// We need not assign empty groups if we have exhausted the total number of elements.
+				break;
+			}
+			int numThisGroup = group < leftover ? perGroup + 1 : perGroup;
+			List<T> groupList = new ArrayList<>(numThisGroup);
+			for (int i = 0; i < numThisGroup; i++) {
+				groupList.add(elements.get(assigned));
+				assigned++;
+			}
+			res.add(groupList);
+		}
+
+		result.addAll(res);
+	}
+
+	/**
+	 * This grouping function ensures that we group the tablets in a way that each task contains
+	 * all the tables of just one colocated tablet. For non-colocated tables, the division of tablets
+	 * will be done the regular way.
+	 * @param elements a list of pairs where key is tableId and value is tabletId
+	 * @param numGroups the total number of groups we should be dividing the tasks to.
+	 */
+	public static List<List<Pair<String, String>>> groupPartitionsSmartly(
+			List<Pair<String, String>> elements, int numGroups) {
+		if (elements.size() == 0) {
+			throw new IllegalStateException("Elements to be grouped must be positive");
+		}
+
+		if (numGroups <= 0) {
+			throw new IllegalArgumentException("Number of groups must be positive");
+		}
+
+		List<List<Pair<String, String>>> result = new ArrayList<>(numGroups);
+
+		// Filter out groups having the same tabletId as value
+		// The map will have tabletId -> table1,table2,table3 map
+		Map<String, ArrayList<String>> reverseMap = new HashMap<>(
+			elements.stream().collect(Collectors.groupingBy(Pair::getValue)).values().stream()
+				.collect(Collectors.toMap(
+					item -> item.get(0).getValue(),
+					item -> new ArrayList<>(
+						item.stream()
+							.map(Map.Entry::getKey)
+							.collect(Collectors.toList())
+					))
+				));
+
+		// If there are same number of tablets in the grouped reverse map then use the older function
+		// to group rather than going to the complicated logic of grouping colocated and non-colocated
+		// tablets differently.
+		// Note: The keySet of the reverse map will only contain tablets.
+		if (reverseMap.keySet().size() == elements.size()) {
+			groupPartitions(elements, numGroups, result);
+			return result;
+		}
+
+		// Divide tablets into tasks and then form groups based on that.
+		List<List<String>> groupedTablets = new ArrayList<>();
+		groupPartitions(new ArrayList<>(reverseMap.keySet()), numGroups, groupedTablets);
+
+		// Iterate over grouped tablets now.
+		// The assumption here is that at this stage, the division of tablets across tasks would be
+		// something similar to:
+		// 1. Task 1 -
+		//    a. tablet_1
+		//    b. tablet_2
+		//    b. tablet_3
+		// 2. Task 2 -
+		//    a. tablet_4
+		//    b. tablet_5
+		// After this, we can simply iterate over the reversed map and just put proper table-tablet
+		// pairs to the task list.
+		for (List<String> tablets : groupedTablets) {
+			List<Pair<String, String>> groupList = new ArrayList<>();
+			for (String tablet : tablets) {
+				for (String table : reverseMap.get(tablet)) {
+					groupList.add(new ImmutablePair<>(table, tablet));
+				}
+			}
+
+			result.add(groupList);
+		}
+
+		return result;
+	}
+}

--- a/src/test/java/io/debezium/connector/yugabytedb/HelperStrings.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/HelperStrings.java
@@ -1,6 +1,10 @@
 package io.debezium.connector.yugabytedb;
 
 public class HelperStrings {
+    public static String CREATE_ALL_TYPES = "CREATE TABLE all_types (id serial PRIMARY KEY, bigintcol bigint, bitcol bit(5), varbitcol varbit(5), booleanval boolean, byteaval bytea, ch char(5), vchar varchar(25), " +
+                                             "cidrval cidr, dt date, dp double precision, inetval inet, intervalval interval, jsonval json, jsonbval jsonb, mc macaddr, mc8 macaddr8, mn money, nm numeric, rl real, " +
+                                             "si smallint, i4r int4range, i8r int8range, nr numrange, tsr tsrange, tstzr tstzrange, dr daterange, txt text, tm time, tmtz timetz, ts timestamp, tstz timestamptz, " +
+                                             "uuidval uuid) WITH (COLOCATION = false);";
     public static String INSERT_ALL_TYPES = "INSERT INTO all_types (bigintcol, bitcol, varbitcol, booleanval, byteaval, ch, vchar, cidrval, dt, dp, inetval, "
             + "intervalval, jsonval, jsonbval, mc, mc8, mn, nm, rl, si, i4r, i8r, nr, tsr, tstzr, dr, txt, tm, tmtz, ts, tstz, uuidval) VALUES "
             + "(123456, '11011', '10101', FALSE, E'\\\\001', 'five5', 'sample_text', '10.1.0.0/16', '2022-02-24', 12.345, '127.0.0.1', "

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBColocatedTablesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBColocatedTablesTest.java
@@ -196,6 +196,7 @@ public class YugabyteDBColocatedTablesTest extends YugabyteDBContainerTestBase {
     // table test_3 won't be streamed since it might have gotten garbage collected since it resides
     // on the same tablet i.e. colocated
     start(YugabyteDBConnector.class, configBuilder.build());
+    awaitUntilConnectorIsReady();
 
     // The below statements will insert records of the respective types with keys in the
     // range [11,21)

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBExplicitCheckpointingTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBExplicitCheckpointingTest.java
@@ -20,11 +20,13 @@ import org.yb.client.YBClient;
 
 import java.sql.SQLException;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -115,7 +117,7 @@ public class YugabyteDBExplicitCheckpointingTest extends YugabyteDBContainerTest
         YBClient ybClient = TestHelper.getYbClient(getMasterAddress());
         for (Map.Entry<String, ?> entry : offsetMap.entrySet()) {
             if (!entry.getKey().equals("transaction_id")) {
-                String tabletId = entry.getKey();
+                String tabletId = entry.getKey().split(Pattern.quote("."))[1];
                 CdcSdkCheckpoint cp = OpId.valueOf((String) entry.getValue()).toCdcSdkCheckpoint();
 
                 GetCheckpointResponse resp = ybClient.getCheckpoint(

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBExplicitCheckpointingTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBExplicitCheckpointingTest.java
@@ -117,7 +117,11 @@ public class YugabyteDBExplicitCheckpointingTest extends YugabyteDBContainerTest
         YBClient ybClient = TestHelper.getYbClient(getMasterAddress());
         for (Map.Entry<String, ?> entry : offsetMap.entrySet()) {
             if (!entry.getKey().equals("transaction_id")) {
-                String tabletId = entry.getKey().split(Pattern.quote("."))[1];
+                String[] splitString = entry.getKey().split(Pattern.quote("."));
+
+                // If string doesn't split, that means we have only received the tabletId in the
+                // response, if it splits then we will have two elements - tableId and tabletId.
+                String tabletId = splitString.length == 1 ? splitString[0] : splitString[1];
                 CdcSdkCheckpoint cp = OpId.valueOf((String) entry.getValue()).toCdcSdkCheckpoint();
 
                 GetCheckpointResponse resp = ybClient.getCheckpoint(

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -185,7 +185,7 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
     }
 
     @ParameterizedTest
-    @ValueSource(booleans = {true})
+    @ValueSource(booleans = {true, false})
     public void snapshotForMultipleTables(boolean colocation) throws Exception {
         TestHelper.dropAllSchemas();
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -88,9 +88,10 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         // Insert records in the table test_1
         insertBulkRecords(recordCountT1, "public.test_1");
 
-        // Insert records in the table all_types
-        TestHelper.executeInDatabase(DEFAULT_COLOCATED_DB_NAME, HelperStrings.INSERT_ALL_TYPES);
-        TestHelper.executeInDatabase(DEFAULT_COLOCATED_DB_NAME, HelperStrings.INSERT_ALL_TYPES);
+        // Create table and insert records in all_types
+        TestHelper.executeInDatabase(HelperStrings.CREATE_ALL_TYPES, DEFAULT_COLOCATED_DB_NAME);
+        TestHelper.executeInDatabase(HelperStrings.INSERT_ALL_TYPES, DEFAULT_COLOCATED_DB_NAME);
+        TestHelper.executeInDatabase(HelperStrings.INSERT_ALL_TYPES, DEFAULT_COLOCATED_DB_NAME);
 
         String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME, "public.test_1,public.all_types", dbStreamId);
@@ -143,8 +144,8 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
             String.format("generate_series(%d, %d)",
               recordCountT1, recordCountT1 + 1000)), DEFAULT_COLOCATED_DB_NAME);
 
-        // Total records inserted at this stage would be recordCountT1 + 1000
-        int totalRecords = recordCountT1 + 1000;
+        // Total records inserted at this stage would be recordCountT1 + 1001
+        int totalRecords = recordCountT1 + 1001;
 
         // Consume and assert that we have received all the records now.
         List<SourceRecord> records = new ArrayList<>();
@@ -372,6 +373,7 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         TestHelper.executeInDatabase("DROP TABLE IF EXISTS test_2;", DEFAULT_COLOCATED_DB_NAME);
         TestHelper.executeInDatabase("DROP TABLE IF EXISTS test_3;", DEFAULT_COLOCATED_DB_NAME);
         TestHelper.executeInDatabase("DROP TABLE IF EXISTS test_no_colocated;", DEFAULT_COLOCATED_DB_NAME);
+        TestHelper.executeInDatabase("DROP TABLE IF EXISTS all_types;", DEFAULT_COLOCATED_DB_NAME);
     }
 
     private void insertBulkRecords(int numRecords, String fullTableName) {
@@ -411,7 +413,7 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
                       LOGGER.info("Consumed " + totalConsumedRecords + " records");
                   }
 
-                  return totalConsumedRecords.get() >= recordsCount;
+                  return totalConsumedRecords.get() == recordsCount;
               });
         } catch (ConditionTimeoutException exception) {
             fail("Failed to consume " + recordsCount + " in " + seconds + " seconds", exception);

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -2,14 +2,16 @@ package io.debezium.connector.yugabytedb;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
+import io.debezium.connector.yugabytedb.common.YugabytedTestBase;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.yb.client.YBClient;
 import org.yb.client.YBTable;
 
-import java.sql.SQLException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,12 +20,19 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Basic unit tests to increase the test coverage for snapshot of tables in YugabyteDB. This class
+ * contains parameterized tests as well which will run the tests once on colocated tables and then
+ * on non-colocated tables.
+ *
+ * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
+ */
 public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
-
     @BeforeAll
-    public static void beforeClass() throws SQLException {
+    public static void beforeClass() throws Exception {
         initializeYBContainer();
         TestHelper.dropAllSchemas();
+        TestHelper.executeDDL("yugabyte_create_tables.ddl");
     }
 
     @BeforeEach
@@ -34,6 +43,7 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
     @AfterEach
     public void after() throws Exception {
         stopConnector();
+        dropAllTables();
         TestHelper.executeDDL("drop_tables_and_databases.ddl");
     }
 
@@ -42,16 +52,18 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         shutdownYBContainer();
     }
 
-    @Test
-    public void testSnapshotRecordConsumption() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testSnapshotRecordConsumption(boolean colocation) throws Exception {
         TestHelper.dropAllSchemas();
-        TestHelper.executeDDL("yugabyte_create_tables.ddl");
+        createTables(colocation);
         final int recordsCount = 5000;
-        // insert rows in the table t1 with values <some-pk, 'Vaibhav', 'Kushwaha', 30>
-        insertBulkRecords(recordsCount);
+        insertBulkRecords(recordsCount, "public.test_1");
 
-        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
-        Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
+        LOGGER.info("Creating DB stream ID");
+        String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
+        Configuration.Builder configBuilder =
+          TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME, "public.test_1", dbStreamId);
         configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE, YugabyteDBConnectorConfig.SnapshotMode.INITIAL.getValue());
         start(YugabyteDBConnector.class, configBuilder.build());
 
@@ -60,29 +72,30 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         // Only verifying the record count since the snapshot records are not ordered, so it may be
         // a little complex to verify them in the sorted order at the moment
         CompletableFuture.runAsync(() -> verifyRecordCount(recordsCount))
-                .exceptionally(throwable -> {
-                    throw new RuntimeException(throwable);
-                }).get();
+          .exceptionally(throwable -> {
+              throw new RuntimeException(throwable);
+          }).get();
     }
 
-    @Test
-    public void shouldOnlySnapshotTablesInList() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void shouldOnlySnapshotTablesInList(boolean colocation) throws Exception {
         TestHelper.dropAllSchemas();
-        TestHelper.executeDDL("yugabyte_create_tables.ddl");
+        createTables(colocation);
 
         int recordCountT1 = 5000;
 
-        // Insert records in the table t1
-        insertBulkRecords(recordCountT1);
+        // Insert records in the table test_1
+        insertBulkRecords(recordCountT1, "public.test_1");
 
         // Insert records in the table all_types
-        TestHelper.execute(HelperStrings.INSERT_ALL_TYPES);
-        TestHelper.execute(HelperStrings.INSERT_ALL_TYPES);
+        TestHelper.executeInDatabase(DEFAULT_COLOCATED_DB_NAME, HelperStrings.INSERT_ALL_TYPES);
+        TestHelper.executeInDatabase(DEFAULT_COLOCATED_DB_NAME, HelperStrings.INSERT_ALL_TYPES);
 
-        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
-        Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1,public.all_types", dbStreamId);
+        String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
+        Configuration.Builder configBuilder = TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME, "public.test_1,public.all_types", dbStreamId);
         configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE, "initial");
-        configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE_TABLES, "public.t1");
+        configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE_TABLES, "public.test_1");
 
         start(YugabyteDBConnector.class, configBuilder.build());
 
@@ -96,25 +109,26 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         assertNotNull(records);
 
         // Assert that there are the expected number of records in the snapshot table
-        assertEquals(recordCountT1, records.recordsForTopic("test_server.public.t1").size());
+        assertEquals(recordCountT1, records.recordsForTopic("test_server.public.test_1").size());
 
         // Since there are no records for this topic, the topic itself won't be created
         // so if the topic simply doesn't exist then the test should pass
         assertFalse(records.topics().contains("test_server.public.all_types"));
     }
 
-    @Test
-    public void snapshotTableThenStreamData() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void snapshotTableThenStreamData(boolean colocation) throws Exception {
         TestHelper.dropAllSchemas();
-        TestHelper.executeDDL("yugabyte_create_tables.ddl");
+        createTables(colocation);
 
         int recordCountT1 = 5000;
 
-        // Insert records in the table t1
-        insertBulkRecords(recordCountT1);
+        // Insert records in the table test_1
+        insertBulkRecords(recordCountT1, "public.test_1");
 
-        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
-        Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
+        String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
+        Configuration.Builder configBuilder = TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME, "public.test_1", dbStreamId);
         configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE, "initial");
 
         start(YugabyteDBConnector.class, configBuilder.build());
@@ -123,8 +137,11 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
 
         // Dummy wait for some time so that the connector has some time to transition to streaming.
         TestHelper.waitFor(Duration.ofSeconds(30));
-        String insertStringFormat = "INSERT INTO t1 VALUES (%d, 'Vaibhav', 'Kushwaha', 30);";
-        TestHelper.executeBulkWithRange(insertStringFormat, recordCountT1, recordCountT1 + 1000);
+        String insertStringFormat = "INSERT INTO test_1 VALUES (%s);";
+        TestHelper.executeInDatabase(
+          String.format(insertStringFormat,
+            String.format("generate_series(%d, %d)",
+              recordCountT1, recordCountT1 + 1000)), DEFAULT_COLOCATED_DB_NAME);
 
         // Total records inserted at this stage would be recordCountT1 + 1000
         int totalRecords = recordCountT1 + 1000;
@@ -135,18 +152,19 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
     }
 
     // GitHub issue: https://github.com/yugabyte/debezium-connector-yugabytedb/issues/143
-    @Test
-    public void snapshotTableWithCompaction() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void snapshotTableWithCompaction(boolean colocation) throws Exception {
         TestHelper.dropAllSchemas();
-        TestHelper.executeDDL("yugabyte_create_tables.ddl");
+        createTables(colocation);
 
         int recordCount = 5000;
 
-        // Insert records in the table t1
-        insertBulkRecords(recordCount);
+        // Insert records in the table test_1
+        insertBulkRecords(recordCount, "public.test_1");
 
-        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
-        Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
+        String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
+        Configuration.Builder configBuilder = TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME, "public.test_1", dbStreamId);
         configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE, "initial");
 
         start(YugabyteDBConnector.class, configBuilder.build());
@@ -155,9 +173,9 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
 
         // Assuming that at this point snapshot would still be running, update a few records and
         // compact the table.
-        TestHelper.execute("UPDATE t1 SET first_name='fname' WHERE id < 10;");
+        TestHelper.executeInDatabase("UPDATE test_1 SET name='fname' WHERE id < 10;", DEFAULT_COLOCATED_DB_NAME);
         YBClient ybClient = TestHelper.getYbClient(TestHelper.getMasterAddress());
-        YBTable ybTable = TestHelper.getYbTable(ybClient, "t1");
+        YBTable ybTable = TestHelper.getYbTable(ybClient, "test_1");
         ybClient.flushTable(ybTable.getTableId());
 
         // Consume and assert that we have received all the records now.
@@ -165,12 +183,139 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         waitAndFailIfCannotConsume(records, recordCount + 10 /* updates */);
     }
 
-    private void insertBulkRecords(int numRecords) throws Exception {
-        String formatInsertString = "INSERT INTO t1 VALUES (%d, 'Vaibhav', 'Kushwaha', 30);";
-        CompletableFuture.runAsync(() -> TestHelper.executeBulk(formatInsertString, numRecords))
-                .exceptionally(throwable -> {
-            throw new RuntimeException(throwable);
-        }).get();
+    @ParameterizedTest
+    @ValueSource(booleans = {true})
+    public void snapshotForMultipleTables(boolean colocation) throws Exception {
+        TestHelper.dropAllSchemas();
+
+        // Create colocated tables
+        createTables(colocation);
+
+        final int recordsTest1 = 10;
+        final int recordsTest2 = 20;
+        final int recordsTest3 = 30;
+        insertBulkRecords(recordsTest1, "public.test_1");
+        insertBulkRecords(recordsTest2, "public.test_2");
+        insertBulkRecords(recordsTest3, "public.test_3");
+
+        String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
+        Configuration.Builder configBuilder =
+          TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME, "public.test_1,public.test_2,public.test_3", dbStreamId);
+        configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE, YugabyteDBConnectorConfig.SnapshotMode.INITIAL.getValue());
+        start(YugabyteDBConnector.class, configBuilder.build());
+
+        awaitUntilConnectorIsReady();
+
+        List<SourceRecord> recordsForTest1 = new ArrayList<>();
+        List<SourceRecord> recordsForTest2 = new ArrayList<>();
+        List<SourceRecord> recordsForTest3 = new ArrayList<>();
+
+        List<SourceRecord> records = new ArrayList<>();
+        waitAndFailIfCannotConsume(records, recordsTest1 + recordsTest2 + recordsTest3);
+
+        // Iterate over the records and add them to their respective topic
+        for (SourceRecord record : records) {
+            if (record.topic().equals(TestHelper.TEST_SERVER + ".public.test_1")) {
+                recordsForTest1.add(record);
+            } else if (record.topic().equals(TestHelper.TEST_SERVER + ".public.test_2")) {
+                recordsForTest2.add(record);
+            } else if (record.topic().equals(TestHelper.TEST_SERVER + ".public.test_3")) {
+                recordsForTest3.add(record);
+            }
+        }
+
+        assertEquals(recordsTest1, recordsForTest1.size());
+        assertEquals(recordsTest2, recordsForTest2.size());
+        assertEquals(recordsTest3, recordsForTest3.size());
+    }
+
+    @Test
+    public void snapshotMixOfColocatedNonColocatedTables() throws Exception {
+        TestHelper.dropAllSchemas();
+
+        // Create tables.
+        createTables(true /* enforce creation of the colocated tables only */);
+
+        final int recordCountForTest1 = 1000;
+        final int recordCountForTest2 = 2000;
+        final int recordCountForTest3 = 3000;
+        final int recordCountInNonColocated = 4000;
+        insertBulkRecords(recordCountForTest1, "public.test_1");
+        insertBulkRecords(recordCountForTest2, "public.test_2");
+        insertBulkRecords(recordCountForTest3, "public.test_3");
+        insertBulkRecords(recordCountInNonColocated, "public.test_no_colocated");
+
+        String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
+        Configuration.Builder configBuilder =
+          TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME, "public.test_1,public.test_2,public.test_3,public.test_no_colocated", dbStreamId);
+        configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE, YugabyteDBConnectorConfig.SnapshotMode.INITIAL.getValue());
+        start(YugabyteDBConnector.class, configBuilder.build());
+
+        awaitUntilConnectorIsReady();
+
+        List<SourceRecord> recordsForTest1 = new ArrayList<>();
+        List<SourceRecord> recordsForTest2 = new ArrayList<>();
+        List<SourceRecord> recordsForTest3 = new ArrayList<>();
+        List<SourceRecord> recordsForNonColocated = new ArrayList<>();
+
+        List<SourceRecord> records = new ArrayList<>();
+        waitAndFailIfCannotConsume(records, recordCountForTest1 + recordCountForTest2 + recordCountForTest3 + recordCountInNonColocated);
+
+        // Iterate over the records and add them to their respective topic
+        for (SourceRecord record : records) {
+            if (record.topic().equals(TestHelper.TEST_SERVER + ".public.test_1")) {
+                recordsForTest1.add(record);
+            } else if (record.topic().equals(TestHelper.TEST_SERVER + ".public.test_2")) {
+                recordsForTest2.add(record);
+            } else if (record.topic().equals(TestHelper.TEST_SERVER + ".public.test_3")) {
+                recordsForTest3.add(record);
+            } else if (record.topic().equals(TestHelper.TEST_SERVER + ".public.test_no_colocated")) {
+                recordsForNonColocated.add(record);
+            }
+        }
+
+        assertEquals(recordCountForTest1, recordsForTest1.size());
+        assertEquals(recordCountForTest2, recordsForTest2.size());
+        assertEquals(recordCountForTest3, recordsForTest3.size());
+        assertEquals(recordCountInNonColocated, recordsForNonColocated.size());
+    }
+
+    /**
+     * Helper function to create the required tables in the database DEFAULT_COLOCATED_DB_NAME
+     */
+    private void createTables(boolean colocation) {
+        final String createTest1 = String.format("CREATE TABLE test_1 (id INT PRIMARY KEY," +
+                                                 "name TEXT DEFAULT 'Vaibhav Kushwaha') " +
+                                                  "WITH (COLOCATION = %b);", colocation);
+        final String createTest2 = String.format("CREATE TABLE test_2 (text_key TEXT PRIMARY " +
+                                                 "KEY) WITH (COLOCATION = %b);", colocation);
+        final String createTest3 =
+          String.format("CREATE TABLE test_3 (hours FLOAT PRIMARY KEY, " +
+                        "hours_in_text VARCHAR(40) DEFAULT 'some_default_hour_value') " +
+                        "WITH (COLOCATION = %b);", colocation);
+        final String createTestNoColocated = "CREATE TABLE test_no_colocated (id INT PRIMARY KEY," +
+                                             "name TEXT DEFAULT 'name_for_non_colocated') " +
+                                             "WITH (COLOCATION = false) SPLIT INTO 3 TABLETS;";
+
+        TestHelper.executeInDatabase(createTest1, DEFAULT_COLOCATED_DB_NAME);
+        TestHelper.executeInDatabase(createTest2, DEFAULT_COLOCATED_DB_NAME);
+        TestHelper.executeInDatabase(createTest3, DEFAULT_COLOCATED_DB_NAME);
+        TestHelper.executeInDatabase(createTestNoColocated, DEFAULT_COLOCATED_DB_NAME);
+    }
+
+    /**
+     * Helper function to drop all the tables being created as a part of this test.
+     */
+    private void dropAllTables() {
+        TestHelper.executeInDatabase("DROP TABLE IF EXISTS test_1;", DEFAULT_COLOCATED_DB_NAME);
+        TestHelper.executeInDatabase("DROP TABLE IF EXISTS test_2;", DEFAULT_COLOCATED_DB_NAME);
+        TestHelper.executeInDatabase("DROP TABLE IF EXISTS test_3;", DEFAULT_COLOCATED_DB_NAME);
+        TestHelper.executeInDatabase("DROP TABLE IF EXISTS test_no_colocated;", DEFAULT_COLOCATED_DB_NAME);
+    }
+
+    private void insertBulkRecords(int numRecords, String fullTableName) {
+        String formatInsertString = "INSERT INTO " + fullTableName + " VALUES (%d);";
+        TestHelper.executeBulk(formatInsertString, numRecords, DEFAULT_COLOCATED_DB_NAME);
     }
 
     private void verifyRecordCount(long recordsCount) {
@@ -194,19 +339,19 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         long seconds = milliSecondsToWait / 1000;
         try {
             Awaitility.await()
-                    .atMost(Duration.ofSeconds(seconds))
-                    .until(() -> {
-                        int consumed = super.consumeAvailableRecords(record -> {
-                            LOGGER.debug("The record being consumed is " + record);
-                            records.add(record);
-                        });
-                        if (consumed > 0) {
-                            totalConsumedRecords.addAndGet(consumed);
-                            LOGGER.debug("Consumed " + totalConsumedRecords + " records");
-                        }
+              .atMost(Duration.ofSeconds(seconds))
+              .until(() -> {
+                  int consumed = super.consumeAvailableRecords(record -> {
+                      LOGGER.debug("The record being consumed is " + record);
+                      records.add(record);
+                  });
+                  if (consumed > 0) {
+                      totalConsumedRecords.addAndGet(consumed);
+                      LOGGER.info("Consumed " + totalConsumedRecords + " records");
+                  }
 
-                        return totalConsumedRecords.get() == recordsCount;
-                    });
+                  return totalConsumedRecords.get() >= recordsCount;
+              });
         } catch (ConditionTimeoutException exception) {
             fail("Failed to consume " + recordsCount + " in " + seconds + " seconds", exception);
         }

--- a/src/test/java/io/debezium/connector/yugabytedb/util/YugabyteDBConnectorUtilsTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/util/YugabyteDBConnectorUtilsTest.java
@@ -1,0 +1,180 @@
+package io.debezium.connector.yugabytedb.util;
+
+import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests to verify the behaviour of various APIs the connector is supposed to use
+ * in order to make sure those APIs are working fine as an individual unit. This test class will
+ * always remain a work in progress.
+ *
+ * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
+ */
+public class YugabyteDBConnectorUtilsTest extends YugabyteDBContainerTestBase {
+	@Test
+	public void allColocatedTablesBelongToSameTablet() throws Exception {
+		Pair<String, String> pair1 = new ImmutablePair<>("table1", "same_tablet");
+		Pair<String, String> pair2 = new ImmutablePair<>("table2", "same_tablet");
+		Pair<String, String> pair3 = new ImmutablePair<>("table3", "same_tablet");
+
+		List<Pair<String, String>> pairList = new ArrayList<>();
+		pairList.add(pair1);
+		pairList.add(pair2);
+		pairList.add(pair3);
+
+		// A random number of groups.
+		final int numberGroups = 2;
+
+		List<List<Pair<String, String>>> groupedTablets =
+			YugabyteDBConnectorUtils.groupPartitionsSmartly(pairList, numberGroups);
+
+		// Since all the tablets are the same, we should be getting only 1 batch i.e. the size of
+		// grouped tablets would be 1.
+		assertEquals(1, groupedTablets.size());
+	}
+
+	@ParameterizedTest(name = "Equal tablets as groups: {0}")
+	@ValueSource(booleans = {true, false})
+	public void someTablesBelongToDifferentTablet(boolean equalTabletsAsGroups) {
+		Pair<String, String> pair1 = new ImmutablePair<>("table1", "same_tablet");
+		Pair<String, String> pair2 = new ImmutablePair<>("table2", "same_tablet");
+		Pair<String, String> pair3 = new ImmutablePair<>("table3", "different_tablet");
+
+		List<Pair<String, String>> pairList = new ArrayList<>();
+		pairList.add(pair1);
+		pairList.add(pair2);
+		pairList.add(pair3);
+
+		final int numGroups = equalTabletsAsGroups ? 2 : 1;
+
+		List<List<Pair<String, String>>> groupedTablets =
+			YugabyteDBConnectorUtils.groupPartitionsSmartly(pairList, numGroups);
+
+		// Since all the tablets are NOT the same, we should be getting only 2 batches
+		// i.e. the size of grouped tablets would be 2.
+		assertEquals(numGroups, groupedTablets.size());
+	}
+
+	@ParameterizedTest(name = "All tablets to one group: {0}")
+	@ValueSource(booleans = {true, false})
+	public void higherTabletsLowerGroups(boolean allTabletsToOneGroup) {
+		Pair<String, String> pair1 = new ImmutablePair<>("table1", "tablet_1");
+		Pair<String, String> pair2 = new ImmutablePair<>("table2", "tablet_1");
+		Pair<String, String> pair3 = new ImmutablePair<>("table3", "tablet_2");
+		Pair<String, String> pair4 = new ImmutablePair<>("table4", "tablet_2");
+		Pair<String, String> pair5 = new ImmutablePair<>("table5", "tablet_3");
+		Pair<String, String> pair6 = new ImmutablePair<>("table6", "tablet_3");
+		Pair<String, String> pair7 = new ImmutablePair<>("table7", "tablet_4");
+
+		List<Pair<String, String>> pairList = new ArrayList<>();
+		pairList.add(pair1);
+		pairList.add(pair2);
+		pairList.add(pair3);
+		pairList.add(pair4);
+		pairList.add(pair5);
+		pairList.add(pair6);
+		pairList.add(pair7);
+
+		final int numGroups = allTabletsToOneGroup ? 1 : 2;
+		List<List<Pair<String, String>>> groupedTablets =
+			YugabyteDBConnectorUtils.groupPartitionsSmartly(pairList, numGroups);
+
+		// Since all the tablets are NOT the same, we should be getting only 2 batches
+		// i.e. the size of grouped tablets would be 2.
+		assertEquals(numGroups, groupedTablets.size());
+	}
+
+	@Test
+	public void multipleColocatedTabletsPresent() {
+		Pair<String, String> pair1 = new ImmutablePair<>("table1", "same_tablet");
+		Pair<String, String> pair2 = new ImmutablePair<>("table2", "same_tablet");
+		Pair<String, String> pair3 = new ImmutablePair<>("table3", "different_tablet");
+		Pair<String, String> pair4 = new ImmutablePair<>("table4", "different_tablet");
+		Pair<String, String> pair5 = new ImmutablePair<>("table5", "different_tablet");
+
+		List<Pair<String, String>> pairList = new ArrayList<>();
+		pairList.add(pair1);
+		pairList.add(pair2);
+		pairList.add(pair3);
+		pairList.add(pair4);
+		pairList.add(pair5);
+
+		// A random number of groups.
+		final int numberGroups = 5;
+
+		List<List<Pair<String, String>>> groupedTablets =
+			YugabyteDBConnectorUtils.groupPartitionsSmartly(pairList, numberGroups);
+
+		// Since all the tablets are NOT the same, we should be getting only 2 batches
+		// i.e. the size of grouped tablets would be 2.
+		assertEquals(2, groupedTablets.size());
+	}
+
+	@Test
+	public void throwExceptionOnInvalidGroupSize() {
+		Pair<String, String> pair1 = new ImmutablePair<>("table1", "same_tablet");
+
+		List<Pair<String, String>> pairList = new ArrayList<>();
+		pairList.add(pair1);
+
+		// 0 is an invalid group size.
+		final int numberGroups = 0;
+
+		try {
+			List<List<Pair<String, String>>> groupedTablets =
+				YugabyteDBConnectorUtils.groupPartitionsSmartly(pairList, numberGroups);
+		} catch (Exception e) {
+			assertTrue(e instanceof IllegalArgumentException);
+			assertTrue(e.getMessage().contains("Number of groups must be positive"));
+		}
+	}
+
+	@Test
+	public void throwExceptionOnEmptyList() {
+		List<Pair<String, String>> pairList = new ArrayList<>();
+
+		// 0 is an invalid group size.
+		final int numberGroups = 1;
+
+		try {
+			List<List<Pair<String, String>>> groupedTablets =
+				YugabyteDBConnectorUtils.groupPartitionsSmartly(pairList, numberGroups);
+		} catch (Exception e) {
+			assertTrue(e instanceof IllegalStateException);
+			assertTrue(e.getMessage().contains("Elements to be grouped must be positive"));
+		}
+	}
+
+	@ParameterizedTest(name = "{0} tasks")
+	@ValueSource(ints = {1, 2, 3, 4, 5})
+	public void allNonColocatedTablets(int maxTasks) {
+		Pair<String, String> pair1 = new ImmutablePair<>("table1", "tablet1");
+		Pair<String, String> pair2 = new ImmutablePair<>("table2", "tablet2");
+		Pair<String, String> pair3 = new ImmutablePair<>("table3", "tablet3");
+		Pair<String, String> pair4 = new ImmutablePair<>("table4", "tablet4");
+		Pair<String, String> pair5 = new ImmutablePair<>("table5", "tablet5");
+
+		List<Pair<String, String>> pairList = new ArrayList<>();
+		pairList.add(pair1);
+		pairList.add(pair2);
+		pairList.add(pair3);
+		pairList.add(pair4);
+		pairList.add(pair5);
+
+		List<List<Pair<String, String>>> groupedTablets =
+			YugabyteDBConnectorUtils.groupPartitionsSmartly(pairList, maxTasks);
+
+		// Since all the tablets are NOT the same, we should be getting only 2 batches
+		// i.e. the size of grouped tablets would be 2.
+		assertEquals(maxTasks, groupedTablets.size());
+	}
+}

--- a/src/test/resources/yugabyte_create_tables.ddl
+++ b/src/test/resources/yugabyte_create_tables.ddl
@@ -3,7 +3,7 @@ CREATE TABLE t1 (id INT PRIMARY KEY, first_name TEXT NOT NULL, last_name VARCHAR
 CREATE TABLE all_types (id serial PRIMARY KEY, bigintcol bigint, bitcol bit(5), varbitcol varbit(5), booleanval boolean, byteaval bytea, ch char(5), vchar varchar(25),
 cidrval cidr, dt date, dp double precision, inetval inet, intervalval interval, jsonval json, jsonbval jsonb, mc macaddr, mc8 macaddr8, mn money, nm numeric, rl real,
 si smallint, i4r int4range, i8r int8range, nr numrange, tsr tsrange, tstzr tstzrange, dr daterange, txt text, tm time, tmtz timetz, ts timestamp, tstz timestamptz,
-uuidval uuid);
+uuidval uuid) WITH (COLOCATION = false);
 
 DROP DATABASE IF EXISTS secondary_database;
 CREATE DATABASE secondary_database;


### PR DESCRIPTION
This PR changes the mechanism with which we store the OpIds, OffsetContext, SourceInfo and all the related things. Before this, they were keyed against the `tabletId` but this change modifies the logic so that they can be queried with `tableId.tabletId`. This will also help us in accommodating the changes for streaming the snapshot for colocated tables.

For example:
**Older logic:***
```
tablet_1 : op_id_1,
tablet_2 : op_id_2
```
**New logic:**
```
table.tablet_1 : op_id_1,
table.tablet_2 : op_id_2
```

The major changes in this PR (in no specific order) are:
1. Lookup of data using `tableId.tabletId` key
2. Sending a `snapshot_done_key` just once in the `GetChanges` call after we receive the snapshot complete marker from the server
3. Modification of existing snapshot tests to make them parameterised so that they now run twice - once with colocated tables, once without colocated tables
4. Addition of a test to ensure the snapshot with the mix of colocated and non colocated tables
5. Addition of a grouping function `YugabyteDBConnectorUtils#groupPartitionsSmartly` (and tests) which will ensure that the tables belonging to the same colocated tablet always go to the same task.

However, there is **one exception** to the above:
In streaming mode, we are now forcefully marking all the tables as non-colocated and in snapshot we are marking them all as colocated.