### PR TITLE
[#192] Send a snapshot done key at the beginning of every streaming iteration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.kafka>3.3.1</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>
-        <version.ybclient>0.8.43-20230310.162944-1</version.ybclient>
+        <version.ybclient>0.8.48-20230327.090534-1</version.ybclient>
         <version.gson>2.8.9</version.gson>
 
         <!--

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -31,6 +31,7 @@ import io.debezium.util.Clock;
 
 public class YugabyteDBOffsetContext implements OffsetContext {
     public static final String LAST_COMPLETELY_PROCESSED_LSN_KEY = "lsn_proc";
+    public static final String SNAPSHOT_DONE_KEY = "snapshot_done_key";
 
     private static final Logger LOGGER = LoggerFactory
             .getLogger(YugabyteDBSnapshotChangeEventSource.class);
@@ -152,7 +153,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
      * @return the starting {@link OpId} to begin the streaming with
      */
     public static OpId streamingStartLsn() {
-        return new OpId(0, 0, "".getBytes(), 0, 0);
+        return new OpId(0, 0, SNAPSHOT_DONE_KEY.getBytes(), 0, 0);
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -371,7 +371,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                 GetChangesResponse resp = this.syncClient.getChangesCDCSDK(table, 
                     connectorConfig.streamId(), tabletId, cp.getTerm(), cp.getIndex(), cp.getKey(), 
                     cp.getWrite_id(), cp.getTime(), schemaNeeded.get(tabletId),
-                    taskContext.shouldEnableExplicitCheckpointing() ? tabletToExplicitCheckpoint.get(tabletId) : null, table.getTableId());
+                    taskContext.shouldEnableExplicitCheckpointing() ? tabletToExplicitCheckpoint.get(tabletId) : null);
 
                 // If EXPLICIT checkpointing is enabled then check if the checkpoint is the marker for snapshot completion
                 // and in case it is IMPLICIT checkpointing, the marker value should be checked on the from_op_id we are sending

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -360,7 +360,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                         response = this.syncClient.getChangesCDCSDK(
                             table, streamId, tabletId, cp.getTerm(), cp.getIndex(), cp.getKey(),
                             cp.getWrite_id(), cp.getTime(), schemaNeeded.get(tabletId),
-                            taskContext.shouldEnableExplicitCheckpointing() ? tabletToExplicitCheckpoint.get(tabletId) : null, table.getTableId());
+                            taskContext.shouldEnableExplicitCheckpointing() ? tabletToExplicitCheckpoint.get(tabletId) : null);
                       } catch (CDCErrorException cdcException) {
                         // Check if exception indicates a tablet split.
                         LOGGER.debug("Code received in CDCErrorException: {}", cdcException.getCDCError().getCode());


### PR DESCRIPTION
This PR modifies the code logic so that at the beginning of every iteration for streaming, we send out a key which has the `snapshot_done_key` as its key to tell the server that it is the point where snapshot has been completed.

Additionally, this closes #192 