### PR TITLE
[#205] Start snapshot from the key received in GetCheckpointResponse

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -9,7 +9,6 @@ import java.sql.SQLException;
 import java.time.Duration;
 import java.util.*;
 import java.util.Map.Entry;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -9,6 +9,7 @@ import java.sql.SQLException;
 import java.time.Duration;
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -93,6 +94,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
 
         this.yugabyteDbTypeRegistry = taskContext.schema().getTypeRegistry();
         this.tabletToExplicitCheckpoint = new HashMap<>();
+
     }
 
     @Override
@@ -288,7 +290,8 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
 
         GetCheckpointResponse resp = this.syncClient.getCheckpoint(
           tableIdToTable.get(entry.getKey()), this.connectorConfig.streamId(), entry.getValue());
-        LOGGER.info("The response received has term {} index {} and key {}", resp.getTerm(), resp.getIndex(), resp.getSnapshotKey());
+        LOGGER.debug("The response received has term {} index {} key {} and time {}",
+                     resp.getTerm(), resp.getIndex(), resp.getSnapshotKey(), resp.getSnapshotTime());
 
         OpId startLsn = (resp.getSnapshotKey().length == 0) ? YugabyteDBOffsetContext.snapshotStartLsn() : OpId.from(resp);
         previousOffset.initSourceInfo(entry.getValue(), this.connectorConfig, startLsn);

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
@@ -7,6 +7,7 @@ import org.yb.cdc.CdcService.CDCSDKCheckpointPB;
 
 import com.google.common.base.Objects;
 import org.yb.client.CdcSdkCheckpoint;
