### PR TITLE
[yugabyte/yugabyte-db#16905] Fix metrics regex 

### DIFF
--- a/metrics.yml
+++ b/metrics.yml
@@ -113,14 +113,14 @@ rules:
       context: "$2"
       table: "$4"
 
-  - pattern: "debezium.([^:]+)<type=connector-metrics, server=([^,]+), task=([^,]+), context=([^,]+), id=([^>]+)>([^:]+)"
+  - pattern: "debezium.([^:]+)<type=connector-metrics, server=([^,]+), task=([^,]+), context=([^,]+), partition=([^>]+)>([^:]+)"
     name: "debezium_metrics_$6"
     labels:
       plugin: "$1"
       name: "$2"
       context: "$4"
       task: "$3"
-      id: "$5"
+      partition: "$5"
 
   - pattern: "debezium.([^:]+)<type=connector-metrics, server=([^,]+), task=([^,]+), context=([^>]+)>([^:]+)"
     name: "debezium_metrics_$5"

--- a/metrics.yml
+++ b/metrics.yml
@@ -113,14 +113,14 @@ rules:
       context: "$2"
       table: "$4"
 
-  - pattern: "debezium.([^:]+)<type=connector-metrics, server=([^,]+), task=([^,]+), context=([^,]+), tablet=([^>]+)>([^:]+)"
+  - pattern: "debezium.([^:]+)<type=connector-metrics, server=([^,]+), task=([^,]+), context=([^,]+), id=([^>]+)>([^:]+)"
     name: "debezium_metrics_$6"
     labels:
       plugin: "$1"
       name: "$2"
       context: "$4"
       task: "$3"
-      tablet: "$5"
+      id: "$5"
 
   - pattern: "debezium.([^:]+)<type=connector-metrics, server=([^,]+), task=([^,]+), context=([^>]+)>([^:]+)"
     name: "debezium_metrics_$5"


### PR DESCRIPTION
This PR modifies the regex to use the partition id instead of just tablet id which we further use to scrape Debezium metrics for Prometheus.

This closes yugabyte/yugabyte-db#16905