### PR TITLE
[yugabyte/yugabyte-db#16946] Handle tablet split scenario with explicit checkpointing

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -360,6 +360,9 @@ public class YugabyteDBStreamingChangeEventSource implements
                                         part.getTabletId());
                             handleTabletSplit(part.getTabletId(), tabletPairList, offsetContext, streamId, schemaNeeded);
                             splitTabletsWaitingForCallback.remove(part.getId());
+
+                            // Break out of the loop so that processing can happen on the modified list.
+                            break;
                         } else {
                             continue;
                         }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -356,6 +356,11 @@ public class YugabyteDBStreamingChangeEventSource implements
                               && (explicitCheckpoint.getIndex() == cp.getIndex())) {
                             // At this position, we know we have received a callback for split tablet
                             // handle tablet split and delete the tablet from the waiting list.
+
+                            // Call getChanges to make sure checkpoint is set on the cdc_state table.
+                            GetChangesResponse resp = this.syncClient.getChangesCDCSDK(
+                              tableIdToTable.get(part.getTableId()), streamId, tabletId, cp.getTerm(), cp.getIndex(), cp.getKey(),
+                              cp.getWrite_id(), cp.getTime(), schemaNeeded.get(part.getId()), explicitCheckpoint);
                             LOGGER.info("Handling tablet split for enqueued tablet {} as we have now received the commit callback",
                                         part.getTabletId());
                             handleTabletSplit(part.getTabletId(), tabletPairList, offsetContext, streamId, schemaNeeded);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -408,11 +408,13 @@ public class YugabyteDBStreamingChangeEventSource implements
                                 if (explicitCheckpoint != null
                                       && (cp.getTerm() == explicitCheckpoint.getTerm())
                                       && (cp.getIndex() == explicitCheckpoint.getIndex())) {
-                                    LOGGER.info("Explicit checkpoint same as from_op_id, handling tablet split immediately, explicit checkpoint {}:{} from_op_id: {}.{}",
-                                                explicitCheckpoint.getTerm(), explicitCheckpoint.getIndex(), cp.getTerm(), cp.getIndex());
+                                    LOGGER.info("Explicit checkpoint same as from_op_id, handling tablet split immediately for partition {}, explicit checkpoint {}:{} from_op_id: {}.{}",
+                                                part.getId(), explicitCheckpoint.getTerm(), explicitCheckpoint.getIndex(), cp.getTerm(), cp.getIndex());
                                     handleTabletSplit(cdcException, tabletPairList, offsetContext, streamId, schemaNeeded);
                                 } else {
                                     // Add the tablet for being processed later, this will mark the tablet as locked.
+                                    LOGGER.info("Adding partition {} to wait-list since the explicit checkpoint ({}.{}) and from_op_id are not the same ({}.{})",
+                                                part.getId(), explicitCheckpoint.getTerm(), explicitCheckpoint.getIndex(), cp.getTerm(), cp.getIndex());
                                     splitTabletsWaitingForCallback.add(part.getId());
                                 }
                             } else {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -431,9 +431,11 @@ public class YugabyteDBStreamingChangeEventSource implements
                                                 part.getId(), explicitCheckpoint.getTerm(), explicitCheckpoint.getIndex(), cp.getTerm(), cp.getIndex());
                                     handleTabletSplit(cdcException, tabletPairList, offsetContext, streamId, schemaNeeded);
                                 } else {
-                                    // Add the tablet for being processed later, this will mark the tablet as locked.
-                                    LOGGER.info("Adding partition {} to wait-list since the explicit checkpoint ({}.{}) and from_op_id are not the same ({}.{})",
-                                                part.getId(), explicitCheckpoint.getTerm(), explicitCheckpoint.getIndex(), cp.getTerm(), cp.getIndex());
+                                    // Add the tablet for being processed later, this will mark the tablet as locked. There is a chance that explicit checkpoint may
+                                    // be null, in that case, just to avoid NullPointerException in the log, simply log a null value.
+                                    final String explicitString = (explicitCheckpoint == null) ? null : (explicitCheckpoint.getTerm() + "." + explicitCheckpoint.getIndex());
+                                    LOGGER.info("Adding partition {} to wait-list since the explicit checkpoint ({}) and from_op_id ({}.{}) are not the same",
+                                                part.getId(), explicitString, cp.getTerm(), cp.getIndex());
                                     splitTabletsWaitingForCallback.add(part.getId());
                                 }
                             } else {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -358,9 +358,11 @@ public class YugabyteDBStreamingChangeEventSource implements
                             // handle tablet split and delete the tablet from the waiting list.
 
                             // Call getChanges to make sure checkpoint is set on the cdc_state table.
+                            LOGGER.info("Calling GetChanges to ensure explicit checkpoint is set to {}.{}", explicitCheckpoint.getTerm(), explicitCheckpoint.getIndex());
                             GetChangesResponse resp = this.syncClient.getChangesCDCSDK(
                               tableIdToTable.get(part.getTableId()), streamId, tabletId, cp.getTerm(), cp.getIndex(), cp.getKey(),
                               cp.getWrite_id(), cp.getTime(), schemaNeeded.get(part.getId()), explicitCheckpoint);
+
                             LOGGER.info("Handling tablet split for enqueued tablet {} as we have now received the commit callback",
                                         part.getTabletId());
                             handleTabletSplit(part.getTabletId(), tabletPairList, offsetContext, streamId, schemaNeeded);


### PR DESCRIPTION
This PR fixes a bug with explicit checkpoint and tablet splitting wherein let's say a tablet got split and the children got split further, but we haven't received a callback from Kafka about the parent record, in this case no explicit checkpoint was being marked on the `cdc_state` table thus leading us to in a error:

```
The logs from index -1 have been garbage collected and cannot be read
```

The fix to this is to detect that when we receive the tablet split message, then check if we have received the explicit commit callback as well, if we have then handle the split normally, if not then we proceed to add a tablet to a wait list so that we can pause polling on it for a while till the time we do not receive explicit commit callback.

This closes yugabyte/yugabyte-db#16946