### PR TITLE
[#200] Add a transformer for Striim compatibility

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/transforms/StriimCompatible.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/transforms/StriimCompatible.java
@@ -1,0 +1,208 @@
+package io.debezium.connector.yugabytedb.transforms;
+
+import java.util.*;
+
+import io.debezium.connector.yugabytedb.transforms.SchemaUtil;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yb.util.Pair;
+
+public class StriimCompatible<R extends ConnectRecord<R>> implements Transformation<R> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(StriimCompatible.class);
+
+    @Override
+    public R apply(final R record) {
+        if (record == null || (record.value() != null && !(record.value() instanceof Struct))) {
+            return record;
+        }
+
+        List<String> primaryKeys = getAllFieldsInOrder(record.keySchema());
+
+        Schema updatedSchemaForValue = null;
+        Struct updatedValueForValue = null;
+        if (record.value() != null) {
+            Pair<Schema, Struct> val = getUpdatedValueAndSchema(record.valueSchema(), (Struct) record.value(), primaryKeys);
+            updatedSchemaForValue = val.getFirst();
+            updatedValueForValue = val.getSecond();
+        }
+
+        return record.newRecord(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(), updatedSchemaForValue, updatedValueForValue, record.timestamp());
+    }
+
+    @Override
+    public ConfigDef config() {
+        return new ConfigDef();
+    }
+
+    @Override
+    public void close() {
+    }
+
+    private List<String> getAllFieldsInOrder(Schema schema) {
+        List<String> fields = Arrays.asList(new String[schema.fields().size()]);
+        for (Field field : schema.fields()) {
+            fields.set(field.index(), field.name());
+        }
+        return fields;
+    }
+
+    private boolean isValueSetStruct(Field field) {
+        return field.schema().fields().size() == 2
+                && (Objects.equals(field.schema().fields().get(0).name(), "value")
+                && Objects.equals(field.schema().fields().get(1).name(), "set"));
+    }
+
+    private Schema makeMetadataSchema() {
+        final SchemaBuilder builder = SchemaBuilder.struct();
+        builder.field("LSN", Schema.STRING_SCHEMA);
+        builder.field("OperationName", Schema.STRING_SCHEMA);
+        builder.field("PK_UPDATE", Schema.OPTIONAL_BOOLEAN_SCHEMA);
+        builder.field("Sequence", Schema.STRING_SCHEMA);
+        builder.field("TableName", Schema.STRING_SCHEMA);
+        builder.field("TxnID", Schema.STRING_SCHEMA);
+        return builder.build();
+    }
+
+    private Struct makeMetadata(Struct value, Schema metadataSchema) {
+        Struct metadata = new Struct(metadataSchema);
+        Struct sourceValue = (Struct) value.get("source");
+        metadata.put("LSN", sourceValue.get("lsn").toString());
+        metadata.put("Sequence", sourceValue.get("sequence").toString());
+        metadata.put("TxnID", sourceValue.get("txId"));
+        metadata.put("TableName", sourceValue.get("schema") + "." + sourceValue.get("table"));
+        return metadata;
+    }
+
+    private Schema makeUpdatedSchema(Schema schema) {
+        final SchemaBuilder arrayBuilder = SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA);
+        final SchemaBuilder builder = SchemaUtil.copySchemaBasics(schema, SchemaBuilder.struct());
+        builder.field("metadata", makeMetadataSchema());
+        builder.field("data", arrayBuilder.build());
+        builder.field("columns", arrayBuilder.build());
+        builder.field("before", arrayBuilder.optional().build());
+        return builder.build();
+    }
+
+    private Map<String, Object> extractData(Struct value) {
+        Map<String, Object> values = new HashMap<>();
+        if (value == null) {
+            return values;
+        }
+
+        for (Field field : value.schema().fields()) {
+            LOGGER.debug("Considering value {}", field.name());
+            if (field.schema().type() == Type.STRUCT) {
+                LOGGER.debug("Value is a struct");
+                Struct fieldValue = (Struct) value.get(field);
+                if (isValueSetStruct(field)) {
+                    LOGGER.debug("value is valueset");
+                    values.put(field.name(), fieldValue == null ? null : fieldValue.get("value").toString());
+                } else if (fieldValue != null) {
+                    LOGGER.debug("value is not valueset");
+                    values.put(field.name(), fieldValue == null ? null : fieldValue.toString());
+                }
+            } else {
+                LOGGER.debug("value is not a struct");
+            }
+        }
+        return values;
+    }
+
+    private List<Object> convertToOrderedList(Map<String, Object> values, List<String> orderedKeys) {
+        List<Object> valuesList = new ArrayList<>();
+        for (String key : orderedKeys) {
+            if (values.containsKey(key)) {
+                valuesList.add(values.get(key));
+            } else {
+                LOGGER.debug("{} not found in values", key);
+            }
+        }
+        return valuesList;
+    }
+
+    private void removeNonPrimaryKeyValues(Map<String, Object> values, List<String> primaryKeys) {
+        values.forEach((fieldName, fieldValue) -> {
+            if (!primaryKeys.contains(fieldName)) {
+                values.put(fieldName, null);
+            }
+        });
+    }
+
+    private boolean comparePrimaryKeyValues(Map<String, Object> after, Map<String, Object> before, List<String> primaryKeys) {
+        for (String key : primaryKeys) {
+            if (!after.get(key).equals(before.get(key))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public Pair<Schema, Struct> getUpdatedValueAndSchema(Schema schema, Struct value, List<String> primaryKeys) {
+        LOGGER.debug("Original Schema as json: " + io.debezium.data.SchemaUtil.asString(schema));
+        Schema updatedSchema = makeUpdatedSchema(schema);
+        LOGGER.debug("Updated schema as json: " + io.debezium.data.SchemaUtil.asString(updatedSchema));
+
+        List<String> allFields = getAllFieldsInOrder(schema.field("after").schema());
+
+        LOGGER.debug("Original value as json: {}", io.debezium.data.SchemaUtil.asDetailedString(value));
+        Struct newVal = new Struct(updatedSchema);
+        Struct metadata = makeMetadata(value, updatedSchema.field("metadata").schema());
+        newVal.put("columns", allFields);
+
+        switch ((String)value.get("op")) {
+            case "c": {
+               Map<String, Object> newValues = extractData((Struct) value.get("after"));
+
+                metadata.put("OperationName", "INSERT");
+                newVal.put("metadata", metadata);
+                newVal.put("data", convertToOrderedList(newValues, allFields));
+
+               LOGGER.debug("Update value as json: {}", io.debezium.data.SchemaUtil.asDetailedString(newVal));
+               return new org.yb.util.Pair<>(updatedSchema, newVal);
+            }
+            case "u": {
+                Map<String, Object> newValues = extractData((Struct) value.get("after"));
+                Map<String, Object> oldValues = extractData((Struct) value.get("before"));
+                removeNonPrimaryKeyValues(oldValues, primaryKeys);
+
+                metadata.put("OperationName", "UPDATE");
+                if (!comparePrimaryKeyValues(newValues, oldValues, primaryKeys)) {
+                    metadata.put("PK_UPDATE", true);
+                }
+                newVal.put("metadata", metadata);
+                newVal.put("data", convertToOrderedList(newValues, allFields));
+                newVal.put("before", convertToOrderedList(oldValues, allFields));
+
+                LOGGER.debug("Update value as json: {}", io.debezium.data.SchemaUtil.asDetailedString(newVal));
+                return new org.yb.util.Pair<>(updatedSchema, newVal);
+            }
+            case "d": {
+                Map<String, Object> oldValues = extractData((Struct) value.get("before"));
+                removeNonPrimaryKeyValues(oldValues, primaryKeys);
+
+                metadata.put("OperationName", "DELETE");
+                newVal.put("metadata", metadata);
+                newVal.put("data", convertToOrderedList(oldValues, allFields));
+
+                LOGGER.debug("Update value as json: {}", io.debezium.data.SchemaUtil.asDetailedString(newVal));
+                return new org.yb.util.Pair<>(updatedSchema, newVal);
+            }
+            default: {
+                return new org.yb.util.Pair<>(schema, value);
+            }
+        }
+    }
+
+    @Override
+    public void configure(Map<String, ?> map) {
+
+    }
+}

--- a/src/main/java/io/debezium/connector/yugabytedb/transforms/StriimCompatible.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/transforms/StriimCompatible.java
@@ -159,9 +159,9 @@ public class StriimCompatible<R extends ConnectRecord<R>> implements Transformat
             case "c": {
                Map<String, Object> newValues = extractData((Struct) value.get("after"));
 
-                metadata.put("OperationName", "INSERT");
-                newVal.put("metadata", metadata);
-                newVal.put("data", convertToOrderedList(newValues, allFields));
+               metadata.put("OperationName", "INSERT");
+               newVal.put("metadata", metadata);
+               newVal.put("data", convertToOrderedList(newValues, allFields));
 
                LOGGER.debug("Update value as json: {}", io.debezium.data.SchemaUtil.asDetailedString(newVal));
                return new org.yb.util.Pair<>(updatedSchema, newVal);
@@ -189,6 +189,16 @@ public class StriimCompatible<R extends ConnectRecord<R>> implements Transformat
                 metadata.put("OperationName", "DELETE");
                 newVal.put("metadata", metadata);
                 newVal.put("data", convertToOrderedList(oldValues, allFields));
+
+                LOGGER.debug("Update value as json: {}", io.debezium.data.SchemaUtil.asDetailedString(newVal));
+                return new org.yb.util.Pair<>(updatedSchema, newVal);
+            }
+            case "r": {
+                Map<String, Object> newValues = extractData((Struct) value.get("after"));
+
+                metadata.put("OperationName", "READ");
+                newVal.put("metadata", metadata);
+                newVal.put("data", convertToOrderedList(newValues, allFields));
 
                 LOGGER.debug("Update value as json: {}", io.debezium.data.SchemaUtil.asDetailedString(newVal));
                 return new org.yb.util.Pair<>(updatedSchema, newVal);

--- a/src/test/java/io/debezium/connector/yugabytedb/transforms/StriimCompatibleTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/transforms/StriimCompatibleTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
@@ -38,6 +39,8 @@ public class StriimCompatibleTest {
             .field("schema", Schema.STRING_SCHEMA)
             .field("table", Schema.STRING_SCHEMA)
             .build();
+
+    final List<String> columns = Arrays.asList("id", "name");
 
     final Envelope envelope = Envelope.defineSchema()
             .withName("dummy.Envelope")
@@ -137,6 +140,7 @@ public class StriimCompatibleTest {
             assert(((Struct)unwrappedKey.get("id")).getInt64("value") == 1);
             assert(unwrappedValue.get("before") == null);
             assert(unwrappedValue.getArray("data").equals(expectedData));
+            assert(unwrappedValue.getArray("columns").equals(columns));
 
             assert(((Struct)unwrappedValue.get("metadata")).getString("LSN").equals("1:3::0:0"));
             assert(((Struct)unwrappedValue.get("metadata")).getString("Sequence").equals("[\"454::89\"]"));
@@ -167,6 +171,7 @@ public class StriimCompatibleTest {
             assert(((Struct)unwrappedKey.get("id")).getInt64("value") == 2);
             assert(unwrappedValue.getArray("before").equals(expectedBeforeData));
             assert(unwrappedValue.getArray("data").equals(expectedData));
+            assert(unwrappedValue.getArray("columns").equals(columns));
 
             assert(((Struct)unwrappedValue.get("metadata")).getString("LSN").equals("1:3::0:0"));
             assert(((Struct)unwrappedValue.get("metadata")).getString("Sequence").equals("[\"454::89\"]"));
@@ -197,6 +202,7 @@ public class StriimCompatibleTest {
             assert(((Struct)unwrappedKey.get("id")).getInt64("value") == 1);
             assert(unwrappedValue.getArray("before").equals(expectedBeforeData));
             assert(unwrappedValue.getArray("data").equals(expectedData));
+            assert(unwrappedValue.getArray("columns").equals(columns));
 
             assert(((Struct)unwrappedValue.get("metadata")).getString("LSN").equals("1:3::0:0"));
             assert(((Struct)unwrappedValue.get("metadata")).getString("Sequence").equals("[\"454::89\"]"));
@@ -224,6 +230,7 @@ public class StriimCompatibleTest {
             assert(((Struct)unwrappedKey.get("id")).getInt64("value") == 1);
             assert(unwrappedValue.get("before") == null);
             assert(unwrappedValue.getArray("data").equals(expectedData));
+            assert(unwrappedValue.getArray("columns").equals(columns));
 
             assert(((Struct)unwrappedValue.get("metadata")).getString("LSN").equals("1:3::0:0"));
             assert(((Struct)unwrappedValue.get("metadata")).getString("Sequence").equals("[\"454::89\"]"));

--- a/src/test/java/io/debezium/connector/yugabytedb/transforms/StriimCompatibleTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/transforms/StriimCompatibleTest.java
@@ -1,0 +1,238 @@
+package io.debezium.connector.yugabytedb.transforms;
+
+import io.debezium.data.Envelope;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class StriimCompatibleTest {
+    final Schema idSchema =  SchemaBuilder.struct()
+            .field("value", Schema.INT64_SCHEMA)
+            .field("set", Schema.BOOLEAN_SCHEMA);
+
+    final Schema nameSchema =  SchemaBuilder.struct()
+            .field("value", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("set", Schema.BOOLEAN_SCHEMA)
+            .optional();
+
+    final Schema keySchema = SchemaBuilder.struct()
+            .field("id", idSchema)
+            .build();
+
+    final Schema valueSchema = SchemaBuilder.struct()
+            .field("id", idSchema)
+            .field("name", nameSchema)
+            .build();
+
+    final Schema sourceSchema = SchemaBuilder.struct()
+            .field("lsn", Schema.STRING_SCHEMA)
+            .field("sequence", Schema.STRING_SCHEMA)
+            .field("txId", Schema.STRING_SCHEMA)
+            .field("schema", Schema.STRING_SCHEMA)
+            .field("table", Schema.STRING_SCHEMA)
+            .build();
+
+    final Envelope envelope = Envelope.defineSchema()
+            .withName("dummy.Envelope")
+            .withRecord(valueSchema)
+            .withSource(sourceSchema)
+            .build();
+
+    private Struct createIdStruct() {
+        final Struct id = new Struct(idSchema);
+        id.put("value", (long) 1L);
+        id.put("set", true);
+        return id;
+    }
+
+    private Struct createUpdatedIdStruct() {
+        final Struct id = new Struct(idSchema);
+        id.put("value", (long) 2L);
+        id.put("set", true);
+        return id;
+    }
+
+    private Struct createNameStruct() {
+        final Struct name = new Struct(nameSchema);
+        name.put("value", "yb");
+        name.put("set", true);
+        return name;
+    }
+
+    private Struct createUpdatedNameStruct() {
+        final Struct name = new Struct(nameSchema);
+        name.put("value", "yb2");
+        name.put("set", true);
+        return name;
+    }
+
+    private Struct createValue() {
+        final Struct value = new Struct(valueSchema);
+        value.put("id", createIdStruct());
+        value.put("name", createNameStruct());
+        return value;
+    }
+
+    private Struct createUpdatedValue(boolean updateId) {
+        final Struct value = new Struct(valueSchema);
+        value.put("id", updateId ? createUpdatedIdStruct() : createIdStruct());
+        value.put("name", createUpdatedNameStruct());
+        return value;
+    }
+
+    private Struct createSourceStruct() {
+        final Struct source = new Struct(sourceSchema);
+        source.put("lsn", "1:3::0:0");
+        source.put("sequence", "[\"454::89\"]");
+        source.put("schema", "public");
+        source.put("table", "store");
+        source.put("txId", "");
+        return source;
+    }
+
+    private SourceRecord createCreateRecord() {
+        final Struct key = new Struct(keySchema);
+        key.put("id", createIdStruct());
+
+        final Struct createPayload = envelope.create(createValue(), createSourceStruct(), Instant.now());
+        return new SourceRecord(new HashMap<>(), new HashMap<>(), "dummy", keySchema, key, envelope.schema(), createPayload);
+    }
+
+    private SourceRecord createUpdateRecord(boolean updateId) {
+        final Struct key = new Struct(keySchema);
+        key.put("id", updateId ? createUpdatedIdStruct() : createIdStruct());
+
+        final Struct updatePayload = envelope.update(createValue(), createUpdatedValue(updateId), createSourceStruct(), Instant.now());
+        return new SourceRecord(new HashMap<>(), new HashMap<>(), "dummy", keySchema, key, envelope.schema(), updatePayload);
+    }
+
+    private SourceRecord createDeleteRecord() {
+        final Struct key = new Struct(keySchema);
+        key.put("id", createIdStruct());
+
+        final Struct deletePayload = envelope.delete(createValue(), createSourceStruct(), Instant.now());
+        return new SourceRecord(new HashMap<>(), new HashMap<>(), "dummy", keySchema, key, envelope.schema(), deletePayload);
+    }
+
+    @Test
+    public void testCreateRecord() {
+        try (final StriimCompatible<SourceRecord> transform = new StriimCompatible<>()) {
+            final SourceRecord createRecord = createCreateRecord();
+
+            List<String> expectedData = new ArrayList<>();
+            expectedData.add("1");
+            expectedData.add("yb");
+
+            final SourceRecord unwrapped = transform.apply(createRecord);
+            Struct unwrappedKey = (Struct) unwrapped.key();
+            Struct unwrappedValue = (Struct) unwrapped.value();
+
+            assert(((Struct)unwrappedKey.get("id")).getInt64("value") == 1);
+            assert(unwrappedValue.get("before") == null);
+            assert(unwrappedValue.getArray("data").equals(expectedData));
+
+            assert(((Struct)unwrappedValue.get("metadata")).getString("LSN").equals("1:3::0:0"));
+            assert(((Struct)unwrappedValue.get("metadata")).getString("Sequence").equals("[\"454::89\"]"));
+            assert(((Struct)unwrappedValue.get("metadata")).getString("TxnID").equals(""));
+            assert(((Struct)unwrappedValue.get("metadata")).getString("TableName").equals("public.store"));
+            assert(((Struct)unwrappedValue.get("metadata")).getString("OperationName").equals("INSERT"));
+            assert(((Struct)unwrappedValue.get("metadata")).get("PK_UPDATE") == null);
+        }
+    }
+
+    @Test
+    public void testUpdateRecord() {
+        try (final StriimCompatible<SourceRecord> transform = new StriimCompatible<>()) {
+            final SourceRecord updateRecord = createUpdateRecord(true);
+
+            List<String> expectedData = new ArrayList<>();
+            expectedData.add("2");
+            expectedData.add("yb2");
+
+            List<String> expectedBeforeData = new ArrayList<>();
+            expectedBeforeData.add("1");
+            expectedBeforeData.add(null);
+
+            final SourceRecord unwrapped = transform.apply(updateRecord);
+            Struct unwrappedKey = (Struct) unwrapped.key();
+            Struct unwrappedValue = (Struct) unwrapped.value();
+
+            assert(((Struct)unwrappedKey.get("id")).getInt64("value") == 2);
+            assert(unwrappedValue.getArray("before").equals(expectedBeforeData));
+            assert(unwrappedValue.getArray("data").equals(expectedData));
+
+            assert(((Struct)unwrappedValue.get("metadata")).getString("LSN").equals("1:3::0:0"));
+            assert(((Struct)unwrappedValue.get("metadata")).getString("Sequence").equals("[\"454::89\"]"));
+            assert(((Struct)unwrappedValue.get("metadata")).getString("TxnID").equals(""));
+            assert(((Struct)unwrappedValue.get("metadata")).getString("TableName").equals("public.store"));
+            assert(((Struct)unwrappedValue.get("metadata")).getString("OperationName").equals("UPDATE"));
+            assert(((Struct)unwrappedValue.get("metadata")).getBoolean("PK_UPDATE") == true);
+        }
+    }
+
+    @Test
+    public void testUpdateRecordWithoutPrimaryKeyChange() {
+        try (final StriimCompatible<SourceRecord> transform = new StriimCompatible<>()) {
+            final SourceRecord updateRecord = createUpdateRecord(false);
+
+            List<String> expectedData = new ArrayList<>();
+            expectedData.add("1");
+            expectedData.add("yb2");
+
+            List<String> expectedBeforeData = new ArrayList<>();
+            expectedBeforeData.add("1");
+            expectedBeforeData.add(null);
+
+            final SourceRecord unwrapped = transform.apply(updateRecord);
+            Struct unwrappedKey = (Struct) unwrapped.key();
+            Struct unwrappedValue = (Struct) unwrapped.value();
+
+            assert(((Struct)unwrappedKey.get("id")).getInt64("value") == 1);
+            assert(unwrappedValue.getArray("before").equals(expectedBeforeData));
+            assert(unwrappedValue.getArray("data").equals(expectedData));
+
+            assert(((Struct)unwrappedValue.get("metadata")).getString("LSN").equals("1:3::0:0"));
+            assert(((Struct)unwrappedValue.get("metadata")).getString("Sequence").equals("[\"454::89\"]"));
+            assert(((Struct)unwrappedValue.get("metadata")).getString("TxnID").equals(""));
+            assert(((Struct)unwrappedValue.get("metadata")).getString("TableName").equals("public.store"));
+            assert(((Struct)unwrappedValue.get("metadata")).getString("OperationName").equals("UPDATE"));
+            assert(((Struct)unwrappedValue.get("metadata")).get("PK_UPDATE") == null);
+        }
+    }
+
+
+    @Test
+    public void testDeleteRecord() {
+        try (final StriimCompatible<SourceRecord> transform = new StriimCompatible<>()) {
+            final SourceRecord deleteRecord = createDeleteRecord();
+
+            List<String> expectedData = new ArrayList<>();
+            expectedData.add("1");
+            expectedData.add(null);
+
+            final SourceRecord unwrapped = transform.apply(deleteRecord);
+            Struct unwrappedKey = (Struct) unwrapped.key();
+            Struct unwrappedValue = (Struct) unwrapped.value();
+
+            assert(((Struct)unwrappedKey.get("id")).getInt64("value") == 1);
+            assert(unwrappedValue.get("before") == null);
+            assert(unwrappedValue.getArray("data").equals(expectedData));
+
+            assert(((Struct)unwrappedValue.get("metadata")).getString("LSN").equals("1:3::0:0"));
+            assert(((Struct)unwrappedValue.get("metadata")).getString("Sequence").equals("[\"454::89\"]"));
+            assert(((Struct)unwrappedValue.get("metadata")).getString("TxnID").equals(""));
+            assert(((Struct)unwrappedValue.get("metadata")).getString("TableName").equals("public.store"));
+            assert(((Struct)unwrappedValue.get("metadata")).getString("OperationName").equals("DELETE"));
+            assert(((Struct)unwrappedValue.get("metadata")).get("PK_UPDATE") == null);
+        }
+    }
+
+
+}

--- a/src/test/java/io/debezium/connector/yugabytedb/transforms/StriimCompatibleTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/transforms/StriimCompatibleTest.java
@@ -13,6 +13,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
+/**
+ * Unit tests for {@link StriimCompatible} transformer.
+ */
 public class StriimCompatibleTest {
     final Schema idSchema =  SchemaBuilder.struct()
             .field("value", Schema.INT64_SCHEMA)
@@ -240,6 +243,4 @@ public class StriimCompatibleTest {
             assert(((Struct)unwrappedValue.get("metadata")).get("PK_UPDATE") == null);
         }
     }
-
-
 }


### PR DESCRIPTION
Create a transformer so that the records sent to kafka are compatible with [striim](https://www.striim.com/docs/en/postgresql-cdc.html#UUID-bb4c7685-acc1-6f6a-f4a2-afbfecf4febf).

### Target Structure

**metadata (struct)** 
- LSN: log sequence number of the transaction's commit
- NEXT_LSN: next log sequence number (used for reconnecting to the replication slot after a non-fatal network interruption)
- OperationName: INSERT, UPDATE, or DELETE
- PK_UPDATE: included only when an UPDATE changes the primary key
- Sequence: incremented for each operation within a transaction
- TableName: the name of the table including its schema
- TimeStamp: timestamp from the replication subscription
- TxnID: transaction identifier

**data (array)**
- for an INSERT operation, the values that were inserted
- for an UPDATE, the values after the operation was completed
- for a DELETE, the value of the primary key and nulls for the other fields

**before (array)**
- for UPDATE operations, contains the primary key value from before the update. 

Closes #200.