### PR TITLE
Add tablet safetime to GetChanges call

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
@@ -186,6 +186,7 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
                                         cp.getWrite_id(), cp.getTime(), schemaNeeded.get(tabletId),
                                         taskContext.shouldEnableExplicitCheckpointing() ? tabletToExplicitCheckpoint.get(part.getId()) : null,
                                         tabletSafeTime.getOrDefault(part.getId(), -1L));
+
                                 tabletSafeTime.put(part.getId(), response.getResp().getSafeHybridTime());
                             } catch (CDCErrorException cdcException) {
                                 // Check if exception indicates a tablet split.

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
@@ -185,7 +185,7 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
                                         table, streamId, tabletId, cp.getTerm(), cp.getIndex(), cp.getKey(),
                                         cp.getWrite_id(), cp.getTime(), schemaNeeded.get(tabletId),
                                         taskContext.shouldEnableExplicitCheckpointing() ? tabletToExplicitCheckpoint.get(part.getId()) : null,
-                                        tabletSafeTime.get(part.getId()));
+                                        tabletSafeTime.getOrDefault(part.getId(), -1L));
                                 tabletSafeTime.put(part.getId(), response.getResp().getSafeHybridTime());
                             } catch (CDCErrorException cdcException) {
                                 // Check if exception indicates a tablet split.

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -284,6 +284,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
       Map<String, Boolean> schemaNeeded = new HashMap<>();
       Set<String> snapshotCompletedTablets = new HashSet<>();
       Set<String> snapshotCompletedPreviously = new HashSet<>();
+      Map<String, Long> tabletSafeTime = new HashMap<>();
 
       for (Pair<String, String> entry : tableToTabletIds) {
         // We can use tableIdToTable.get(entry.getKey()).isColocated() to get actual status.
@@ -395,7 +396,10 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                 GetChangesResponse resp = this.syncClient.getChangesCDCSDK(table,
                     connectorConfig.streamId(), tabletId, cp.getTerm(), cp.getIndex(), cp.getKey(),
                     cp.getWrite_id(), cp.getTime(), schemaNeeded.get(part.getId()),
-                    taskContext.shouldEnableExplicitCheckpointing() ? tabletToExplicitCheckpoint.get(part.getId()) : null);
+                    taskContext.shouldEnableExplicitCheckpointing() ? tabletToExplicitCheckpoint.get(part.getId()) : null,
+                    tabletSafeTime.get(part.getId()));
+
+                tabletSafeTime.put(part.getId(), resp.getResp().getSafeHybridTime());
 
                 // Process the response
                 for (CdcService.CDCSDKProtoRecordPB record :

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -397,7 +397,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                     connectorConfig.streamId(), tabletId, cp.getTerm(), cp.getIndex(), cp.getKey(),
                     cp.getWrite_id(), cp.getTime(), schemaNeeded.get(part.getId()),
                     taskContext.shouldEnableExplicitCheckpointing() ? tabletToExplicitCheckpoint.get(part.getId()) : null,
-                    tabletSafeTime.get(part.getId()));
+                    tabletSafeTime.getOrDefault(part.getId(), -1L));
 
                 tabletSafeTime.put(part.getId(), resp.getResp().getSafeHybridTime());
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -366,7 +366,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                                 GetChangesResponse resp = this.syncClient.getChangesCDCSDK(
                                   tableIdToTable.get(part.getTableId()), streamId, tabletId, cp.getTerm(), cp.getIndex(), cp.getKey(),
                                   cp.getWrite_id(), cp.getTime(), schemaNeeded.get(part.getId()), explicitCheckpoint,
-                                  tabletSafeTime.get(part.getId()));
+                                  tabletSafeTime.getOrDefault(part.getId(), -1L));
                             } catch (CDCErrorException cdcErrorException) {
                                 if (cdcErrorException.getCDCError().getCode() == Code.TABLET_SPLIT) {
                                     LOGGER.debug("Handling tablet split error gracefully for enqueued tablet {}", part.getTabletId());
@@ -422,7 +422,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                             table, streamId, tabletId, cp.getTerm(), cp.getIndex(), cp.getKey(),
                             cp.getWrite_id(), cp.getTime(), schemaNeeded.get(part.getId()),
                             taskContext.shouldEnableExplicitCheckpointing() ? tabletToExplicitCheckpoint.get(part.getId()) : null,
-                            tabletSafeTime.get(part.getId()));
+                            tabletSafeTime.getOrDefault(part.getId(), -1L));
 
                         tabletSafeTime.put(part.getId(), response.getResp().getSafeHybridTime());
                       } catch (CDCErrorException cdcException) {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -367,6 +367,10 @@ public class YugabyteDBStreamingChangeEventSource implements
                                   tableIdToTable.get(part.getTableId()), streamId, tabletId, cp.getTerm(), cp.getIndex(), cp.getKey(),
                                   cp.getWrite_id(), cp.getTime(), schemaNeeded.get(part.getId()), explicitCheckpoint,
                                   tabletSafeTime.getOrDefault(part.getId(), -1L));
+
+                                // We are not updating the tablet safetime we get from the response here because the previous
+                                // GetChanges call is supposed to throw an exception for tablet split which will then be
+                                // handled further.
                             } catch (CDCErrorException cdcErrorException) {
                                 if (cdcErrorException.getCDCError().getCode() == Code.TABLET_SPLIT) {
                                     LOGGER.debug("Handling tablet split error gracefully for enqueued tablet {}", part.getTabletId());


### PR DESCRIPTION
This PR adds a tablet safetime parameter to the `GetChanges` call in the change event sources files.