+import org.yb.client.GetCheckpointResponse;
 
 public class OpId implements Comparable<OpId> {
 
@@ -127,6 +128,11 @@ public class OpId implements Comparable<OpId> {
         return new OpId(checkpoint.getTerm(), checkpoint.getIndex(),
                 checkpoint.getKey(), checkpoint.getWriteId(),
                 checkpoint.getTime());
+    }
+
+    public static OpId from(GetCheckpointResponse response) {
+        return new OpId(response.getTerm(), response.getIndex(), response.getSnapshotKey(),
+                        -1 /* write_id */ , response.getSnapshotTime());
     }
 
     public CdcSdkCheckpoint toCdcSdkCheckpoint() {

--- a/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
@@ -6,9 +6,6 @@
 
 package io.debezium.connector.yugabytedb;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
@@ -56,6 +53,8 @@ import io.debezium.connector.yugabytedb.connection.YugabyteDBConnection;
 import io.debezium.connector.yugabytedb.connection.YugabyteDBConnection.YugabyteDBValueConverterBuilder;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * A utility for integration test cases to connect the YugabyteDB instance running in the Docker 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotMidwayTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotMidwayTest.java
@@ -1,0 +1,145 @@
+package io.debezium.connector.yugabytedb;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
+import io.debezium.connector.yugabytedb.common.YugabytedTestBase;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
+import org.junit.jupiter.api.*;
+
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class YugabyteDBSnapshotMidwayTest extends YugabytedTestBase {
+	@BeforeAll
+	public static void beforeClass() throws SQLException {
+		initializeYBContainer(null, "cdc_snapshot_batch_size=20");
+		TestHelper.dropAllSchemas();
+	}
+
+	@BeforeEach
+	public void before() {
+		initializeConnectorTestFramework();
+	}
+
+	@AfterEach
+	public void after() throws Exception {
+		stopConnector();
+		TestHelper.executeDDL("drop_tables_and_databases.ddl");
+	}
+
+	@AfterAll
+	public static void afterClass() {
+		shutdownYBContainer();
+	}
+
+	@Test
+	public void baseTestToAssertSnapshotResumeFeature() throws Exception {
+		TestHelper.dropAllSchemas();
+		TestHelper.executeDDL("yugabyte_create_tables.ddl");
+
+		final int recordsCount = 5_000;
+		// insert rows in the table t1 with values <some-pk, 'Vaibhav', 'Kushwaha', 30>
+		insertBulkRecords(recordsCount);
+
+		String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
+		Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
+		configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE, YugabyteDBConnectorConfig.SnapshotMode.INITIAL.getValue());
+		start(YugabyteDBConnector.class, configBuilder.build());
+
+		awaitUntilConnectorIsReady();
+
+		AtomicLong totalConsumedAfterKill = new AtomicLong();
+		AtomicInteger timesNoRecordReceived = new AtomicInteger();
+		Awaitility.await()
+			.atMost(Duration.ofSeconds(60))
+			.until(() -> {
+				int consumed = super.consumeAvailableRecords(record -> {
+					LOGGER.debug("The record being consumed is " + record);
+				});
+				if (consumed > 0) {
+					totalConsumedAfterKill.addAndGet(consumed);
+					LOGGER.info("Consumed " + totalConsumedAfterKill + " records");
+				} else {
+					LOGGER.info("Got 0 records upon consumption");
+					timesNoRecordReceived.incrementAndGet();
+				}
+
+				return totalConsumedAfterKill.get() >= 1500;
+			});
+		LOGGER.info("Total consumed records after kill are {}", totalConsumedAfterKill.get());
+
+		// Kill the connector after some seconds and consume whatever data is available.
+		TestHelper.waitFor(Duration.ofSeconds(5));
+		stopConnector();
+		assertNoRecordsToConsume();
+
+		TestHelper.waitFor(Duration.ofSeconds(15));
+
+		// Start the connector again.
+		start(YugabyteDBConnector.class, configBuilder.build());
+		awaitUntilConnectorIsReady();
+
+		// Only verifying the record count since the snapshot records are not ordered, so it may be
+		// a little complex to verify them in the sorted order at the moment
+		CompletableFuture.runAsync(() -> verifyRecordCount(recordsCount - totalConsumedAfterKill.get()))
+			.exceptionally(throwable -> {
+				throw new RuntimeException(throwable);
+			}).get();
+	}
+
+	private void insertBulkRecords(int numRecords) throws Exception {
+		String formatInsertString = "INSERT INTO t1 VALUES (%d, 'Vaibhav', 'Kushwaha', 30);";
+		TestHelper.executeBulk(formatInsertString, numRecords);
+	}
+
+	private void verifyRecordCount(long recordsCount) {
+		waitAndFailIfCannotConsume(new ArrayList<>(), recordsCount);
+	}
+
+	private void waitAndFailIfCannotConsume(List<SourceRecord> records, long recordsCount) {
+		waitAndFailIfCannotConsume(records, recordsCount, 300 * 1000 /* 5 minutes */);
+	}
+
+	/**
+	 * Consume the records available and add them to a list for further assertion purposes.
+	 * @param records list to which we need to add the records we consume, pass a
+	 * {@code new ArrayList<>()} if you do not need assertions on the consumed values
+	 * @param recordsCount total number of records which should be consumed
+	 * @param milliSecondsToWait duration in milliseconds to wait for while consuming
+	 */
+	private void waitAndFailIfCannotConsume(List<SourceRecord> records, long recordsCount,
+																					long milliSecondsToWait) {
+		AtomicLong totalConsumedRecords = new AtomicLong();
+		long seconds = milliSecondsToWait / 1000;
+		try {
+			Awaitility.await()
+				.atMost(Duration.ofSeconds(seconds))
+				.until(() -> {
+					int consumed = super.consumeAvailableRecords(record -> {
+						LOGGER.debug("The record being consumed is " + record);
+						records.add(record);
+					});
+					if (consumed > 0) {
+						totalConsumedRecords.addAndGet(consumed);
+						LOGGER.info("Consumed " + totalConsumedRecords + " records");
+					}
+
+					return totalConsumedRecords.get() == recordsCount;
+				});
+		} catch (ConditionTimeoutException exception) {
+			fail("Failed to consume " + recordsCount + " in " + seconds + " seconds", exception);
+		}
+
+		assertEquals(recordsCount, totalConsumedRecords.get());
+	}
+}

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotResumeTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotResumeTest.java
@@ -1,6 +1,8 @@
 package io.debezium.connector.yugabytedb;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.yugabytedb.annotations.PreviewOnly;
+import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
 import io.debezium.connector.yugabytedb.common.YugabytedTestBase;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.awaitility.Awaitility;
@@ -25,7 +27,8 @@ import static org.junit.jupiter.api.Assertions.fail;
  *
  * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
  */
-public class YugabyteDBSnapshotResumeTest extends YugabytedTestBase {
+@PreviewOnly
+public class YugabyteDBSnapshotResumeTest extends YugabyteDBContainerTestBase {
 	private final String insertStmtFormat = "INSERT INTO t1 VALUES (%d, 'Vaibhav', 'Kushwaha', 30);";
 	@BeforeAll
 	public static void beforeClass() throws SQLException {


### PR DESCRIPTION
Before this PR, if snapshot gets aborted in the middle for any reason and if the connector is restarted, it will start the snapshot from the beginning.

This PR changes the way snapshot is resumed, basically we persist the snapshot key on the server and once the connector is started, we check whether the server has any `snapshot_key` stored on the server - if yes, then we resume the snapshot from that point onwards only.

This also closes #205 