### PR TITLE
[yugabyte/yugabyte-db#16563] Send transaction metadata to the transaction topic properly

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBEventDispatcher.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBEventDispatcher.java
@@ -6,7 +6,17 @@ package io.debezium.connector.yugabytedb;
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 
+import io.debezium.data.Envelope;
+import io.debezium.heartbeat.Heartbeat;
 import io.debezium.heartbeat.HeartbeatFactory;
+import io.debezium.pipeline.signal.Signal;
+import io.debezium.pipeline.source.spi.DataChangeEventListener;
+import io.debezium.pipeline.spi.ChangeRecordEmitter;
+import io.debezium.schema.*;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,11 +30,11 @@ import io.debezium.pipeline.source.spi.EventMetadataProvider;
 import io.debezium.pipeline.spi.ChangeEventCreator;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.Partition;
-import io.debezium.schema.DataCollectionFilters;
-import io.debezium.schema.DataCollectionId;
-import io.debezium.schema.DatabaseSchema;
-import io.debezium.schema.TopicSelector;
 import io.debezium.util.SchemaNameAdjuster;
+
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Custom extension of the {@link EventDispatcher} to accommodate routing {@link LogicalDecodingMessage} events to the change event queue.
@@ -33,24 +43,38 @@ import io.debezium.util.SchemaNameAdjuster;
  */
 public class YugabyteDBEventDispatcher<T extends DataCollectionId> extends EventDispatcher<YBPartition, T> {
     private static final Logger LOGGER = LoggerFactory.getLogger(YugabyteDBEventDispatcher.class);
+    private final YugabyteDBConnectorConfig connectorConfig;
+    private final ChangeEventCreator changeEventCreator;
     private final ChangeEventQueue<DataChangeEvent> queue;
+    private final boolean emitTombstonesOnDelete;
     private final LogicalDecodingMessageMonitor logicalDecodingMessageMonitor;
     private final LogicalDecodingMessageFilter messageFilter;
+    private final TopicSelector<T> topicSelector;
+    private final DatabaseSchema<T> schema;
+    private DataChangeEventListener<YBPartition> eventListener = DataChangeEventListener.NO_OP();
+    private final InconsistentSchemaHandler<YBPartition, T> inconsistentSchemaHandler;
+    private final Signal<YBPartition> signal;
+    private final boolean neverSkip;
+    private final Heartbeat heartbeat;
+    private final EnumSet<Envelope.Operation> skippedOperations;
+    private final DataCollectionFilters.DataCollectionFilter<T> filter;
+    private final YugabyteDBTransactionMonitor transactionMonitor;
+    private final YugabyteDBStreamingChangeRecordReceiver streamingReceiver;
 
-    public YugabyteDBEventDispatcher(YugabyteDBConnectorConfig connectorConfig, TopicSelector<T> topicSelector,
-                                   DatabaseSchema<T> schema, ChangeEventQueue<DataChangeEvent> queue, DataCollectionFilters.DataCollectionFilter<T> filter,
-                                   ChangeEventCreator changeEventCreator, EventMetadataProvider metadataProvider, SchemaNameAdjuster schemaNameAdjuster) {
-        this(connectorConfig, topicSelector, schema, queue, filter, changeEventCreator, null, metadataProvider,
-                new HeartbeatFactory<>(connectorConfig, topicSelector, schemaNameAdjuster), schemaNameAdjuster, null);
-    }
-
-    public YugabyteDBEventDispatcher(YugabyteDBConnectorConfig connectorConfig, TopicSelector<T> topicSelector,
-                                   DatabaseSchema<T> schema, ChangeEventQueue<DataChangeEvent> queue, DataCollectionFilters.DataCollectionFilter<T> filter,
-                                   ChangeEventCreator changeEventCreator, EventMetadataProvider metadataProvider,
-                                     HeartbeatFactory<T> heartbeatFactory, SchemaNameAdjuster schemaNameAdjuster) {
-        this(connectorConfig, topicSelector, schema, queue, filter, changeEventCreator, null, metadataProvider,
-                heartbeatFactory, schemaNameAdjuster, null);
-    }
+//    public YugabyteDBEventDispatcher(YugabyteDBConnectorConfig connectorConfig, TopicSelector<T> topicSelector,
+//                                   DatabaseSchema<T> schema, ChangeEventQueue<DataChangeEvent> queue, DataCollectionFilters.DataCollectionFilter<T> filter,
+//                                   ChangeEventCreator changeEventCreator, EventMetadataProvider metadataProvider, SchemaNameAdjuster schemaNameAdjuster) {
+//        this(connectorConfig, topicSelector, schema, queue, filter, changeEventCreator, null, metadataProvider,
+//                new HeartbeatFactory<>(connectorConfig, topicSelector, schemaNameAdjuster), schemaNameAdjuster, null);
+//    }
+//
+//    public YugabyteDBEventDispatcher(YugabyteDBConnectorConfig connectorConfig, TopicSelector<T> topicSelector,
+//                                   DatabaseSchema<T> schema, ChangeEventQueue<DataChangeEvent> queue, DataCollectionFilters.DataCollectionFilter<T> filter,
+//                                   ChangeEventCreator changeEventCreator, EventMetadataProvider metadataProvider,
+//                                     HeartbeatFactory<T> heartbeatFactory, SchemaNameAdjuster schemaNameAdjuster) {
+//        this(connectorConfig, topicSelector, schema, queue, filter, changeEventCreator, null, metadataProvider,
+//                heartbeatFactory, schemaNameAdjuster, null);
+//    }
 
     public YugabyteDBEventDispatcher(YugabyteDBConnectorConfig connectorConfig, TopicSelector<T> topicSelector,
                                    DatabaseSchema<T> schema, ChangeEventQueue<DataChangeEvent> queue, DataCollectionFilters.DataCollectionFilter<T> filter,
@@ -59,9 +83,22 @@ public class YugabyteDBEventDispatcher<T extends DataCollectionId> extends Event
                                    JdbcConnection jdbcConnection) {
         super(connectorConfig, topicSelector, schema, queue, filter, changeEventCreator, inconsistentSchemaHandler, metadataProvider,
                 heartbeatFactory, schemaNameAdjuster);
+        this.connectorConfig = connectorConfig;
+        this.changeEventCreator = changeEventCreator;
         this.queue = queue;
         this.logicalDecodingMessageMonitor = new LogicalDecodingMessageMonitor(connectorConfig, this::enqueueLogicalDecodingMessage);
         this.messageFilter = connectorConfig.getMessageFilter();
+        this.topicSelector = topicSelector;
+        this.heartbeat = heartbeatFactory.createHeartbeat();
+        this.streamingReceiver = new YugabyteDBStreamingChangeRecordReceiver();
+        this.inconsistentSchemaHandler = inconsistentSchemaHandler != null ? inconsistentSchemaHandler : this::errorOnMissingSchema;
+        this.signal = new Signal<>(connectorConfig, this);
+        this.skippedOperations = connectorConfig.getSkippedOperations();
+        this.emitTombstonesOnDelete = connectorConfig.isEmitTombstoneOnDelete();
+        this.neverSkip = connectorConfig.supportsOperationFiltering() || this.skippedOperations.isEmpty();
+        this.filter = filter;
+        this.schema = schema;
+        this.transactionMonitor = new YugabyteDBTransactionMonitor(connectorConfig, metadataProvider, schemaNameAdjuster, this::enqueueTransactionMessage);
     }
 
     public void dispatchLogicalDecodingMessage(Partition partition, OffsetContext offset, Long decodeTimestamp,
@@ -75,7 +112,144 @@ public class YugabyteDBEventDispatcher<T extends DataCollectionId> extends Event
         }
     }
 
+    public void setEventListener(DataChangeEventListener<YBPartition> eventListener) {
+        this.eventListener = eventListener;
+    }
+
+    @Override
+    public boolean dispatchDataChangeEvent(YBPartition partition, T dataCollectionId, ChangeRecordEmitter<YBPartition> changeRecordEmitter) throws InterruptedException {
+        try {
+            boolean handled = false;
+            if (!filter.isIncluded(dataCollectionId)) {
+                LOGGER.trace("Filtered data change event for {}", dataCollectionId);
+                eventListener.onFilteredEvent(partition, "source = " + dataCollectionId, changeRecordEmitter.getOperation());
+                dispatchFilteredEvent(changeRecordEmitter.getPartition(), changeRecordEmitter.getOffset());
+            } else {
+                DataCollectionSchema dataCollectionSchema = schema.schemaFor(dataCollectionId);
+
+                // TODO handle as per inconsistent schema info option
+                if (dataCollectionSchema == null) {
+                    final Optional<DataCollectionSchema> replacementSchema = inconsistentSchemaHandler.handle(partition,
+                      dataCollectionId, changeRecordEmitter);
+                    if (!replacementSchema.isPresent()) {
+                        return false;
+                    }
+                    dataCollectionSchema = replacementSchema.get();
+                }
+
+                changeRecordEmitter.emitChangeRecords(dataCollectionSchema, new ChangeRecordEmitter.Receiver<YBPartition>() {
+                    @Override
+                    public void changeRecord(YBPartition partition,
+                                             DataCollectionSchema schema,
+                                             Envelope.Operation operation,
+                                             Object key, Struct value,
+                                             OffsetContext offset,
+                                             ConnectHeaders headers)
+                      throws InterruptedException {
+                        if (operation == Envelope.Operation.CREATE && signal.isSignal(dataCollectionId)) {
+                            signal.process(partition, value, offset);
+                        }
+
+                        if (neverSkip || !skippedOperations.contains(operation)) {
+                            transactionMonitor.dataEvent(partition, dataCollectionId, offset, key, value);
+                            eventListener.onEvent(partition, dataCollectionId, offset, key, value, operation);
+
+                            streamingReceiver.changeRecord(partition, schema, operation, key, value, offset, headers);
+                        }
+                    }
+                });
+                handled = true;
+            }
+
+            // TODO Vaibhav: Remove this as we do not use any heartbeat events
+//            heartbeat.heartbeat(
+//              changeRecordEmitter.getPartition().getSourcePartition(),
+//              changeRecordEmitter.getOffset().getOffset(),
+//              this::enqueueHeartbeat);
+
+            return handled;
+        } catch (Exception e) {
+          switch (connectorConfig.getEventProcessingFailureHandlingMode()) {
+            case FAIL:
+               throw new ConnectException("Error while processing event at offset " + changeRecordEmitter.getOffset().getOffset(), e);
+            case WARN:
+                LOGGER.warn(
+                   "Error while processing event at offset {}",
+                   changeRecordEmitter.getOffset().getOffset());
+                   break;
+            case SKIP:
+                LOGGER.debug(
+                  "Error while processing event at offset {}",
+                  changeRecordEmitter.getOffset().getOffset());
+                break;
+            }
+          return false;
+        }
+    }
+
+    @Override
+    public void dispatchTransactionStartedEvent(YBPartition partition, String transactionId, OffsetContext offset) throws InterruptedException {
+        this.transactionMonitor.transactionStartedEvent(partition, transactionId, offset);
+    }
+
+    @Override
+    public void dispatchTransactionCommittedEvent(YBPartition partition, OffsetContext offset) throws InterruptedException {
+        this.transactionMonitor.transactionCommittedEventImpl(partition, (YugabyteDBOffsetContext) offset);
+    }
+
+    private void enqueueTransactionMessage(SourceRecord record) throws InterruptedException {
+        queue.enqueue(new DataChangeEvent(record));
+    }
+
+    private void enqueueHeartbeat(SourceRecord record) throws InterruptedException {
+        queue.enqueue(new DataChangeEvent(record));
+    }
+
     private void enqueueLogicalDecodingMessage(SourceRecord record) throws InterruptedException {
         queue.enqueue(new DataChangeEvent(record));
+    }
+
+    private final class YugabyteDBStreamingChangeRecordReceiver implements ChangeRecordEmitter.Receiver<YBPartition> {
+        @Override
+        public void changeRecord(YBPartition partition,
+                                 DataCollectionSchema dataCollectionSchema,
+                                 Envelope.Operation operation,
+                                 Object key, Struct value,
+                                 OffsetContext offsetContext,
+                                 ConnectHeaders headers) throws InterruptedException {
+            Objects.requireNonNull(value, "value must not be null");
+
+            LOGGER.trace("Received change record for {} operation on key {}", operation, key);
+
+            // Truncate events must have null key schema as they are sent to table topics without keys
+            Schema keySchema = (key == null && operation == Envelope.Operation.TRUNCATE) ? null
+                                 : dataCollectionSchema.keySchema();
+            String topicName = topicSelector.topicNameFor((T) dataCollectionSchema.id());
+
+            SourceRecord record = new SourceRecord(partition.getSourcePartition(),
+              offsetContext.getOffset(),
+              topicName, null,
+              keySchema, key,
+              dataCollectionSchema.getEnvelopeSchema().schema(),
+              value,
+              null,
+              headers);
+
+            queue.enqueue(changeEventCreator.createDataChangeEvent(record));
+
+            if (emitTombstonesOnDelete && operation == Envelope.Operation.DELETE) {
+                SourceRecord tombStone = record.newRecord(
+                  record.topic(),
+                  record.kafkaPartition(),
+                  record.keySchema(),
+                  record.key(),
+                  null, // value schema
+                  null, // value
+                  record.timestamp(),
+                  record.headers());
+
+                queue.enqueue(changeEventCreator.createDataChangeEvent(tombStone));
+            }
+        }
     }
 }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBEventDispatcher.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBEventDispatcher.java
