### PR TITLE
[yugabyte/yugabyte-db#16929] Add method to implement yugabyted restart

### DIFF
--- a/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
@@ -425,12 +425,6 @@ public final class TestHelper {
         return container;
     }
 
-    public static String startupCommandString;
-
-    public static String getYBStart() {
-        return startupCommandString;
-    }
-
     public static YugabyteYSQLContainer getYbContainer() {
         return getYbContainer(null, null);
     }

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
@@ -15,7 +15,6 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
 import org.junit.jupiter.api.*;
-import org.yb.client.AsyncYBClient;
 import org.yb.client.GetDBStreamInfoResponse;
 import org.yb.client.YBClient;
 
@@ -264,21 +263,10 @@ public class YugabyteDBDatatypesTest extends YugabyteDBContainerTestBase {
         start(YugabyteDBConnector.class, configBuilder.build());
         awaitUntilConnectorIsReady();
 
-        AsyncYBClient asyncClient = new AsyncYBClient.AsyncYBClientBuilder(getMasterAddress())
-                .defaultAdminOperationTimeoutMs(10000)
-                .defaultOperationTimeoutMs(10000)
-                .defaultSocketReadTimeoutMs(10000)
-                .numTablets(YugabyteDBConnectorConfig.DEFAULT_MAX_NUM_TABLETS)
-                .build();
-
-        YBClient ybClient = new YBClient(asyncClient);
-
-        // Stop manually
-        LOGGER.info("Stop manually");
-        TestHelper.waitFor(Duration.ofMinutes(2));
+        YBClient ybClient = TestHelper.getYbClient(getMasterAddress());
 
         // Stop YugabyteDB instance, this should result in failure of yb-client APIs as well
-        restartYugabyteDB(500);
+        restartYugabyteDB(5000);
 
         GetDBStreamInfoResponse response = ybClient.getDBStreamInfo(dbStreamId);
         assertNotNull(response.getNamespaceId());

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBRestartTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBRestartTest.java
@@ -1,0 +1,97 @@
+package io.debezium.connector.yugabytedb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
+import io.debezium.connector.yugabytedb.connection.YugabyteDBConnection;
+
+public class YugabyteDBRestartTest extends YugabyteDBContainerTestBase {
+    final String formatInsertString = "INSERT INTO t1 VALUES (generate_series(%d,%d), "
+                                        + "'Vaibhav', 'Kushwaha', 30);";
+    @BeforeAll
+    public static void beforeClass() throws SQLException {
+        initializeYBContainer();
+        TestHelper.dropAllSchemas();
+    }
+
+    @BeforeEach
+    public void before() throws Exception {
+        initializeConnectorTestFramework();
+        TestHelper.executeDDL("yugabyte_create_tables.ddl");
+    }
+
+    @AfterEach
+    public void after() throws Exception {
+        stopConnector();
+        TestHelper.executeDDL("drop_tables_and_databases.ddl");
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        shutdownYBContainer();
+    }
+
+    @Test
+    public void verifyStateAfterRestart() throws Exception {
+        final int totalInsertedRecords = 10;
+        // Insert data into the table
+        TestHelper.execute(String.format(formatInsertString, 1, totalInsertedRecords));
+
+        // Obtain a connection and verify the number of records.
+        try (YugabyteDBConnection ybConnection = TestHelper.create()) {
+            Statement st = ybConnection.connection().createStatement();
+
+            ResultSet rs = st.executeQuery("SELECT COUNT(*) FROM t1;");
+            
+            if (rs.next()) {
+                assertEquals(totalInsertedRecords, rs.getInt("count"));
+            } else {
+                fail("Cannot obtain a result set from the database");
+            }
+        }
+
+        // Stop YugabyteDB, wait and verify that it is stopped and then verify record count
+        // after starting it.
+        stopYugabyteDB();
+        
+        boolean queryFailedWhileYugabytedStopped = false;
+        try {
+            TestHelper.execute("SELECT COUNT(*) FROM t1;");
+        } catch (Exception e) {
+            // The above query will fail since YugabyteDB is not running.
+            assertTrue(e.getMessage().contains("The connection attempt failed"));
+            queryFailedWhileYugabytedStopped = true;
+        }
+
+        assertTrue(queryFailedWhileYugabytedStopped);
+
+        // Start YugabyteDB.
+        startYugabyteDB();
+
+
+        // Verify that the record count is the same after restarting the YugabyteDB process.
+        try (YugabyteDBConnection ybConnection = TestHelper.create()) {
+            Statement st = ybConnection.connection().createStatement();
+
+            ResultSet rs = st.executeQuery("SELECT COUNT(*) FROM t1;");
+            
+            if (rs.next()) {
+                assertEquals(totalInsertedRecords, rs.getInt("count"));
+            } else {
+                fail("Cannot obtain a result set from the database");
+            }
+        }
+    }
+}

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTabletSplitTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTabletSplitTest.java
@@ -144,6 +144,12 @@ public class YugabyteDBTabletSplitTest extends YugabyteDBContainerTestBase {
     ybContainer = TestHelper.getYbContainer(masterFlags, tserverFlags);
     ybContainer.start();
 
+    try {
+      ybContainer.execInContainer(getYugabytedStartCommand().split("\\s+"));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
     TestHelper.setContainerHostPort(ybContainer.getHost(), ybContainer.getMappedPort(5433));
     TestHelper.setMasterAddress(ybContainer.getHost() + ":" + ybContainer.getMappedPort(7100));
     

--- a/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
@@ -1,5 +1,6 @@
 package io.debezium.connector.yugabytedb.common;
 
+import io.debezium.connector.yugabytedb.container.YugabyteCustomContainer;
 import io.debezium.connector.yugabytedb.rules.YugabyteDBLogTestName;
 import io.debezium.embedded.AbstractConnectorTest;
 import org.awaitility.Awaitility;
@@ -19,10 +20,12 @@ import java.time.Duration;
 @ExtendWith(YugabyteDBLogTestName.class)
 public class TestBaseClass extends AbstractConnectorTest {
     public Logger LOGGER = LoggerFactory.getLogger(getClass());
-    protected static YugabyteYSQLContainer ybContainer;
+    protected static YugabyteCustomContainer ybContainer;
 
     protected final String DEFAULT_DB_NAME = "yugabyte";
     protected final String DEFAULT_COLOCATED_DB_NAME = "colocated_database";
+
+    protected static String yugabytedStartCommand = "";
 
     protected void awaitUntilConnectorIsReady() throws Exception {
         Awaitility.await()
@@ -41,7 +44,11 @@ public class TestBaseClass extends AbstractConnectorTest {
         throw new UnsupportedOperationException("Method startYugabyteDB not implemented for base test class");
     }
 
-    protected void restartYugabyteDB(long milliseconds) throws Exception {
+    protected void restartYugabyteDB(long millisecondsToWait) throws Exception {
         throw new UnsupportedOperationException("Method restartYugabyteDB not implemented for base test class");
+    }
+
+    protected static String getYugabytedStartCommand() {
+        return yugabytedStartCommand;
     }
 }

--- a/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
@@ -32,4 +32,16 @@ public class TestBaseClass extends AbstractConnectorTest {
                     return engine.isRunning();
                 });
     }
+
+    protected void stopYugabyteDB() throws Exception {
+        throw new UnsupportedOperationException("Method stopYugabyteDB not implemented for base test class");
+    }
+
+    protected void startYugabyteDB() throws Exception {
+        throw new UnsupportedOperationException("Method startYugabyteDB not implemented for base test class");
+    }
+
+    protected void restartYugabyteDB(long milliseconds) throws Exception {
+        throw new UnsupportedOperationException("Method restartYugabyteDB not implemented for base test class");
+    }
 }

--- a/src/test/java/io/debezium/connector/yugabytedb/common/YugabyteDBContainerTestBase.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/YugabyteDBContainerTestBase.java
@@ -1,5 +1,9 @@
 package io.debezium.connector.yugabytedb.common;
 
+import java.time.Duration;
+
+import org.testcontainers.containers.Container.ExecResult;
+
 import io.debezium.connector.yugabytedb.TestHelper;
 
 /**
@@ -27,5 +31,35 @@ public class YugabyteDBContainerTestBase extends TestBaseClass {
 
     protected static String getMasterAddress() {
         return ybContainer.getHost() + ":" + ybContainer.getMappedPort(7100);
+    }
+
+    @Override
+    protected void stopYugabyteDB() throws Exception {
+        ExecResult stopResult = ybContainer.execInContainer("/home/yugabyte/bin/yugabyted", "stop");
+        LOGGER.info("YugabyteDB stopped with output: {} error: {} toString: {}", stopResult.getStdout(), stopResult.getStderr(), stopResult.toString());
+
+        // ExecResult stopResult2 = ybContainer.execInContainer("/home/yugabyte/bin/yb-admin", "--master_addresses", "0.0.0.0:7100", "create_change_data_stream", "ysql.yugabyte");
+        // LOGGER.info("Stop result 2: {}", stopResult2.getStdout());
+    }
+
+    @Override
+    protected void startYugabyteDB() throws Exception {
+        // This assumes that the yugabyted process will start back up again with the same value of flags which
+        // were there before stopping it.
+        ExecResult startResult = ybContainer.execInContainer("/home/yugabyte/bin/yugabyted", "start");
+        LOGGER.info("YugabyteDB started with output: {}", startResult.getStdout());
+    }
+
+    /**
+     * Restart the yugabyted process running in the TestContainer
+     * 
+     * @param milliseconds amount of time (in ms) to wait before starting after stopping
+     */
+    @Override
+    protected void restartYugabyteDB(long milliseconds) throws Exception {
+        stopYugabyteDB();
+
+        TestHelper.waitFor(Duration.ofMillis(milliseconds));
+        startYugabyteDB();
     }
 }

--- a/src/test/java/io/debezium/connector/yugabytedb/common/YugabyteDBContainerTestBase.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/YugabyteDBContainerTestBase.java
@@ -2,6 +2,8 @@ package io.debezium.connector.yugabytedb.common;
 
 import java.time.Duration;
 
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 import org.testcontainers.containers.Container.ExecResult;
 
 import io.debezium.connector.yugabytedb.TestHelper;
@@ -13,13 +15,41 @@ import io.debezium.connector.yugabytedb.TestHelper;
  * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
  */
 public class YugabyteDBContainerTestBase extends TestBaseClass {
+    private static final Logger logger = LoggerFactory.getLogger(YugabyteDBContainerTestBase.class);
     protected static void initializeYBContainer(String masterFlags, String tserverFlags) {
         ybContainer = TestHelper.getYbContainer(masterFlags, tserverFlags);
         ybContainer.start();
 
+        if (tserverFlags == null || tserverFlags.isEmpty()) {
+            tserverFlags = "";
+        } else {
+            tserverFlags = " --tserver_flags=" + tserverFlags;
+        }
+
+        if (masterFlags == null || masterFlags.isEmpty()) {
+            masterFlags = "--master_flags=rpc_bind_addresses=0.0.0.0";
+        } else {
+            masterFlags = "--master_flags=rpc_bind_addresses=0.0.0.0," + masterFlags;
+        }
+        
+        logger.info("tserver flags: {}", tserverFlags);
+        logger.info("master flags: {}", masterFlags);
+
+        yugabytedStartCommand = "/home/yugabyte/bin/yugabyted start --listen=0.0.0.0 "
+                                    + masterFlags + tserverFlags + " --daemon=true";
+        logger.info("Container startup command: {}", yugabytedStartCommand);
+
+        try {
+            ExecResult result = ybContainer.execInContainer(getYugabytedStartCommand().split("\\s+"));
+
+            logger.info("Started yugabyted inside container: {}", result.getStdout());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
         TestHelper.setContainerHostPort(ybContainer.getHost(), ybContainer.getMappedPort(5433));
         TestHelper.setMasterAddress(ybContainer.getHost() + ":" + ybContainer.getMappedPort(7100));
-    }
+    } 
 
     protected static void initializeYBContainer() {
         initializeYBContainer(null, null);
@@ -35,19 +65,19 @@ public class YugabyteDBContainerTestBase extends TestBaseClass {
 
     @Override
     protected void stopYugabyteDB() throws Exception {
-        ExecResult stopResult = ybContainer.execInContainer("/home/yugabyte/bin/yugabyted", "stop");
-        LOGGER.info("YugabyteDB stopped with output: {} error: {} toString: {}", stopResult.getStdout(), stopResult.getStderr(), stopResult.toString());
-
-        // ExecResult stopResult2 = ybContainer.execInContainer("/home/yugabyte/bin/yb-admin", "--master_addresses", "0.0.0.0:7100", "create_change_data_stream", "ysql.yugabyte");
-        // LOGGER.info("Stop result 2: {}", stopResult2.getStdout());
+        ExecResult stopResult = ybContainer.execInContainer("/sbin/tini", "-s", "--", "/home/yugabyte/bin/yugabyted", "stop");
+        LOGGER.debug("YugabyteDB stopped with output: {} error: {} toString: {}", stopResult.getStdout(), stopResult.getStderr(), stopResult.toString());
     }
 
     @Override
     protected void startYugabyteDB() throws Exception {
         // This assumes that the yugabyted process will start back up again with the same value of flags which
         // were there before stopping it.
-        ExecResult startResult = ybContainer.execInContainer("/home/yugabyte/bin/yugabyted", "start");
-        LOGGER.info("YugabyteDB started with output: {}", startResult.getStdout());
+        ExecResult startResult = ybContainer.execInContainer("/sbin/tini", "-s", "--", "/home/yugabyte/bin/yugabyted", "start");
+        LOGGER.debug("YugabyteDB started with output: {}", startResult.getStdout());
+
+        // Wait for sometime for the process to be initialized properly.
+        TestHelper.waitFor(Duration.ofSeconds(10));
     }
 
     /**
@@ -56,10 +86,10 @@ public class YugabyteDBContainerTestBase extends TestBaseClass {
      * @param milliseconds amount of time (in ms) to wait before starting after stopping
      */
     @Override
-    protected void restartYugabyteDB(long milliseconds) throws Exception {
+    protected void restartYugabyteDB(long millisecondsToWait) throws Exception {
         stopYugabyteDB();
 
-        TestHelper.waitFor(Duration.ofMillis(milliseconds));
+        TestHelper.waitFor(Duration.ofMillis(millisecondsToWait));
         startYugabyteDB();
     }
 }

--- a/src/test/java/io/debezium/connector/yugabytedb/common/YugabytedTestBase.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/YugabytedTestBase.java
@@ -34,4 +34,22 @@ public class YugabytedTestBase extends TestBaseClass {
     public String getMasterAddress() {
         return "127.0.0.1:7100";
     }
+
+    @Override
+    protected void stopYugabyteDB() throws Exception {
+        LOGGER.warn("Method stopYugabyteDB not implemented to be run against local "
+                + "deployment of yugabyted");
+    }
+
+    @Override
+    protected void startYugabyteDB() throws Exception {
+        LOGGER.warn("Method startYugabyteDB not implemented to be run against local "
+                + "deployment of yugabyted");
+    }
+
+    @Override
+    protected void restartYugabyteDB(long milliseconds) throws Exception {
+        LOGGER.warn("Method restartYugabyteDB not implemented to be run against local "
+                + "deployment of yugabyted");
+    }
 }

--- a/src/test/java/io/debezium/connector/yugabytedb/common/YugabytedTestBase.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/YugabytedTestBase.java
@@ -48,7 +48,7 @@ public class YugabytedTestBase extends TestBaseClass {
     }
 
     @Override
-    protected void restartYugabyteDB(long milliseconds) throws Exception {
+    protected void restartYugabyteDB(long millisecondsToWait) throws Exception {
         LOGGER.warn("Method restartYugabyteDB not implemented to be run against local "
                 + "deployment of yugabyted");
     }

--- a/src/test/java/io/debezium/connector/yugabytedb/container/CustomContainerWaitStrategy.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/container/CustomContainerWaitStrategy.java
@@ -1,0 +1,21 @@
+package io.debezium.connector.yugabytedb.container;
+
+import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy;
+import org.testcontainers.containers.wait.strategy.WaitStrategyTarget;
+
+/**
+ * Custom wait strategy for the YSQL container to not wait for anything.
+ * 
+ * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
+ */
+public final class CustomContainerWaitStrategy extends AbstractWaitStrategy {
+    @Override
+    public void waitUntilReady(WaitStrategyTarget waitStrategyTarget) {
+        // Do nothing.
+    }
+
+    @Override
+    protected void waitUntilReady() {
+        // Do nothing.
+    }
+}

--- a/src/test/java/io/debezium/connector/yugabytedb/container/YugabyteCustomContainer.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/container/YugabyteCustomContainer.java
@@ -1,0 +1,37 @@
+package io.debezium.connector.yugabytedb.container;
+
+import org.testcontainers.containers.YugabyteYSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Custom container class to let us skip the container startup JDBC condition check.
+ * 
+ * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
+ */
+public class YugabyteCustomContainer extends YugabyteYSQLContainer {
+    public YugabyteCustomContainer(final String imageName) {
+		this(DockerImageName.parse(imageName));
+	}
+    
+    public YugabyteCustomContainer(final DockerImageName imageName) {
+        super(imageName);
+    }
+
+    @Override
+    protected void waitUntilContainerStarted() {
+        // The super method for this initiates a JDBC connection to the database
+        // and only when the connection is successful, it marks the container to be up,
+        // otherwise the container startup fails.
+
+        // The default behaviour will only suffice when we are starting the yugabyted
+        // process using the startup command for the docker container. But for custom
+        // behaviour, we start a infinite loop as the custom startup command and then
+        // start the yugabyted process - in this case, it is mandatory for us to skip
+        // this check.
+
+        // TODO: This method and class are only here for the time an upstream
+        // contribution is made which can let us skip the check this container provides.
+        
+        logger().debug("Returning from the waitUntilConnectorStarted method");
+    }
+}


### PR DESCRIPTION
This PR adds the method to restart the `yugabyted` process inside the YugabyteDB container. There are 3 methods added to facilitate the process related operations:
1. `stopYugabyteDB()` - stops the yugabyted process
2. `startYugabyteDB()` - starts the yugabyted process
3. `restartYugabyteDB(long)` - restarts the yugabyted process with a wait of specified milliseconds between stopping and starting the process.

A test has also been added to ensure that the APIs are functioning as expected, to run the test, use the command:
```
mvn clean test -Dtest=YugabyteDBDatatypesTest#verifyConsumptionAfterRestart
```

To achieve this, the following changes have been made:
1. Container now starts with a command for infinite loop - this ensured that even if we stop the `yugabyted` process, we do not end up exiting from the container.
2. Overridden a super function from the `YugabyteYSQLContainer` in a new class i.e. `YugabyteCustomContainer` to skip the execution of `waitUntilContainerIsReady` method which was waiting for a successful JDBC connection, but since we are not starting the yugabyted process in the beginning, we cannot open a connection and will need to skip this method
    i. We can remove this overriding once I create a contribution to the upstream container with some flag to skip this method, until then, this custom class will be used.
    
This PR closes yugabyte/yugabyte-db#16929