### PR TITLE
[CDCSDK#16556] Check for snapshot completion after GetChanges call

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -481,6 +481,19 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                          the snapshot as completed.
                  */
                 if (taskContext.shouldEnableExplicitCheckpointing()) {
+                  // snapshotCompletedTablets contain the tablets for which the following two
+                  // conditions are met:
+                  // 1. The server has sent the snapshot end marker.
+                  // 2. In case of EXPLICIT checkpointing - Kafka has sent the callback so we are
+                  //    sure we have received the data.
+                  //
+                  // Now over here, the additional set i.e. tabletsWaitingForCallback is for cases
+                  // of EXPLICIT checkpointing only where the above point 2 is not satisfied,
+                  // so that we know that server has sent the data (1 is satisfied) but
+                  // Kafka hasn't acknowledged the message's presence. If we always add the
+                  // tabletId to snapshotCompletedTablets - there is a chance that when the
+                  // connector crashes, we may lose some data since we may not have published them
+                  // to Kafka yet.
                   if (isSnapshotCompleteMarker(OpId.from(this.tabletToExplicitCheckpoint.get(tabletId)))) {
                     // This will mark the snapshot completed for the tablet
                     snapshotCompletedTablets.add(tabletId);


### PR DESCRIPTION
The issue arose where we were checking whether the `OpId` is the snapshot complete marker on the `from_op_id` i.e. `cp` in our case - that is prone to errors as reported in stress tests as we may end up calling `GetChanges` with a checkpoint meant for streaming.

One such error occured in the call as mentioned in the ticket yugabyte/yugabyte-db#16556, on investigation, it was found that the flow was like:
1. Call `GetChanges` on `from_op_id` (for snapshot)
2. Receive a end marker in response and update the LSN
3. Since we were checking for snapshot end marker on `from_op_id` - it got ignored
4. The LSN now would not be the one we need to use for, but instead it would be the one being used for streaming
5. Now if we call `GetChanges` and if the tablet got split, we will throw a "tablet split detected" error - which will not be handled at the snapshot level - thus leading to the failure of the task.

This PR fixes the above error by checking the marker on the response OpId instead of request OpId and there are following cases where we check:
| **EXPLICIT** | **IMPLICIT** |
| :--- | :--- |
| If the explicit checkpoint is snapshot end marker, add tablet to snapshot completion list | If checkpoint received in response is the snapshot end marker then add tablet to snapshot completion list |
| If explicit checkpoint is not end marker and we have not received the callback yet, add the tablet to a waitlist so that we can avoid calling `GetChanges` for it in further iterations | |

For reference, the snapshot end marker is an `OpId` with the following values:
`term` : some term value
`index` : some index value
`key` : empty byte array
`write_id` : 0
`time` : 0