@@ -61,21 +61,6 @@ public class YugabyteDBEventDispatcher<T extends DataCollectionId> extends Event
     private final YugabyteDBTransactionMonitor transactionMonitor;
     private final YugabyteDBStreamingChangeRecordReceiver streamingReceiver;
 
-//    public YugabyteDBEventDispatcher(YugabyteDBConnectorConfig connectorConfig, TopicSelector<T> topicSelector,
-//                                   DatabaseSchema<T> schema, ChangeEventQueue<DataChangeEvent> queue, DataCollectionFilters.DataCollectionFilter<T> filter,
-//                                   ChangeEventCreator changeEventCreator, EventMetadataProvider metadataProvider, SchemaNameAdjuster schemaNameAdjuster) {
-//        this(connectorConfig, topicSelector, schema, queue, filter, changeEventCreator, null, metadataProvider,
-//                new HeartbeatFactory<>(connectorConfig, topicSelector, schemaNameAdjuster), schemaNameAdjuster, null);
-//    }
-//
-//    public YugabyteDBEventDispatcher(YugabyteDBConnectorConfig connectorConfig, TopicSelector<T> topicSelector,
-//                                   DatabaseSchema<T> schema, ChangeEventQueue<DataChangeEvent> queue, DataCollectionFilters.DataCollectionFilter<T> filter,
-//                                   ChangeEventCreator changeEventCreator, EventMetadataProvider metadataProvider,
-//                                     HeartbeatFactory<T> heartbeatFactory, SchemaNameAdjuster schemaNameAdjuster) {
-//        this(connectorConfig, topicSelector, schema, queue, filter, changeEventCreator, null, metadataProvider,
-//                heartbeatFactory, schemaNameAdjuster, null);
-//    }
-
     public YugabyteDBEventDispatcher(YugabyteDBConnectorConfig connectorConfig, TopicSelector<T> topicSelector,
                                    DatabaseSchema<T> schema, ChangeEventQueue<DataChangeEvent> queue, DataCollectionFilters.DataCollectionFilter<T> filter,
                                    ChangeEventCreator changeEventCreator, InconsistentSchemaHandler<YBPartition, T> inconsistentSchemaHandler,
@@ -106,8 +91,7 @@ public class YugabyteDBEventDispatcher<T extends DataCollectionId> extends Event
             throws InterruptedException {
         if (messageFilter.isIncluded(message.getPrefix())) {
             logicalDecodingMessageMonitor.logicalDecodingMessageEvent(partition, offset, decodeTimestamp, message);
-        }
-        else {
+        } else {
             LOGGER.trace("Filtered data change event for logical decoding message with prefix{}", message.getPrefix());
         }
     }
@@ -195,7 +179,6 @@ public class YugabyteDBEventDispatcher<T extends DataCollectionId> extends Event
 
     @Override
     public void dispatchTransactionCommittedEvent(YBPartition partition, OffsetContext offset) throws InterruptedException {
-        LOGGER.info("Called dispatchTransationCommittedEvent in dispatcher");
         this.transactionMonitor.transactionCommittedEventImpl(partition, (YugabyteDBOffsetContext) offset);
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBEventDispatcher.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBEventDispatcher.java
@@ -173,7 +173,6 @@ public class YugabyteDBEventDispatcher<T extends DataCollectionId> extends Event
 
     @Override
     public void dispatchTransactionStartedEvent(YBPartition partition, String transactionId, OffsetContext offset) throws InterruptedException {
-        LOGGER.info("Called dispatchTransactionStartedEvent in dispatcher");
         this.transactionMonitor.transactionStartedEvent(partition, transactionId, offset);
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBEventDispatcher.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBEventDispatcher.java
@@ -39,7 +39,7 @@ import java.util.Optional;
 /**
  * Custom extension of the {@link EventDispatcher} to accommodate routing {@link LogicalDecodingMessage} events to the change event queue.
  *
- * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
+ * @author Rajat Venkatesh, Vaibhav Kushwaha
  */
 public class YugabyteDBEventDispatcher<T extends DataCollectionId> extends EventDispatcher<YBPartition, T> {
     private static final Logger LOGGER = LoggerFactory.getLogger(YugabyteDBEventDispatcher.class);
@@ -145,11 +145,7 @@ public class YugabyteDBEventDispatcher<T extends DataCollectionId> extends Event
                 handled = true;
             }
 
-            // TODO Vaibhav: Remove this as we do not use any heartbeat events
-//            heartbeat.heartbeat(
-//              changeRecordEmitter.getPartition().getSourcePartition(),
-//              changeRecordEmitter.getOffset().getOffset(),
-//              this::enqueueHeartbeat);
+            // TODO: Add heartbeat event processing here if required.
 
             return handled;
         } catch (Exception e) {
@@ -182,10 +178,6 @@ public class YugabyteDBEventDispatcher<T extends DataCollectionId> extends Event
     }
 
     private void enqueueTransactionMessage(SourceRecord record) throws InterruptedException {
-        queue.enqueue(new DataChangeEvent(record));
-    }
-
-    private void enqueueHeartbeat(SourceRecord record) throws InterruptedException {
         queue.enqueue(new DataChangeEvent(record));
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBEventDispatcher.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBEventDispatcher.java
@@ -39,7 +39,7 @@ import java.util.Optional;
 /**
  * Custom extension of the {@link EventDispatcher} to accommodate routing {@link LogicalDecodingMessage} events to the change event queue.
  *
- * @author Lairen Hightower
+ * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
  */
 public class YugabyteDBEventDispatcher<T extends DataCollectionId> extends EventDispatcher<YBPartition, T> {
     private static final Logger LOGGER = LoggerFactory.getLogger(YugabyteDBEventDispatcher.class);
@@ -189,11 +189,13 @@ public class YugabyteDBEventDispatcher<T extends DataCollectionId> extends Event
 
     @Override
     public void dispatchTransactionStartedEvent(YBPartition partition, String transactionId, OffsetContext offset) throws InterruptedException {
+        LOGGER.info("Called dispatchTransactionStartedEvent in dispatcher");
         this.transactionMonitor.transactionStartedEvent(partition, transactionId, offset);
     }
 
     @Override
     public void dispatchTransactionCommittedEvent(YBPartition partition, OffsetContext offset) throws InterruptedException {
+        LOGGER.info("Called dispatchTransationCommittedEvent in dispatcher");
         this.transactionMonitor.transactionCommittedEventImpl(partition, (YugabyteDBOffsetContext) offset);
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -42,7 +42,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
     private OpId lastCompletelyProcessedLsn;
     private OpId lastCommitLsn;
     private OpId streamingStoppingLsn = null;
-    private TransactionContext transactionContext;
+    private YugabyteDBTransactionContext transactionContext;
     private IncrementalSnapshotContext<TableId> incrementalSnapshotContext;
     private YugabyteDBConnectorConfig connectorConfig;
 
@@ -53,7 +53,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
                                     Instant time,
                                     boolean snapshot,
                                     boolean lastSnapshotRecord,
-                                    TransactionContext transactionContext,
+                                    YugabyteDBTransactionContext transactionContext,
                                     IncrementalSnapshotContext<TableId> incrementalSnapshotContext) {
         sourceInfo = new SourceInfo(connectorConfig);
         this.tabletSourceInfo = new ConcurrentHashMap();
@@ -92,7 +92,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
             }
         }
         LOGGER.debug("Populating the tabletsourceinfo with " + this.getTabletSourceInfo());
-        this.transactionContext = new TransactionContext();
+        this.transactionContext = new YugabyteDBTransactionContext();
         this.incrementalSnapshotContext = new SignalBasedIncrementalSnapshotContext<>();
         this.connectorConfig = config;
     }
@@ -133,7 +133,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
                 clock.currentTimeAsInstant(),
                 false,
                 false,
-                new TransactionContext(),
+                new YugabyteDBTransactionContext(),
                 new SignalBasedIncrementalSnapshotContext<>());
         for (YBPartition p : partitions) {
             if (context.getTabletSourceInfo().get(p.getId()) == null) {
@@ -434,7 +434,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
                     lastCompletelyProcessedLsn,
                     lastCompletelyProcessedLsn,
                     "txId", Instant.MIN, false, false,
-                    TransactionContext.load(offset),
+                    YugabyteDBTransactionContext.load(offset),
                     SignalBasedIncrementalSnapshotContext.load(offset));
 
         }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -413,7 +413,6 @@ public class YugabyteDBStreamingChangeEventSource implements
                             try {
                                 // Tx BEGIN/END event
                                 if (message.isTransactionalMessage()) {
-                                    LOGGER.info("Yes, message is a transactional message");
                                     if (!connectorConfig.shouldProvideTransactionMetadata()) {
                                         LOGGER.debug("Received transactional message {}", record);
                                         // Don't skip on BEGIN message as it would flush LSN for the whole transaction

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionContext.java
@@ -18,23 +18,17 @@ import org.slf4j.LoggerFactory;
  */
 public class YugabyteDBTransactionContext extends TransactionContext {
 	private static final Logger LOGGER = LoggerFactory.getLogger(YugabyteDBTransactionContext.class);
-	private static final String OFFSET_TRANSACTION_ID = TransactionMonitor.DEBEZIUM_TRANSACTION_KEY + "_" + TransactionMonitor.DEBEZIUM_TRANSACTION_ID_KEY;
-	private static final String OFFSET_TABLE_COUNT_PREFIX = TransactionMonitor.DEBEZIUM_TRANSACTION_KEY + "_"
-																														+ TransactionMonitor.DEBEZIUM_TRANSACTION_DATA_COLLECTION_ORDER_KEY + "_";
+	private static final String OFFSET_TRANSACTION_ID = TransactionMonitor.DEBEZIUM_TRANSACTION_KEY
+			+ "_" + TransactionMonitor.DEBEZIUM_TRANSACTION_ID_KEY;
+	private static final String OFFSET_TABLE_COUNT_PREFIX =
+		TransactionMonitor.DEBEZIUM_TRANSACTION_KEY + "_"
+			+ TransactionMonitor.DEBEZIUM_TRANSACTION_DATA_COLLECTION_ORDER_KEY + "_";
 	private static final int OFFSET_TABLE_COUNT_PREFIX_LENGTH = OFFSET_TABLE_COUNT_PREFIX.length();
-	private String transactionId = null;
 
 	private Map<String, String> partitionTransactions = new HashMap<>();
 	private Map<String, Long> partitionTotalEventCount = new HashMap<>();
-	private final Map<String, Long> perTableEventCount = new HashMap<>();
-	private final Map<String, Long> viewPerTableEventCount = Collections.unmodifiableMap(perTableEventCount);
-	private long totalEventCount = 0;
-
-	private void reset() {
-		transactionId = null;
-		totalEventCount = 0;
-		perTableEventCount.clear();
-	}
+//	private final Map<String, Long> perTableEventCount = new HashMap<>();
+//	private final Map<String, Long> viewPerTableEventCount = Collections.unmodifiableMap(perTableEventCount);
 
 	private void reset(String partitionId) {
 		partitionTransactions.put(partitionId, null);
@@ -42,20 +36,19 @@ public class YugabyteDBTransactionContext extends TransactionContext {
 	}
 
 	public static YugabyteDBTransactionContext load(Map<String, ?> offsets) {
+		// TODO Vaibhav: Do we actually load any transaction context from offsets? If not, remove this.
 		final Map<String, Object> o = (Map<String, Object>) offsets;
 		final YugabyteDBTransactionContext context = new YugabyteDBTransactionContext();
 
-		context.transactionId = (String) o.get(OFFSET_TRANSACTION_ID);
-
-		for (final Map.Entry<String, Object> offset : o.entrySet()) {
-			if (offset.getKey().startsWith(OFFSET_TABLE_COUNT_PREFIX)) {
-				final String dataCollectionId = offset.getKey().substring(OFFSET_TABLE_COUNT_PREFIX_LENGTH);
-				final Long count = (Long) offset.getValue();
-				context.perTableEventCount.put(dataCollectionId, count);
-			}
-		}
-
-		context.totalEventCount = context.perTableEventCount.values().stream().mapToLong(x -> x).sum();
+//		context.transactionId = (String) o.get(OFFSET_TRANSACTION_ID);
+//
+//		for (final Map.Entry<String, Object> offset : o.entrySet()) {
+//			if (offset.getKey().startsWith(OFFSET_TABLE_COUNT_PREFIX)) {
+//				final String dataCollectionId = offset.getKey().substring(OFFSET_TABLE_COUNT_PREFIX_LENGTH);
+//				final Long count = (Long) offset.getValue();
+//				context.perTableEventCount.put(dataCollectionId, count);
+//			}
+//		}
 
 		return context;
 	}
@@ -73,12 +66,10 @@ public class YugabyteDBTransactionContext extends TransactionContext {
 	}
 
 	public void beginTransaction(YBPartition partition, String txId) {
-		LOGGER.info("Putting txID {} for partition {}", txId, partition.getId());
 		partitionTransactions.put(partition.getId(), txId);
 	}
 
 	public void endTransaction(YBPartition partition) {
-		LOGGER.info("Inside endTransaction in txn context");
 		reset(partition.getId());
 	}
 
@@ -86,21 +77,47 @@ public class YugabyteDBTransactionContext extends TransactionContext {
 		return partitionTotalEventCount.merge(partition.getId(), 1L, Long::sum);
 	}
 
-	public long event(DataCollectionId source) {
-		totalEventCount++;
-		final String sourceName = source.toString();
-		final long dataCollectionEventOrder = perTableEventCount.getOrDefault(sourceName, 0L) + 1;
-		perTableEventCount.put(sourceName, dataCollectionEventOrder);
-		return dataCollectionEventOrder;
+	public String toString(YBPartition partition) {
+		if (partitionTransactions.get(partition.getId()) == null) {
+			LOGGER.warn("No transaction in progress for given partition ID {}, returning empty string", partition.getId());
+			return "";
+		}
+
+		return String.format("YugabyteDBTransactionContext[partition=%s transaction_id=%s totalEventCount=%d]",
+			partition.getId(), partitionTransactions.get(partition.getId()),
+			partitionTotalEventCount.get(partition.getId()));
 	}
 
-	public Map<String, Long> getPerTableEventCount() {
-		return viewPerTableEventCount;
+	// Override the existing functions to throw exceptions if used anywhere to restrict their usage
+	// as they may cause issues.
+
+	@Override
+	public long event(DataCollectionId source) {
+		throw new UnsupportedOperationException("event(DataCollectionId) is not implemented, use event(YBPartition, DataCollectionId)");
 	}
 
 	@Override
-	public String toString() {
-		return "YugabyteDBTransactionContext [currentTransactionId=" + transactionId + ", perTableEventCount="
-						 + perTableEventCount + ", totalEventCount=" + totalEventCount + "]";
+	public boolean isTransactionInProgress() {
+		throw new UnsupportedOperationException("isTransactionInProgress() is not implemented, use isTransactionInProgress(YBPartition)");
+	}
+
+	@Override
+	public void beginTransaction(String txId) {
+		throw new UnsupportedOperationException("beginTransaction(String) is not implemented, use beginTransaction(YBPartition, String)");
+	}
+
+	@Override
+	public long getTotalEventCount() {
+		throw new UnsupportedOperationException("getTotalEventCount() is not implemented, use getTotalEventCount(YBPartition)");
+	}
+
+	@Override
+	public void endTransaction() {
+		throw new UnsupportedOperationException("endTransaction() is not implemented, use endTransaction(YBPartition)");
+	}
+
+	@Override
+	public String getTransactionId() {
+		throw new UnsupportedOperationException("getTransactionId() is not supported, use getTransactionId(YBPartition)");
 	}
 }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionContext.java
@@ -1,0 +1,100 @@
+package io.debezium.connector.yugabytedb;
+
+import io.debezium.pipeline.txmetadata.TransactionContext;
+import io.debezium.pipeline.txmetadata.TransactionMonitor;
+import io.debezium.schema.DataCollectionId;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Class to manage the distributed transaction related events for YugabyteDB.
+ *
+ * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
+ */
+public class YugabyteDBTransactionContext extends TransactionContext {
+	private static final String OFFSET_TRANSACTION_ID = TransactionMonitor.DEBEZIUM_TRANSACTION_KEY + "_" + TransactionMonitor.DEBEZIUM_TRANSACTION_ID_KEY;
+	private static final String OFFSET_TABLE_COUNT_PREFIX = TransactionMonitor.DEBEZIUM_TRANSACTION_KEY + "_"
+																														+ TransactionMonitor.DEBEZIUM_TRANSACTION_DATA_COLLECTION_ORDER_KEY + "_";
+	private static final int OFFSET_TABLE_COUNT_PREFIX_LENGTH = OFFSET_TABLE_COUNT_PREFIX.length();
+	private String transactionId = null;
+
+	private Map<String, String> partitionTransactions;
+	private Map<String, Long> partitionTotalEventCount = new HashMap<>();
+	private final Map<String, Long> perTableEventCount = new HashMap<>();
+	private final Map<String, Long> viewPerTableEventCount = Collections.unmodifiableMap(perTableEventCount);
+	private long totalEventCount = 0;
+
+	private void reset() {
+		transactionId = null;
+		totalEventCount = 0;
+		perTableEventCount.clear();
+	}
+
+	private void reset(String partitionId) {
+		partitionTransactions.put(partitionId, null);
+		partitionTotalEventCount.put(partitionId, 0L);
+	}
+
+	public static YugabyteDBTransactionContext load(Map<String, ?> offsets) {
+		final Map<String, Object> o = (Map<String, Object>) offsets;
+		final YugabyteDBTransactionContext context = new YugabyteDBTransactionContext();
+
+		context.transactionId = (String) o.get(OFFSET_TRANSACTION_ID);
+
+		for (final Map.Entry<String, Object> offset : o.entrySet()) {
+			if (offset.getKey().startsWith(OFFSET_TABLE_COUNT_PREFIX)) {
+				final String dataCollectionId = offset.getKey().substring(OFFSET_TABLE_COUNT_PREFIX_LENGTH);
+				final Long count = (Long) offset.getValue();
+				context.perTableEventCount.put(dataCollectionId, count);
+			}
+		}
+
+		context.totalEventCount = context.perTableEventCount.values().stream().mapToLong(x -> x).sum();
+
+		return context;
+	}
+
+	public boolean isTransactionInProgress(YBPartition partition) {
+		return partitionTransactions.get(partition.getId()) != null;
+	}
+
+	public String getTransactionId(YBPartition partition) {
+		return partitionTransactions.get(partition.getId());
+	}
+
+	public long getTotalEventCount(YBPartition partition) {
+		return partitionTotalEventCount.get(partition.getId());
+	}
+
+	public void beginTransaction(YBPartition partition, String txId) {
+		partitionTransactions.put(partition.getId(), txId);
+	}
+
+	public void endTransaction(YBPartition partition) {
+		reset(partition.getId());
+	}
+
+	public long event(YBPartition partition, DataCollectionId source) {
+		return partitionTotalEventCount.merge(partition.getId(), 1L, Long::sum);
+	}
+
+	public long event(DataCollectionId source) {
+		totalEventCount++;
+		final String sourceName = source.toString();
+		final long dataCollectionEventOrder = perTableEventCount.getOrDefault(sourceName, 0L) + 1;
+		perTableEventCount.put(sourceName, dataCollectionEventOrder);
+		return dataCollectionEventOrder;
+	}
+
+	public Map<String, Long> getPerTableEventCount() {
+		return viewPerTableEventCount;
+	}
+
+	@Override
+	public String toString() {
+		return "YugabyteDBTransactionContext [currentTransactionId=" + transactionId + ", perTableEventCount="
+						 + perTableEventCount + ", totalEventCount=" + totalEventCount + "]";
+	}
+}

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionContext.java
@@ -8,19 +8,23 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Class to manage the distributed transaction related events for YugabyteDB.
  *
  * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
  */
 public class YugabyteDBTransactionContext extends TransactionContext {
+	private static final Logger LOGGER = LoggerFactory.getLogger(YugabyteDBTransactionContext.class);
 	private static final String OFFSET_TRANSACTION_ID = TransactionMonitor.DEBEZIUM_TRANSACTION_KEY + "_" + TransactionMonitor.DEBEZIUM_TRANSACTION_ID_KEY;
 	private static final String OFFSET_TABLE_COUNT_PREFIX = TransactionMonitor.DEBEZIUM_TRANSACTION_KEY + "_"
 																														+ TransactionMonitor.DEBEZIUM_TRANSACTION_DATA_COLLECTION_ORDER_KEY + "_";
 	private static final int OFFSET_TABLE_COUNT_PREFIX_LENGTH = OFFSET_TABLE_COUNT_PREFIX.length();
 	private String transactionId = null;
 
-	private Map<String, String> partitionTransactions;
+	private Map<String, String> partitionTransactions = new HashMap<>();
 	private Map<String, Long> partitionTotalEventCount = new HashMap<>();
 	private final Map<String, Long> perTableEventCount = new HashMap<>();
 	private final Map<String, Long> viewPerTableEventCount = Collections.unmodifiableMap(perTableEventCount);
@@ -69,10 +73,12 @@ public class YugabyteDBTransactionContext extends TransactionContext {
 	}
 
 	public void beginTransaction(YBPartition partition, String txId) {
+		LOGGER.info("Putting txID {} for partition {}", txId, partition.getId());
 		partitionTransactions.put(partition.getId(), txId);
 	}
 
 	public void endTransaction(YBPartition partition) {
+		LOGGER.info("Inside endTransaction in txn context");
 		reset(partition.getId());
 	}
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionContext.java
@@ -4,7 +4,6 @@ import io.debezium.pipeline.txmetadata.TransactionContext;
 import io.debezium.pipeline.txmetadata.TransactionMonitor;
 import io.debezium.schema.DataCollectionId;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,8 +26,6 @@ public class YugabyteDBTransactionContext extends TransactionContext {
 
 	private Map<String, String> partitionTransactions = new HashMap<>();
 	private Map<String, Long> partitionTotalEventCount = new HashMap<>();
-//	private final Map<String, Long> perTableEventCount = new HashMap<>();
-//	private final Map<String, Long> viewPerTableEventCount = Collections.unmodifiableMap(perTableEventCount);
 
 	private void reset(String partitionId) {
 		partitionTransactions.put(partitionId, null);
@@ -39,16 +36,6 @@ public class YugabyteDBTransactionContext extends TransactionContext {
 		// TODO Vaibhav: Do we actually load any transaction context from offsets? If not, remove this.
 		final Map<String, Object> o = (Map<String, Object>) offsets;
 		final YugabyteDBTransactionContext context = new YugabyteDBTransactionContext();
-
-//		context.transactionId = (String) o.get(OFFSET_TRANSACTION_ID);
-//
-//		for (final Map.Entry<String, Object> offset : o.entrySet()) {
-//			if (offset.getKey().startsWith(OFFSET_TABLE_COUNT_PREFIX)) {
-//				final String dataCollectionId = offset.getKey().substring(OFFSET_TABLE_COUNT_PREFIX_LENGTH);
-//				final Long count = (Long) offset.getValue();
-//				context.perTableEventCount.put(dataCollectionId, count);
-//			}
-//		}
 
 		return context;
 	}

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionMonitor.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionMonitor.java
@@ -152,6 +152,7 @@ public class YugabyteDBTransactionMonitor extends TransactionMonitor {
 		final Struct value = new Struct(transactionValueSchema);
 		value.put(DEBEZIUM_TRANSACTION_STATUS_KEY, TransactionStatus.BEGIN.name());
 		value.put(DEBEZIUM_TRANSACTION_ID_KEY, transactionContext.getTransactionId(partition));
+		value.put(PARTITION_ID_KEY, partition.getId());
 
 		sender.accept(new SourceRecord(partition.getSourcePartition(), offsetContext.getOffset(),
 			topicName, null, key.schema(), key, value.schema(), value));

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionMonitor.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionMonitor.java
@@ -1,0 +1,171 @@
+package io.debezium.connector.yugabytedb;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.data.Envelope;
+import io.debezium.function.BlockingConsumer;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.spi.Partition;
+import io.debezium.pipeline.txmetadata.TransactionMonitor;
+import io.debezium.pipeline.txmetadata.TransactionStatus;
+import io.debezium.schema.DataCollectionId;
+import io.debezium.util.SchemaNameAdjuster;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+public class YugabyteDBTransactionMonitor extends TransactionMonitor {
+	private static final Logger LOGGER = LoggerFactory.getLogger(YugabyteDBTransactionMonitor.class);
+
+	private final Schema transactionKeySchema;
+	private final Schema transactionValueSchema;
+	private final EventMetadataProvider eventMetadataProvider;
+	private final String topicName;
+	private final BlockingConsumer<SourceRecord> sender;
+	private final CommonConnectorConfig connectorConfig;
+
+	public static final Schema TRANSACTION_BLOCK_SCHEMA = SchemaBuilder.struct().optional()
+																													.field(DEBEZIUM_TRANSACTION_ID_KEY, Schema.STRING_SCHEMA)
+																													.field(DEBEZIUM_TRANSACTION_TOTAL_ORDER_KEY, Schema.INT64_SCHEMA)
+																													.field(DEBEZIUM_TRANSACTION_DATA_COLLECTION_ORDER_KEY, Schema.INT64_SCHEMA)
+																													.build();
+
+	private static final Schema EVENT_COUNT_PER_DATA_COLLECTION_SCHEMA = SchemaBuilder.struct()
+																																				 .field(DEBEZIUM_TRANSACTION_COLLECTION_KEY, Schema.STRING_SCHEMA)
+																																				 .field(DEBEZIUM_TRANSACTION_EVENT_COUNT_KEY, Schema.INT64_SCHEMA)
+																																				 .build();
+	public YugabyteDBTransactionMonitor(CommonConnectorConfig connectorConfig, EventMetadataProvider eventMetadataProvider, SchemaNameAdjuster schemaNameAdjuster, BlockingConsumer<SourceRecord> sender) {
+		super(connectorConfig, eventMetadataProvider, schemaNameAdjuster, sender);
+		Objects.requireNonNull(eventMetadataProvider);
+
+		transactionKeySchema = SchemaBuilder.struct()
+														 .name(schemaNameAdjuster.adjust("io.debezium.connector.common.TransactionMetadataKey"))
+														 .field(DEBEZIUM_TRANSACTION_ID_KEY, Schema.STRING_SCHEMA)
+														 .build();
+
+		transactionValueSchema = SchemaBuilder.struct()
+															 .name(schemaNameAdjuster.adjust("io.debezium.connector.common.TransactionMetadataValue"))
+															 .field(DEBEZIUM_TRANSACTION_STATUS_KEY, Schema.STRING_SCHEMA)
+															 .field(DEBEZIUM_TRANSACTION_ID_KEY, Schema.STRING_SCHEMA)
+															 .field(DEBEZIUM_TRANSACTION_EVENT_COUNT_KEY, Schema.OPTIONAL_INT64_SCHEMA)
+															 .field(DEBEZIUM_TRANSACTION_DATA_COLLECTIONS_KEY, SchemaBuilder.array(EVENT_COUNT_PER_DATA_COLLECTION_SCHEMA).optional().build())
+															 .build();
+
+		this.topicName = connectorConfig.getTransactionTopic();
+		this.eventMetadataProvider = eventMetadataProvider;
+		this.sender = sender;
+		this.connectorConfig = connectorConfig;
+	}
+
+	@Override
+	public void dataEvent(Partition partition, DataCollectionId source, OffsetContext offset, Object key, Struct value) throws InterruptedException {
+		dataEventImpl((YBPartition) partition, source, (YugabyteDBOffsetContext) offset, key, value);
+	}
+
+	private void dataEventImpl(YBPartition partition, DataCollectionId source, YugabyteDBOffsetContext offset, Object key, Struct value) throws InterruptedException {
+		if (!connectorConfig.shouldProvideTransactionMetadata()) {
+			return;
+		}
+		final YugabyteDBTransactionContext transactionContext = (YugabyteDBTransactionContext) offset.getTransactionContext();
+
+		final String txId = eventMetadataProvider.getTransactionId(source, offset, key, value);
+		if (txId == null) {
+			if (LOGGER.isTraceEnabled()) {
+				LOGGER.trace("Event '{}' has no transaction id", eventMetadataProvider.toSummaryString(source, offset, key, value));
+			}
+			return;
+		}
+
+		if (!transactionContext.isTransactionInProgress(partition)) {
+			transactionContext.beginTransaction(txId);
+			beginTransaction(partition, offset);
+		}
+		else if (!transactionContext.getTransactionId(partition).equals(txId)) {
+			LOGGER.info("Received a different transaction ID ({}) for the partition {} with another transaction ({}) in progress", txId, partition.getId(), transactionContext.getTransactionId(partition));
+//			endTransaction(partition, offset);
+//			transactionContext.endTransaction();
+//			transactionContext.beginTransaction(txId);
+//			beginTransaction(partition, offset);
+		}
+		transactionEvent(partition, offset, source, value);
+	}
+
+	private void transactionEvent(YBPartition partition, YugabyteDBOffsetContext offsetContext, DataCollectionId source, Struct value) {
+		YugabyteDBTransactionContext transactionContext = (YugabyteDBTransactionContext) offsetContext.getTransactionContext();
+		final long dataCollectionEventOrder = transactionContext.event(partition, source);
+		if (value == null) {
+			LOGGER.debug("Event with key {} without value. Cannot enrich source block.");
+			return;
+		}
+		final Struct txStruct = new Struct(TRANSACTION_BLOCK_SCHEMA);
+		txStruct.put(DEBEZIUM_TRANSACTION_ID_KEY, transactionContext.getTransactionId(partition));
+		txStruct.put(DEBEZIUM_TRANSACTION_TOTAL_ORDER_KEY, transactionContext.getTotalEventCount(partition));
+		txStruct.put(DEBEZIUM_TRANSACTION_DATA_COLLECTION_ORDER_KEY, dataCollectionEventOrder);
+		value.put(Envelope.FieldName.TRANSACTION, txStruct);
+	}
+
+	public void transactionStartedEvent(Partition partition, String transactionId, OffsetContext offset) throws InterruptedException {
+		if (!connectorConfig.shouldProvideTransactionMetadata()) {
+			return;
+		}
+		offset.getTransactionContext().beginTransaction(transactionId);
+		beginTransaction((YBPartition) partition, (YugabyteDBOffsetContext) offset);
+	}
+
+	public void transactionComittedEvent(Partition partition, OffsetContext offset) throws InterruptedException {
+		transactionCommittedEventImpl((YBPartition) partition, (YugabyteDBOffsetContext) offset);
+	}
+
+	public void transactionCommittedEventImpl(YBPartition partition, YugabyteDBOffsetContext offsetContext) throws InterruptedException {
+		if (!connectorConfig.shouldProvideTransactionMetadata()) {
+			return;
+		}
+
+		YugabyteDBTransactionContext transactionContext = (YugabyteDBTransactionContext) offsetContext.getTransactionContext();
+		if (transactionContext.isTransactionInProgress(partition)) {
+			endTransaction(partition, offsetContext);
+		}
+
+		transactionContext.endTransaction(partition);
+	}
+
+	private void beginTransaction(YBPartition partition, YugabyteDBOffsetContext offsetContext) throws InterruptedException {
+		YugabyteDBTransactionContext transactionContext = (YugabyteDBTransactionContext) offsetContext.getTransactionContext();
+		final Struct key = new Struct(transactionKeySchema);
+		key.put(DEBEZIUM_TRANSACTION_ID_KEY, transactionContext.getTransactionId(partition));
+		final Struct value = new Struct(transactionValueSchema);
+		value.put(DEBEZIUM_TRANSACTION_STATUS_KEY, TransactionStatus.BEGIN.name());
+		value.put(DEBEZIUM_TRANSACTION_ID_KEY, transactionContext.getTransactionId(partition));
+
+		sender.accept(new SourceRecord(partition.getSourcePartition(), offsetContext.getOffset(),
+			topicName, null, key.schema(), key, value.schema(), value));
+	}
+
+	private void endTransaction(YBPartition partition, OffsetContext offsetContext) throws InterruptedException {
+		YugabyteDBTransactionContext transactionContext = (YugabyteDBTransactionContext) offsetContext.getTransactionContext();
+		final Struct key = new Struct(transactionKeySchema);
+		key.put(DEBEZIUM_TRANSACTION_ID_KEY, transactionContext.getTransactionId(partition));
+		final Struct value = new Struct(transactionValueSchema);
+		value.put(DEBEZIUM_TRANSACTION_STATUS_KEY, TransactionStatus.END.name());
+		value.put(DEBEZIUM_TRANSACTION_ID_KEY, transactionContext.getTransactionId(partition));
+		value.put(DEBEZIUM_TRANSACTION_EVENT_COUNT_KEY, transactionContext.getTotalEventCount(partition));
+
+		final Set<Map.Entry<String, Long>> perTableEventCount = offsetContext.getTransactionContext().getPerTableEventCount().entrySet();
+		final List<Struct> valuePerTableCount = new ArrayList<>(perTableEventCount.size());
+//		for (Map.Entry<String, Long> tableEventCount : perTableEventCount) {
+//			final Struct perTable = new Struct(EVENT_COUNT_PER_DATA_COLLECTION_SCHEMA);
+//			perTable.put(TRANSACTION_COLLECTION_KEY, tableEventCount.getKey());
+//			perTable.put(TRANSACTION_EVENT_COUNT_KEY, tableEventCount.getValue());
+//			valuePerTableCount.add(perTable);
+//		}
+		value.put(DEBEZIUM_TRANSACTION_DATA_COLLECTIONS_KEY, valuePerTableCount);
+
+		sender.accept(new SourceRecord(partition.getSourcePartition(), offsetContext.getOffset(),
+			topicName, null, key.schema(), key, value.schema(), value));
+	}
+}

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionMonitor.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionMonitor.java
@@ -97,10 +97,6 @@ public class YugabyteDBTransactionMonitor extends TransactionMonitor {
 			LOGGER.info("Received a different transaction ID ({}) for the partition {} " +
 									"with another transaction ({}) in progress", txId, partition.getId(),
 									transactionContext.getTransactionId(partition));
-//			endTransaction(partition, offset);
-//			transactionContext.endTransaction();
-//			transactionContext.beginTransaction(txId);
-//			beginTransaction(partition, offset);
 		}
 		transactionEvent(partition, offset, source, value);
 	}
@@ -168,16 +164,7 @@ public class YugabyteDBTransactionMonitor extends TransactionMonitor {
 		value.put(DEBEZIUM_TRANSACTION_EVENT_COUNT_KEY, transactionContext.getTotalEventCount(partition));
 		value.put(PARTITION_ID_KEY, partition.getId());
 
-		// TODO: Skip the block for adding the per table event count unless actual mechanism figured out.
-		// final Set<Map.Entry<String, Long>> perTableEventCount = offsetContext.getTransactionContext().getPerTableEventCount().entrySet();
-		// final List<Struct> valuePerTableCount = new ArrayList<>(perTableEventCount.size());
-//		for (Map.Entry<String, Long> tableEventCount : perTableEventCount) {
-//			final Struct perTable = new Struct(EVENT_COUNT_PER_DATA_COLLECTION_SCHEMA);
-//			perTable.put(TRANSACTION_COLLECTION_KEY, tableEventCount.getKey());
-//			perTable.put(TRANSACTION_EVENT_COUNT_KEY, tableEventCount.getValue());
-//			valuePerTableCount.add(perTable);
-//		}
-		// value.put(DEBEZIUM_TRANSACTION_DATA_COLLECTIONS_KEY, valuePerTableCount);
+		// TODO: Process and add per table event count here if required.
 
 		sender.accept(new SourceRecord(partition.getSourcePartition(), offsetContext.getOffset(),
 			topicName, null, key.schema(), key, value.schema(), value));

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/pgproto/YbProtoReplicationMessage.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/pgproto/YbProtoReplicationMessage.java
@@ -74,7 +74,7 @@ public class YbProtoReplicationMessage implements ReplicationMessage {
 
     @Override
     public String getTransactionId() {
-        return rawMessage.getTransactionId() == null ? null : String.valueOf(rawMessage.getTransactionId());
+        return rawMessage.getTransactionId() == null ? null : rawMessage.getTransactionId().toStringUtf8();
     }
 
     @Override

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionMetadataTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionMetadataTest.java
@@ -52,7 +52,7 @@ public class YugabyteDBTransactionMetadataTest extends YugabyteDBContainerTestBa
 	@ValueSource(booleans = {true, false})
 	public void shouldPublishTransactionMetadata(boolean customTopicName) throws Exception {
 		String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_DB_NAME, "t1");
-		Configuration.Builder configBuilder = getConfigBuilderForMetadata(dbStreamId);
+		Configuration.Builder configBuilder = getConfigBuilderForMetadata(dbStreamId, "public.t1");
 
 		String transactionTopicName = TestHelper.TEST_SERVER + ".transaction";
 		if (customTopicName) {
@@ -83,7 +83,7 @@ public class YugabyteDBTransactionMetadataTest extends YugabyteDBContainerTestBa
 	@Test
 	public void assertMultipleTransactions() throws Exception {
 		String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_DB_NAME, "t1");
-		Configuration.Builder configBuilder = getConfigBuilderForMetadata(dbStreamId);
+		Configuration.Builder configBuilder = getConfigBuilderForMetadata(dbStreamId, "public.t1");
 
 		String transactionTopicName = TestHelper.TEST_SERVER + ".transaction";
 
@@ -127,7 +127,8 @@ public class YugabyteDBTransactionMetadataTest extends YugabyteDBContainerTestBa
 		TestHelper.execute(createTable);
 
 		String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_DB_NAME, "test_table");
-		Configuration.Builder configBuilder = getConfigBuilderForMetadata(dbStreamId);
+		Configuration.Builder configBuilder =
+			getConfigBuilderForMetadata(dbStreamId, "public.test_table");
 
 		String transactionTopicName = TestHelper.TEST_SERVER + ".transaction";
 
@@ -162,8 +163,9 @@ public class YugabyteDBTransactionMetadataTest extends YugabyteDBContainerTestBa
 		assertEquals(transactionId1, transactionId2);
 	}
 
-	private Configuration.Builder getConfigBuilderForMetadata(String dbStreamId) throws Exception {
-		Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
+	private Configuration.Builder getConfigBuilderForMetadata(String dbStreamId, String tableName)
+			throws Exception {
+		Configuration.Builder configBuilder = TestHelper.getConfigBuilder(tableName, dbStreamId);
 		configBuilder.with(YugabyteDBConnectorConfig.PROVIDE_TRANSACTION_METADATA, true);
 		return configBuilder;
 	}

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionMetadataTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionMetadataTest.java
@@ -1,0 +1,170 @@
+package io.debezium.connector.yugabytedb;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.*;
+
+import java.sql.SQLException;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class to verify that we are properly sending the transaction metadata to the topic.
+ *
+ * @author Vaibhav Kushwaha
+ */
+public class YugabyteDBTransactionMetadataTest extends YugabyteDBContainerTestBase {
+	// By using generate_series(), we are ensuring that there are explicit transactions.
+	private static final String INSERT_FORMAT =
+		"INSERT INTO t1 VALUES (generate_series(%d,%d), 'fname', 'lname', 12.34);";
+
+	@BeforeAll
+	public static void beforeClass() throws SQLException {
+		initializeYBContainer();
+		TestHelper.dropAllSchemas();
+	}
+
+	@BeforeEach
+	public void before() throws Exception {
+		initializeConnectorTestFramework();
+		TestHelper.executeDDL("yugabyte_create_tables.ddl");
+	}
+
+	@AfterEach
+	public void after() throws Exception {
+		stopConnector();
+		TestHelper.executeDDL("drop_tables_and_databases.ddl");
+	}
+
+	@AfterAll
+	public static void afterClass() {
+		shutdownYBContainer();
+	}
+
+	@ParameterizedTest(name = "Custom topic name: {0}")
+	@ValueSource(booleans = {true, false})
+	public void shouldPublishTransactionMetadata(boolean customTopicName) throws Exception {
+		String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_DB_NAME, "t1");
+		Configuration.Builder configBuilder = getConfigBuilderForMetadata(dbStreamId);
+
+		String transactionTopicName = TestHelper.TEST_SERVER + ".transaction";
+		if (customTopicName) {
+			transactionTopicName = "custom.transaction.topic";
+			configBuilder.with(YugabyteDBConnectorConfig.TRANSACTION_TOPIC, transactionTopicName);
+		}
+
+		start(YugabyteDBConnector.class, configBuilder.build());
+		awaitUntilConnectorIsReady();
+
+		TestHelper.execute(String.format(INSERT_FORMAT, 1, 5));
+
+		// Wait for records to be available for consuming.
+		waitForAvailableRecords(10000, TimeUnit.MILLISECONDS);
+
+		// Consume records
+		SourceRecords records = consumeRecordsByTopic(7 /* BEGIN + 5 INSERT + COMMIT */);
+
+		// Assert for records in the transaction topic.
+		List<SourceRecord> metadataRecords = records.recordsForTopic(transactionTopicName);
+		assertEquals(2, records.recordsForTopic(transactionTopicName).size());
+
+		Struct begin = (Struct) metadataRecords.get(0).value();
+		String transactionId = assertBeginTransaction(metadataRecords.get(0));
+		assertEndTransaction(metadataRecords.get(1), transactionId, 5, begin.getString("partition_id"));
+	}
+
+	@Test
+	public void assertMultipleTransactions() throws Exception {
+		String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_DB_NAME, "t1");
+		Configuration.Builder configBuilder = getConfigBuilderForMetadata(dbStreamId);
+
+		String transactionTopicName = TestHelper.TEST_SERVER + ".transaction";
+
+		start(YugabyteDBConnector.class, configBuilder.build());
+		awaitUntilConnectorIsReady();
+
+		TestHelper.execute(String.format(INSERT_FORMAT, 1, 5));
+
+		TestHelper.execute(String.format(INSERT_FORMAT, 6, 20));
+
+		// Wait for records to be available for consuming.
+		waitForAvailableRecords(10000, TimeUnit.MILLISECONDS);
+
+		// Consume records
+		SourceRecords records = consumeRecordsByTopic(
+			24 /* BEGIN + 5 INSERT + COMMIT + BEGIN + 15 INSERT + COMMIT*/);
+
+		// Assert for records in the transaction topic.
+		List<SourceRecord> metadataRecords = records.recordsForTopic(transactionTopicName);
+		assertEquals(4, records.recordsForTopic(transactionTopicName).size());
+
+		Struct begin1 = (Struct) metadataRecords.get(0).value();
+		String transactionId1 = assertBeginTransaction(metadataRecords.get(0));
+		assertEndTransaction(metadataRecords.get(1), transactionId1, 5,
+												 begin1.getString("partition_id"));
+
+		Struct begin2 = (Struct) metadataRecords.get(2).value();
+		String transactionId2 = assertBeginTransaction(metadataRecords.get(2));
+		assertEndTransaction(metadataRecords.get(3), transactionId2, 15,
+												 begin2.getString("partition_id"));
+
+		// Since there is just one tablet, the partition_id for begin1 and begin2 should be the same.
+		assertEquals(begin1.getString("partition_id"), begin2.getString("partition_id"));
+	}
+
+	@Test
+	public void assertTransactionalDataAcrossMultipleTablets() throws Exception {
+		// This will lead to 2 tablets of range [lowest, 1000] and (1000, highest]
+		final String createTable =
+			"CREATE TABLE test_table (id INT, PRIMARY KEY(id ASC)) SPLIT AT VALUES ((1000));";
+		TestHelper.execute(createTable);
+
+		String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_DB_NAME, "test_table");
+		Configuration.Builder configBuilder = getConfigBuilderForMetadata(dbStreamId);
+
+		String transactionTopicName = TestHelper.TEST_SERVER + ".transaction";
+
+		start(YugabyteDBConnector.class, configBuilder.build());
+		awaitUntilConnectorIsReady();
+
+		TestHelper.execute("INSERT INTO test_table VALUES (generate_series(990, 1010));");
+
+		waitForAvailableRecords(10000, TimeUnit.MILLISECONDS);
+
+		// Consume records
+		SourceRecords records = consumeRecordsByTopic(
+			24 /* BEGIN + 5 INSERT + COMMIT + BEGIN + 15 INSERT + COMMIT*/);
+
+		// Assert for records in the transaction topic.
+		List<SourceRecord> metadataRecords = records.recordsForTopic(transactionTopicName);
+		assertEquals(4, records.recordsForTopic(transactionTopicName).size());
+
+		// Both the begin-commit block are the same and they both belong to the same transaction
+		// thus they will have the same transaction_id.
+		Struct begin1 = (Struct) metadataRecords.get(0).value();
+		String transactionId1 = assertBeginTransaction(metadataRecords.get(0));
+		assertEndTransaction(metadataRecords.get(1), transactionId1, 10,
+			begin1.getString("partition_id"));
+
+		Struct begin2 = (Struct) metadataRecords.get(2).value();
+		String transactionId2 = assertBeginTransaction(metadataRecords.get(2));
+		assertEndTransaction(metadataRecords.get(3), transactionId2, 10,
+			begin2.getString("partition_id"));
+
+		// Since the transaction is the same, the transaction_id should be the same.
+		assertEquals(transactionId1, transactionId2);
+	}
+
+	private Configuration.Builder getConfigBuilderForMetadata(String dbStreamId) throws Exception {
+		Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
+		configBuilder.with(YugabyteDBConnectorConfig.PROVIDE_TRANSACTION_METADATA, true);
+		return configBuilder;
+	}
+}

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionMetadataTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionMetadataTest.java
@@ -120,7 +120,7 @@ public class YugabyteDBTransactionMetadataTest extends YugabyteDBContainerTestBa
 	}
 
 	@Test
-	public void assertTransactionalDataAcrossMultipleTablets() throws Exception {
+	public void verifyTransactionalDataAcrossMultipleTablets() throws Exception {
 		// This will lead to 2 tablets of range [lowest, 1000] and (1000, highest]
 		final String createTable =
 			"CREATE TABLE test_table (id INT, PRIMARY KEY(id ASC)) SPLIT AT VALUES ((1000));";

--- a/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
@@ -6,15 +6,12 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.awaitility.Awaitility;
 
-import org.fest.assertions.Assertions;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.YugabyteYSQLContainer;
 
 import java.time.Duration;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
@@ -2,14 +2,21 @@ package io.debezium.connector.yugabytedb.common;
 
 import io.debezium.connector.yugabytedb.rules.YugabyteDBLogTestName;
 import io.debezium.embedded.AbstractConnectorTest;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
 import org.awaitility.Awaitility;
 
+import org.fest.assertions.Assertions;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.YugabyteYSQLContainer;
 
 import java.time.Duration;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Base class to have common methods and attributes for the containers to be run.
@@ -32,4 +39,43 @@ public class TestBaseClass extends AbstractConnectorTest {
                     return engine.isRunning();
                 });
     }
+
+  @Override
+  protected String assertBeginTransaction(SourceRecord record) {
+    final Struct begin = (Struct) record.value();
+    final Struct beginKey = (Struct) record.key();
+
+    assertEquals("BEGIN", begin.getString("status"));
+    assertNull(begin.getInt64("event_count"));
+
+    final String txId = begin.getString("id");
+    assertEquals(txId, beginKey.getString("id"));
+
+    assertNotNull(begin.getString("partition_id"));
+
+    return txId;
+  }
+
+  /**
+   * Assert that the passed {@link SourceRecord} is a record for END transaction
+   * @param record the record to assert
+   * @param expectedTxId expected transaction ID this record should have
+   * @param expectedEventCount expected event count in the transaction
+   * @param partitionId the partition to which the record belongs, pass null if this assertion needs
+   *                    to be skipped
+   */
+  protected void assertEndTransaction(SourceRecord record, String expectedTxId, long expectedEventCount, String partitionId) {
+    final Struct end = (Struct) record.value();
+    final Struct endKey = (Struct) record.key();
+
+    assertEquals("END", end.getString("status"));
+    assertEquals(expectedTxId, end.getString("id"));
+    assertEquals(expectedEventCount, end.getInt64("event_count"));
+
+    if (partitionId != null) {
+      assertNotNull(end.getString("partition_id"));
+    }
+
+    assertEquals(expectedTxId, endKey.getString("id"));
+  }
 }

--- a/src/test/resources/drop_tables_and_databases.ddl
+++ b/src/test/resources/drop_tables_and_databases.ddl
@@ -1,5 +1,6 @@
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS all_types;
 DROP TABLE IF EXISTS test_enum;
+DROP TYPE IF EXISTS enum_type;
 DROP DATABASE IF EXISTS secondary_database;
 


### PR DESCRIPTION
This PR adds the following changes:
1. Addition of new classes to manage transactions i.e. `YugabyteDBTransactionContext` and `YugabyteDBTransactionMonitor`
    a. Transactions are now monitored at the partition level and are identified by the `partition_id`
    b. The implementation assumes that if two transactions get committed, we will only be seeing records in the order `begin_1` --> `commit_1` --> `begin_2` --> `commit_2`  
3. Addition of tests to verify the functioning of the transaction related classes to ensure that the transactional records are getting published to the respective topic with proper metadata. The tests added are:
    a. Basic publishing of data
    b. Data being published to a configurable topic
    c. Data for multiple transactions is coming in order
    d. Data for multiple tablets published with correct information
5. Modification of an existing DDL file causing issues in test

**Structures of payload:**
* *BEGIN*
    ```
    "payload": {
      "status": "BEGIN",
      "id": "a4855915-16d6-4320-b930-a19b19b63857",
      "event_count": null,
      "data_collections": null,
      "partition_id": "b7a46dc3b9e4474c9753c4a9321391d9"
    }
    ```
* *END*
    ```
    "payload": {
      "status": "END",
      "id": "a4855915-16d6-4320-b930-a19b19b63857",
      "event_count": 10,
      "data_collections": null,
      "partition_id": "b7a46dc3b9e4474c9753c4a9321391d9"
    }
    ```