### PR TITLE
[yugabyte/yugabyte-db#16928] Add intent count check at the end of each test

### DIFF
--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
@@ -210,6 +210,9 @@ public class YugabyteDBDatatypesTest extends YugabyteDBContainerTestBase {
     @AfterEach
     public void after() throws Exception {
         stopConnector();
+        
+        // Assert that there are no intents remaining after the test.
+        assertEquals(0, getIntentsCount());
         TestHelper.executeDDL("drop_tables_and_databases.ddl");
     }
 
@@ -244,6 +247,11 @@ public class YugabyteDBDatatypesTest extends YugabyteDBContainerTestBase {
 
         // insert rows in the table t1 with values <some-pk, 'Vaibhav', 'Kushwaha', 30>
         insertRecords(recordsCount);
+
+        // TestHelper.waitFor(Duration.ofMinutes(2));
+
+        // Get intent count
+        LOGGER.info("VKVK intent count is {}", getIntentsCount());
 
         CompletableFuture.runAsync(() -> verifyPrimaryKeyOnly(recordsCount))
                 .exceptionally(throwable -> {

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSchemaEvolutionTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSchemaEvolutionTest.java
@@ -43,6 +43,9 @@ public class YugabyteDBSchemaEvolutionTest extends YugabyteDBContainerTestBase {
   @AfterEach
   public void after() throws Exception {
       stopConnector();
+
+      // Assert that there are no intents remaining after the test.
+      assertEquals(0, getIntentsCount());
       TestHelper.executeDDL("drop_tables_and_databases.ddl");
   }
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotResumeTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotResumeTest.java
@@ -44,6 +44,9 @@ public class YugabyteDBSnapshotResumeTest extends YugabyteDBContainerTestBase {
 	@AfterEach
 	public void after() throws Exception {
 		stopConnector();
+
+		// Assert that there are no intents remaining after the test.
+        assertEquals(0, getIntentsCount());
 		TestHelper.executeDDL("drop_tables_and_databases.ddl");
 	}
 

--- a/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
@@ -32,4 +32,8 @@ public class TestBaseClass extends AbstractConnectorTest {
                     return engine.isRunning();
                 });
     }
+
+    protected long getIntentsCount() throws Exception {
+        throw new UnsupportedOperationException("Method getIntentCount is not implemented for " + TestBaseClass.class.toString());
+    }
 }

--- a/src/test/java/io/debezium/connector/yugabytedb/common/YugabyteDBContainerTestBase.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/YugabyteDBContainerTestBase.java
@@ -1,5 +1,7 @@
 package io.debezium.connector.yugabytedb.common;
 
+import org.testcontainers.containers.Container.ExecResult;
+
 import io.debezium.connector.yugabytedb.TestHelper;
 
 /**
@@ -27,5 +29,13 @@ public class YugabyteDBContainerTestBase extends TestBaseClass {
 
     protected static String getMasterAddress() {
         return ybContainer.getHost() + ":" + ybContainer.getMappedPort(7100);
+    }
+
+    @Override
+    protected long getIntentsCount() throws Exception {
+        ExecResult result = ybContainer.execInContainer("/home/yugabyte/bin/yb-ts-cli", "--server_address", "0.0.0.0", "count_intents");
+
+        // Assuming the result is just a number, so simply convert the string to long and return.
+        return Long.valueOf(result.getStdout().split("\n")[0]);
     }
 }

--- a/src/test/java/io/debezium/connector/yugabytedb/common/YugabytedTestBase.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/YugabytedTestBase.java
@@ -34,4 +34,11 @@ public class YugabytedTestBase extends TestBaseClass {
     public String getMasterAddress() {
         return "127.0.0.1:7100";
     }
+
+    @Override
+    protected long getIntentsCount() throws Exception {
+        LOGGER.warn("Method getIntentsCount is not implemented for testing "
+                + "with local yugabyted deployment");
+        return 0;
+    }
 }


### PR DESCRIPTION
This PR adds a method which executes a `yb-ts-cli` command inside the container for YugabyteDB and gets the count of intents present in the DB.