### PR TITLE
[#180] Add test annotations for testing against a specific build only

### DIFF
--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBColocatedTablesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBColocatedTablesTest.java
@@ -3,6 +3,7 @@ package io.debezium.connector.yugabytedb;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.yugabytedb.annotations.PreviewOnly;
 import io.debezium.connector.yugabytedb.common.TestBaseClass;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
 
@@ -23,6 +24,7 @@ import org.junit.jupiter.api.*;
  *
  * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
  */
+@PreviewOnly
 public class YugabyteDBColocatedTablesTest extends YugabyteDBContainerTestBase {
   private final String INSERT_TEST_1 = "INSERT INTO test_1 VALUES (%d, 'sample insert');";
   private final String INSERT_TEST_2 = "INSERT INTO test_2 VALUES (%d::text);";

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConfigTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConfigTest.java
@@ -3,6 +3,7 @@ package io.debezium.connector.yugabytedb;
 import java.sql.SQLException;
 import java.util.concurrent.CompletableFuture;
 
+import io.debezium.connector.yugabytedb.annotations.PreviewOnly;
 import org.junit.jupiter.api.*;
 
 import io.debezium.DebeziumException;
@@ -199,6 +200,7 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
     }
 
     @Test
+    @PreviewOnly
     public void shouldThrowProperErrorMessageWithEmptyTableList() throws Exception {
         TestHelper.dropAllSchemas();
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConfigTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConfigTest.java
@@ -3,7 +3,6 @@ package io.debezium.connector.yugabytedb;
 import java.sql.SQLException;
 import java.util.concurrent.CompletableFuture;
 
-import io.debezium.connector.yugabytedb.annotations.PreviewOnly;
 import org.junit.jupiter.api.*;
 
 import io.debezium.DebeziumException;
@@ -200,7 +199,6 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
     }
 
     @Test
-    @PreviewOnly
     public void shouldThrowProperErrorMessageWithEmptyTableList() throws Exception {
         TestHelper.dropAllSchemas();
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBExplicitCheckpointingTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBExplicitCheckpointingTest.java
@@ -1,6 +1,7 @@
 package io.debezium.connector.yugabytedb;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.yugabytedb.annotations.PreviewOnly;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
 
 import io.debezium.connector.yugabytedb.common.YugabytedTestBase;
@@ -34,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
  */
+@PreviewOnly
 public class YugabyteDBExplicitCheckpointingTest extends YugabyteDBContainerTestBase {
     private static final Logger LOGGER = LoggerFactory.getLogger(YugabyteDBExplicitCheckpointingTest.class);
 

--- a/src/test/java/io/debezium/connector/yugabytedb/annotations/PreviewOnly.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/annotations/PreviewOnly.java
@@ -1,0 +1,25 @@
+package io.debezium.connector.yugabytedb.annotations;
+
+import io.debezium.connector.yugabytedb.annotations.conditions.RunOnPreviewOnly;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * {@code @PreviewOnly} is used to signify that the annotated test class or method is only supposed
+ * to run against preview YugabyteDB builds.
+ *
+ * <p>{@code @PreviewOnly} can optionally be declared with a {@link #reason reason} to explain
+ * what was the need for the test method or the class to be run against preview builds only.
+ *
+ * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(RunOnPreviewOnly.class)
+public @interface PreviewOnly {
+	String reason() default "";
+}

--- a/src/test/java/io/debezium/connector/yugabytedb/annotations/StableOnly.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/annotations/StableOnly.java
@@ -1,0 +1,25 @@
+package io.debezium.connector.yugabytedb.annotations;
+
+import io.debezium.connector.yugabytedb.annotations.conditions.RunOnStableOnly;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * {@code @StableOnly} is used to signify that the annotated test class or method is only supposed
+ * to run against stable YugabyteDB builds.
+ *
+ * <p>{@code @StableOnly} can optionally be declared with a {@link #reason() reason} to explain
+ * what was the need for the test method or the class to be run against stable builds only.
+ *
+ * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(RunOnStableOnly.class)
+public @interface StableOnly {
+	String reason() default "";
+}

--- a/src/test/java/io/debezium/connector/yugabytedb/annotations/conditions/RunOnPreviewOnly.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/annotations/conditions/RunOnPreviewOnly.java
@@ -1,0 +1,18 @@
+package io.debezium.connector.yugabytedb.annotations.conditions;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class RunOnPreviewOnly implements ExecutionCondition {
+	private final String PREVIEW_VERSION = "2.17";
+	@Override
+	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+		String imageName = System.getenv("YB_DOCKER_IMAGE");
+		if (imageName.contains(PREVIEW_VERSION)) {
+			return ConditionEvaluationResult.enabled("Test enabled");
+		} else {
+			return ConditionEvaluationResult.disabled("Test disabled on preview builds");
+		}
+	}
+}

--- a/src/test/java/io/debezium/connector/yugabytedb/annotations/conditions/RunOnStableOnly.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/annotations/conditions/RunOnStableOnly.java
@@ -1,0 +1,18 @@
+package io.debezium.connector.yugabytedb.annotations.conditions;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class RunOnStableOnly implements ExecutionCondition {
+	private final String STABLE_VERSION = "2.16";
+	@Override
+	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+		String imageName = System.getenv("YB_DOCKER_IMAGE");
+		if (imageName.contains(STABLE_VERSION)) {
+			return ConditionEvaluationResult.enabled("Test enabled");
+		} else {
+			return ConditionEvaluationResult.disabled("Test disabled on preview builds");
+		}
+	}
+}


### PR DESCRIPTION
This PR adds two annotations `@PreviewOnly` and `@StableOnly` which will ensure that the test execution only happens against the build it is meant for. Eg.
* `@PreviewOnly` - for tests to be run against the preview builds of YugabyteDB
* `@StableOnly` - for tests to be run against the stable builds of YugabyteDB only

If no annotation is specified, the test will be run against both builds.

This PR closes #180 