### PR TITLE
[yugabyte/yugabyte-db#17551] Make all tests in the connector use explicit checkpointing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,14 @@
     <groupId>io.debezium</groupId>
     <artifactId>debezium-connector-yugabytedb</artifactId>
     <name>YugabyteDB Source Connector</name>
-    <version>1.9.5.y.22</version>
+    <version>1.5.y.22-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>
         <connection>scm:git:git@github.com:yugabyte/debezium-connector-yugabytedb.git</connection>
         <developerConnection>scm:git:git@github.com:yugabyte/debezium-connector-yugabytedb.git</developerConnection>
         <url>https://github.com/yugabyte/debezium-connector-yugabytedb</url>
-        <tag>v1.9.5.y.22</tag>
+        <tag>v1.9.5.y.20</tag>
     </scm>
 
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -508,7 +508,8 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                   // tabletId to snapshotCompletedTablets - there is a chance that when the
                   // connector crashes, we may lose some data since we may not have published them
                   // to Kafka yet.
-                  if (isSnapshotCompleteMarker(OpId.from(this.tabletToExplicitCheckpoint.get(part.getId())))) {
+                  CdcSdkCheckpoint explicitCheckpoint = tabletToExplicitCheckpoint.get(part.getId());
+                  if (explicitCheckpoint != null && isSnapshotCompleteMarker(OpId.from(explicitCheckpoint))) {
                     // This will mark the snapshot completed for the tablet
                     snapshotCompletedTablets.add(part.getId());
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -553,10 +553,9 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
           }
 
           LOGGER.warn("Error while trying to get the snapshot from the server; will attempt " 
-                      + "retry {} of {} after {} milli-seconds. Exception message: {}", retryCount, 
+                      + "retry {} of {} after {} milli-seconds. Exception: {}", retryCount, 
                        this.connectorConfig.maxConnectorRetries(), 
-                       this.connectorConfig.connectorRetryDelayMs(), e.getMessage());
-          LOGGER.debug("Stacktrace: ", e);
+                       this.connectorConfig.connectorRetryDelayMs(), e);
 
           try {
             final Metronome retryMetronome = Metronome.parker(Duration.ofMillis(connectorConfig.connectorRetryDelayMs()), Clock.SYSTEM);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -524,6 +524,8 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                   } else if (isSnapshotCompleteMarker(finalOpId)) {
                     // Add it to tablets waiting for callback so that the connector doesn't end up
                     // calling GetChanges for the same again.
+                    LOGGER.info("Adding tablet {} of table {} ({}) to wait-list",
+                      part.getTabletId(), table.getName(), part.getTableId());
                     tabletsWaitingForCallback.add(part.getId());
                   }
                 } else if (!taskContext.shouldEnableExplicitCheckpointing() && isSnapshotCompleteMarker(finalOpId)) {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -397,9 +397,9 @@ public class YugabyteDBStreamingChangeEventSource implements
                       if (taskContext.shouldEnableExplicitCheckpointing()) {
                         CdcSdkCheckpoint ecp = tabletToExplicitCheckpoint.get(part.getId());
                         if (ecp != null) {
-                            LOGGER.info("Requesting changes, explicit checkpointing: {}.{} from_op_id: {}.{}", ecp.getTerm(), ecp.getIndex(), cp.getTerm(), cp.getIndex());
+                            LOGGER.info("Requesting changes for tablet {}, explicit checkpointing: {}.{} from_op_id: {}.{}", part.getId(), ecp.getTerm(), ecp.getIndex(), cp.getTerm(), cp.getIndex());
                         } else {
-                            LOGGER.info("Requesting changes, explicit checkpoint is null and from_op_id: {}.{}", cp.getTerm(), cp.getIndex());
+                            LOGGER.info("Requesting changes for tablet {}, explicit checkpoint is null and from_op_id: {}.{}", part.getId(), cp.getTerm(), cp.getIndex());
                         }
                       }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -645,9 +645,8 @@ public class YugabyteDBStreamingChangeEventSource implements
                 }
 
                 // If there are retries left, perform them after the specified delay.
-                LOGGER.warn("Error while trying to get the changes from the server; will attempt retry {} of {} after {} milli-seconds. Exception message: {}",
-                        retryCount, connectorConfig.maxConnectorRetries(), connectorConfig.connectorRetryDelayMs(), e.getMessage());
-                LOGGER.warn("Stacktrace", e);
+                LOGGER.warn("Error while trying to get the changes from the server; will attempt retry {} of {} after {} milli-seconds. Exception: {}",
+                        retryCount, connectorConfig.maxConnectorRetries(), connectorConfig.connectorRetryDelayMs(), e);
 
                 try {
                     final Metronome retryMetronome = Metronome.parker(Duration.ofMillis(connectorConfig.connectorRetryDelayMs()), Clock.SYSTEM);

--- a/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
@@ -478,7 +478,7 @@ public final class TestHelper {
 
     public static String getNewDbStreamId(String namespaceName, String tableName,
                                           boolean withBeforeImage) throws Exception {
-        return getNewDbStreamId(namespaceName, tableName, withBeforeImage, false /* explicit x*/);
+        return getNewDbStreamId(namespaceName, tableName, withBeforeImage, true /* explicit */);
     }
 
     public static String getNewDbStreamId(String namespaceName, String tableName) throws Exception {

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBBeforeImageTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBBeforeImageTest.java
@@ -19,7 +19,7 @@ import io.debezium.config.Configuration;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
 import io.debezium.connector.yugabytedb.common.YugabytedTestBase;
 
-public class YugabyteDBBeforeImageTest extends YugabytedTestBase {
+public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
   private final String formatInsertString =
       "INSERT INTO t1 VALUES (%d, 'Vaibhav', 'Kushwaha', 12.345);";
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBBeforeImageTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBBeforeImageTest.java
@@ -17,8 +17,9 @@ import org.junit.jupiter.api.*;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
+import io.debezium.connector.yugabytedb.common.YugabytedTestBase;
 
-public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
+public class YugabyteDBBeforeImageTest extends YugabytedTestBase {
   private final String formatInsertString =
       "INSERT INTO t1 VALUES (%d, 'Vaibhav', 'Kushwaha', 12.345);";
 
@@ -50,7 +51,7 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
 
       String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", true /* withBeforeImage */);
       Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
-      start(YugabyteDBConnector.class, configBuilder.build());
+      startEngine(configBuilder);
 
       awaitUntilConnectorIsReady();
 
@@ -79,7 +80,7 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
 
       String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", true /* withBeforeImage */);
       Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
-      start(YugabyteDBConnector.class, configBuilder.build());
+      startEngine(configBuilder);
 
       awaitUntilConnectorIsReady();
 
@@ -114,7 +115,7 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
 
     String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", true /* withBeforeImage */);
     Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
-    start(YugabyteDBConnector.class, configBuilder.build());
+    startEngine(configBuilder);
 
     awaitUntilConnectorIsReady();
 
@@ -172,7 +173,7 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
 
     String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", true /* withBeforeImage */);
     Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
-    start(YugabyteDBConnector.class, configBuilder.build());
+    startEngine(configBuilder);
 
     awaitUntilConnectorIsReady();
 
@@ -204,7 +205,7 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
 
     String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", true /* withBeforeImage */);
     Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
-    start(YugabyteDBConnector.class, configBuilder.build());
+    startEngine(configBuilder);
 
     awaitUntilConnectorIsReady();
 
@@ -253,7 +254,7 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
                                                     true /* withBeforeImage */);
     Configuration.Builder configBuilder =
         TestHelper.getConfigBuilder("public.table_with_defaults", dbStreamId);
-    start(YugabyteDBConnector.class, configBuilder.build());
+    startEngine(configBuilder);
 
     awaitUntilConnectorIsReady();
 
@@ -306,7 +307,7 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
           Awaitility.await()
               .atMost(Duration.ofSeconds(seconds))
               .until(() -> {
-                  int consumed = super.consumeAvailableRecords(record -> {
+                  int consumed = consumeAvailableRecords(record -> {
                       LOGGER.debug("The record being consumed is " + record);
                       records.add(record);
                   });

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBColocatedTablesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBColocatedTablesTest.java
@@ -322,7 +322,7 @@ public class YugabyteDBColocatedTablesTest extends YugabyteDBContainerTestBase {
       Awaitility.await()
               .atMost(Duration.ofSeconds(seconds))
               .until(() -> {
-                int consumed = super.consumeAvailableRecords(record -> {
+                int consumed = consumeAvailableRecords(record -> {
                   LOGGER.debug("The record being consumed is " + record);
                   records.add(record);
                 });

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBColocatedTablesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBColocatedTablesTest.java
@@ -6,6 +6,7 @@ import io.debezium.config.Configuration;
 import io.debezium.connector.yugabytedb.annotations.PreviewOnly;
 import io.debezium.connector.yugabytedb.common.TestBaseClass;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
+import io.debezium.connector.yugabytedb.common.YugabytedTestBase;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -24,7 +25,6 @@ import org.junit.jupiter.api.*;
  *
  * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
  */
-@PreviewOnly
 public class YugabyteDBColocatedTablesTest extends YugabyteDBContainerTestBase {
   private final String INSERT_TEST_1 = "INSERT INTO test_1 VALUES (%d, 'sample insert');";
   private final String INSERT_TEST_2 = "INSERT INTO test_2 VALUES (%d::text);";
@@ -64,7 +64,7 @@ public class YugabyteDBColocatedTablesTest extends YugabyteDBContainerTestBase {
     Configuration.Builder configBuilder = TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME,
         "public.test_1", dbStreamId);
 
-    start(YugabyteDBConnector.class, configBuilder.build());
+    startEngine(configBuilder);
 
     awaitUntilConnectorIsReady();
 
@@ -95,7 +95,7 @@ public class YugabyteDBColocatedTablesTest extends YugabyteDBContainerTestBase {
     Configuration.Builder configBuilder = TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME,
         "public.test_1,public.test_2", dbStreamId);
 
-    start(YugabyteDBConnector.class, configBuilder.build());
+    startEngine(configBuilder);
 
     awaitUntilConnectorIsReady();
 
@@ -129,7 +129,7 @@ public class YugabyteDBColocatedTablesTest extends YugabyteDBContainerTestBase {
     Configuration.Builder configBuilder = TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME,
         "public.test_1,public.test_2,public.test_no_colocated", dbStreamId);
 
-    start(YugabyteDBConnector.class, configBuilder.build());
+    startEngine(configBuilder);
 
     awaitUntilConnectorIsReady();
 
@@ -163,7 +163,7 @@ public class YugabyteDBColocatedTablesTest extends YugabyteDBContainerTestBase {
     Configuration.Builder configBuilder = TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME,
         "public.test_1,public.test_2", dbStreamId);
 
-    start(YugabyteDBConnector.class, configBuilder.build());
+    startEngine(configBuilder);
 
     awaitUntilConnectorIsReady();
 
@@ -195,7 +195,7 @@ public class YugabyteDBColocatedTablesTest extends YugabyteDBContainerTestBase {
     // The connector would now start polling for the included tables. Note that the earlier data for
     // table test_3 won't be streamed since it might have gotten garbage collected since it resides
     // on the same tablet i.e. colocated
-    start(YugabyteDBConnector.class, configBuilder.build());
+    startEngine(configBuilder);
     awaitUntilConnectorIsReady();
 
     // The below statements will insert records of the respective types with keys in the

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBColocatedTablesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBColocatedTablesTest.java
@@ -73,7 +73,7 @@ public class YugabyteDBColocatedTablesTest extends YugabyteDBContainerTestBase {
     // Dummy wait for 10 seconds
     TestHelper.waitFor(Duration.ofSeconds(10));
 
-    SourceRecords records = consumeRecordsByTopic(10);
+    SourceRecords records = consumeByTopic(10);
 
     assertNotNull(records);
 
@@ -106,7 +106,7 @@ public class YugabyteDBColocatedTablesTest extends YugabyteDBContainerTestBase {
     // Dummy wait for 10 seconds
     TestHelper.waitFor(Duration.ofSeconds(10));
 
-    SourceRecords records = consumeRecordsByTopic(20);
+    SourceRecords records = consumeByTopic(20);
 
     assertNotNull(records);
 
@@ -141,7 +141,7 @@ public class YugabyteDBColocatedTablesTest extends YugabyteDBContainerTestBase {
     // Dummy wait for 10 seconds
     TestHelper.waitFor(Duration.ofSeconds(10));
 
-    SourceRecords records = consumeRecordsByTopic(30);
+    SourceRecords records = consumeByTopic(30);
 
     assertNotNull(records);
 
@@ -175,7 +175,7 @@ public class YugabyteDBColocatedTablesTest extends YugabyteDBContainerTestBase {
     // Dummy wait for 10 seconds
     TestHelper.waitFor(Duration.ofSeconds(10));
 
-    SourceRecords records = consumeRecordsByTopic(20);
+    SourceRecords records = consumeByTopic(20);
 
     assertNotNull(records);
 
@@ -207,7 +207,7 @@ public class YugabyteDBColocatedTablesTest extends YugabyteDBContainerTestBase {
     // Dummy wait for 10 more seconds
     TestHelper.waitFor(Duration.ofSeconds(10));
 
-    SourceRecords recordsAfterRestart = consumeRecordsByTopic(30);
+    SourceRecords recordsAfterRestart = consumeByTopic(30);
 
     assertNotNull(recordsAfterRestart);
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCompleteTypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCompleteTypesTest.java
@@ -8,6 +8,8 @@ import java.util.concurrent.CompletableFuture;
 
 import io.debezium.util.HexConverter;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
+import io.debezium.connector.yugabytedb.common.YugabytedTestBase;
+
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.*;
 
@@ -43,7 +45,7 @@ public class YugabyteDBCompleteTypesTest extends YugabyteDBContainerTestBase {
         long start = System.currentTimeMillis();
         List<SourceRecord> records = new ArrayList<>();
         while (totalConsumedRecords < recordsCount) {
-            int consumed = super.consumeAvailableRecords(record -> {
+            int consumed = consumeAvailableRecords(record -> {
                 LOGGER.debug("The record being consumed is " + record);
                 records.add(record);
             });
@@ -103,7 +105,7 @@ public class YugabyteDBCompleteTypesTest extends YugabyteDBContainerTestBase {
 
         String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "all_types");
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.all_types", dbStreamId);
-        start(YugabyteDBConnector.class, configBuilder.build());
+        startEngine(configBuilder);
 
         awaitUntilConnectorIsReady();
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConfigTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConfigTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.*;
 import io.debezium.DebeziumException;
 import io.debezium.config.Configuration;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
+import io.debezium.connector.yugabytedb.common.YugabytedTestBase;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -49,7 +50,7 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
     private void verifyRecordCount(int recordsCount) {
         int totalConsumedRecords = 0;
         while (totalConsumedRecords < recordsCount) {
-            int consumed = super.consumeAvailableRecords(record -> {
+            int consumed = consumeAvailableRecords(record -> {
             });
             if (consumed > 0) {
                 totalConsumedRecords += consumed;
@@ -74,7 +75,7 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.all_types,public.not_part_of_stream", dbStreamId);
 
         // This should throw a DebeziumException saying the table not_part_of_stream is not a part of stream ID
-        start(YugabyteDBConnector.class, configBuilder.build(), (success, msg, error) -> {
+        startEngine(configBuilder, (success, msg, error) -> {
             assertFalse(success);
             assertTrue(error instanceof DebeziumException);
 
@@ -105,7 +106,7 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
         // The config builder returns a default config with the database as "postgres"
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
 
-        start(YugabyteDBConnector.class, configBuilder.build());
+        startEngine(configBuilder);
 
         awaitUntilConnectorIsReady();
 
@@ -127,7 +128,7 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
         String invalidStreamId = "someInvalidDbStreamId";
 
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", invalidStreamId);
-        start(YugabyteDBConnector.class, configBuilder.build(), (success, message, error) -> {
+        startEngine(configBuilder, (success, message, error) -> {
             assertFalse(success);
 
             String expectedErrorMessageLine = String.format("Could not find CDC stream: db_stream_id: \"%s\"", invalidStreamId);
@@ -148,7 +149,7 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
 
         String wrongNamespaceName = "wrong_namespace";
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder(wrongNamespaceName, "public.t1", dbStreamId);
-        start(YugabyteDBConnector.class, configBuilder.build(), (success, message, error) -> {
+        startEngine(configBuilder, (success, message, error) -> {
             assertFalse(success);
 
             String expectedErrorMessageLine = String.format("FATAL: database \"%s\" does not exist", wrongNamespaceName);
@@ -169,7 +170,7 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
 
         Configuration.Builder configBuilderWithWrongUser = TestHelper.getConfigBuilder("public.t1", dbStreamId);
         configBuilderWithWrongUser.with(YugabyteDBConnectorConfig.USER, "wrong_username");
-        start(YugabyteDBConnector.class, configBuilderWithWrongUser.build(), (success, message, error) -> {
+        startEngine(configBuilderWithWrongUser, (success, message, error) -> {
             assertFalse(success);
 
             assertTrue(error.getCause().getMessage().contains("authentication failed for user \"wrong_username\""));
@@ -189,7 +190,7 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
 
         Configuration.Builder configBuilderWithWrongPassword = TestHelper.getConfigBuilder("public.t1", dbStreamId);
         configBuilderWithWrongPassword.with(YugabyteDBConnectorConfig.PASSWORD, "wrong_password");
-        start(YugabyteDBConnector.class, configBuilderWithWrongPassword.build(), (success, message, error) -> {
+        startEngine(configBuilderWithWrongPassword, (success, message, error) -> {
             assertFalse(success);
 
             assertTrue(error.getCause().getMessage().contains("password authentication failed for user \"yugabyte\""));
@@ -208,7 +209,7 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
         String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
 
         Configuration.Builder configBuilderWithWrongPassword = TestHelper.getConfigBuilder("", dbStreamId);
-        start(YugabyteDBConnector.class, configBuilderWithWrongPassword.build(), (success, message, error) -> {
+        startEngine(configBuilderWithWrongPassword, (success, message, error) -> {
             assertFalse(success);
 
             assertTrue(error.getMessage().contains("The table.include.list is empty, please provide a list of tables to get the changes from"));
@@ -227,7 +228,7 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
         String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
 
         Configuration.Builder configBuilderWithWrongPassword = TestHelper.getConfigBuilder("public.non_existent_table", dbStreamId);
-        start(YugabyteDBConnector.class, configBuilderWithWrongPassword.build(), (success, message, error) -> {
+        startEngine(configBuilderWithWrongPassword, (success, message, error) -> {
             assertFalse(success);
 
             assertTrue(error.getMessage().contains("The tables provided in table.include.list do not exist"));
@@ -246,7 +247,7 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
         String dbStreamId = "";
 
         Configuration.Builder configBuilderWithWrongPassword = TestHelper.getConfigBuilder("public.t1", dbStreamId);
-        start(YugabyteDBConnector.class, configBuilderWithWrongPassword.build(), (success, message, error) -> {
+        startEngine(configBuilderWithWrongPassword, (success, message, error) -> {
             assertFalse(success);
 
             assertTrue(error.getMessage().contains("DB Stream ID not provided, please provide a DB stream ID to proceed"));
@@ -265,7 +266,7 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
         Configuration.Builder configBuilderWithHollowStreamId = 
             TestHelper.getConfigBuilder("public.dummy_table", dbStreamId);
         
-        start(YugabyteDBConnector.class, configBuilderWithHollowStreamId.build(), (success, message, error) -> {
+        startEngine(configBuilderWithHollowStreamId, (success, message, error) -> {
             assertFalse(success);
 
             assertTrue(error.getMessage().contains("The provided stream ID is not associated with any table"));

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorIT.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorIT.java
@@ -7,6 +7,8 @@ import org.apache.kafka.common.config.ConfigDef;
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
+import io.debezium.connector.yugabytedb.common.YugabytedTestBase;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,11 +50,11 @@ public class YugabyteDBConnectorIT extends YugabyteDBContainerTestBase {
     @Test
     public void shouldNotStartWithInvalidConfiguration() {
         // use an empty configuration which should be invalid because of the lack of DB connection details
-        Configuration config = Configuration.create().build();
+        Configuration.Builder configBuilder = Configuration.create();
 
         // we expect the engine will log at least one error, so preface it ...
         LOGGER.info("Attempting to start the connector with an INVALID configuration, so MULTIPLE error messages & one exception will appear in the log");
-        start(YugabyteDBConnector.class, config, (success, msg, error) -> {
+        startEngine(configBuilder, (success, msg, error) -> {
             assertThat(success).isFalse();
             assertThat(error).isNotNull();
         });

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
@@ -239,7 +239,7 @@ public class YugabyteDBDatatypesTest extends YugabyteDBContainerTestBase {
 
         String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
-        start(YugabyteDBConnector.class, configBuilder.build());
+        startEngine(YugabyteDBConnector.class, configBuilder.build());
         final long recordsCount = 1;
 
         awaitUntilConnectorIsReady();

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
@@ -10,6 +10,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
+import io.debezium.connector.yugabytedb.common.YugabytedTestBase;
+
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.awaitility.Awaitility;
@@ -30,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
  */
 
-public class YugabyteDBDatatypesTest extends YugabyteDBContainerTestBase {
+public class YugabyteDBDatatypesTest extends YugabytedTestBase {
     private static final String INSERT_STMT = "INSERT INTO s1.a (aa) VALUES (1);" +
             "INSERT INTO s2.a (aa) VALUES (1);";
     private static final String CREATE_TABLES_STMT = "DROP SCHEMA IF EXISTS s1 CASCADE;" +
@@ -239,7 +241,7 @@ public class YugabyteDBDatatypesTest extends YugabyteDBContainerTestBase {
 
         String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
-        startEngine(YugabyteDBConnector.class, configBuilder.build());
+        startEngine(configBuilder);
         final long recordsCount = 1;
 
         awaitUntilConnectorIsReady();

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
@@ -221,6 +221,7 @@ public class YugabyteDBDatatypesTest extends YugabytedTestBase {
     public static void afterClass() {
         shutdownYBContainer();
     }
+
     // This test will just verify that the TestContainers are up and running
     // and it will also verify that the unit tests are able to make API calls.
     @Test
@@ -262,7 +263,7 @@ public class YugabyteDBDatatypesTest extends YugabytedTestBase {
 
         String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_DB_NAME, "t1");
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
-        start(YugabyteDBConnector.class, configBuilder.build());
+        startEngine(configBuilder);
         awaitUntilConnectorIsReady();
 
         YBClient ybClient = TestHelper.getYbClient(getMasterAddress());
@@ -297,7 +298,7 @@ public class YugabyteDBDatatypesTest extends YugabytedTestBase {
 
         String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
-        start(YugabyteDBConnector.class, configBuilder.build());
+        startEngine(configBuilder);
         final long rowsCount = 1;
 
         awaitUntilConnectorIsReady();
@@ -328,7 +329,7 @@ public class YugabyteDBDatatypesTest extends YugabytedTestBase {
 
         String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
-        start(YugabyteDBConnector.class, configBuilder.build());
+        startEngine(configBuilder);
         final long recordsCount = 75;
 
         awaitUntilConnectorIsReady();
@@ -348,7 +349,7 @@ public class YugabyteDBDatatypesTest extends YugabytedTestBase {
 
         String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
-        start(YugabyteDBConnector.class, configBuilder.build());
+        startEngine(configBuilder);
         final long recordsCount = 1;
 
         awaitUntilConnectorIsReady();
@@ -370,7 +371,7 @@ public class YugabyteDBDatatypesTest extends YugabytedTestBase {
 
         String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "test_enum");
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.test_enum", dbStreamId);
-        start(YugabyteDBConnector.class, configBuilder.build());
+        startEngine(configBuilder);
         assertConnectorIsRunning();
 
         // 3 because there are 3 enum values in the enum type
@@ -394,7 +395,7 @@ public class YugabyteDBDatatypesTest extends YugabytedTestBase {
 
         String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "table_in_schema");
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("test_schema.table_in_schema", dbStreamId);
-        start(YugabyteDBConnector.class, configBuilder.build());
+        startEngine(configBuilder);
         final long recordsCount = 1;
 
         awaitUntilConnectorIsReady();
@@ -418,7 +419,7 @@ public class YugabyteDBDatatypesTest extends YugabytedTestBase {
         // Ignore tombstones since we will not need them for verification.
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
         configBuilder.with(YugabyteDBConnectorConfig.TOMBSTONES_ON_DELETE, false);
-        start(YugabyteDBConnector.class, configBuilder.build());
+        startEngine(configBuilder);
 
         awaitUntilConnectorIsReady();
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
@@ -134,8 +134,8 @@ public class YugabyteDBDatatypesTest extends YugabytedTestBase {
             Awaitility.await()
                 .atMost(Duration.ofSeconds(seconds))
                 .until(() -> {
-                    int consumed = super.consumeAvailableRecords(record -> {
-                        LOGGER.debug("The record being consumed is " + record);
+                    int consumed = consumeAvailableRecords(record -> {
+                        LOGGER.info("The record being consumed is " + record);
                         records.add(record);
                     });
                     if (consumed > 0) {

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
  */
 
-public class YugabyteDBDatatypesTest extends YugabytedTestBase {
+public class YugabyteDBDatatypesTest extends YugabyteDBContainerTestBase {
     private static final String INSERT_STMT = "INSERT INTO s1.a (aa) VALUES (1);" +
             "INSERT INTO s2.a (aa) VALUES (1);";
     private static final String CREATE_TABLES_STMT = "DROP SCHEMA IF EXISTS s1 CASCADE;" +

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
@@ -135,7 +135,7 @@ public class YugabyteDBDatatypesTest extends YugabytedTestBase {
                 .atMost(Duration.ofSeconds(seconds))
                 .until(() -> {
                     int consumed = consumeAvailableRecords(record -> {
-                        LOGGER.info("The record being consumed is " + record);
+                        LOGGER.debug("The record being consumed is " + record);
                         records.add(record);
                     });
                     if (consumed > 0) {

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBPartitionTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBPartitionTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.*;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
+import io.debezium.connector.yugabytedb.common.YugabytedTestBase;
 import io.debezium.util.Strings;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -50,7 +51,7 @@ public class YugabyteDBPartitionTest extends YugabyteDBContainerTestBase {
     String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
     Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
 
-    start(YugabyteDBConnector.class, configBuilder.build(), (success, message, error) -> {
+    startEngine(configBuilder, (success, message, error) -> {
       assertTrue(success);
     });
 
@@ -72,7 +73,7 @@ public class YugabyteDBPartitionTest extends YugabyteDBContainerTestBase {
     int totalConsumedRecords = 0;
     long start = System.currentTimeMillis();
     while (totalConsumedRecords < recordsCount) {
-        int consumed = super.consumeAvailableRecords(record -> {
+        int consumed = consumeAvailableRecords(record -> {
             LOGGER.info("The record being consumed is " + record);
         });
         if (consumed > 0) {

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSchemaEvolutionTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSchemaEvolutionTest.java
@@ -70,7 +70,7 @@ public class YugabyteDBSchemaEvolutionTest extends YugabyteDBContainerTestBase {
     configBuilder.with(YugabyteDBConnectorConfig.CDC_POLL_INTERVAL_MS, 10_000);
     configBuilder.with(YugabyteDBConnectorConfig.CONNECTOR_RETRY_DELAY_MS, 10000);
 
-    start(YugabyteDBConnector.class, configBuilder.build(), (success, message, error) -> {
+    startEngine(configBuilder, (success, message, error) -> {
       assertTrue(success);
     });
 
@@ -119,7 +119,7 @@ public class YugabyteDBSchemaEvolutionTest extends YugabyteDBContainerTestBase {
     configBuilder.with(YugabyteDBConnectorConfig.CDC_POLL_INTERVAL_MS, 5_000);
     configBuilder.with(YugabyteDBConnectorConfig.CONNECTOR_RETRY_DELAY_MS, 10000);
 
-    start(YugabyteDBConnector.class, configBuilder.build(), (success, message, error) -> {
+    startEngine(configBuilder, (success, message, error) -> {
       assertTrue(success);
     });
 
@@ -166,7 +166,7 @@ public class YugabyteDBSchemaEvolutionTest extends YugabyteDBContainerTestBase {
     configBuilder.with(YugabyteDBConnectorConfig.CDC_POLL_INTERVAL_MS, 5_000);
     configBuilder.with(YugabyteDBConnectorConfig.CONNECTOR_RETRY_DELAY_MS, 10000);
 
-    start(YugabyteDBConnector.class, configBuilder.build(), (success, message, error) -> {
+    startEngine(configBuilder, (success, message, error) -> {
       assertTrue(success);
     });
 
@@ -205,7 +205,7 @@ public class YugabyteDBSchemaEvolutionTest extends YugabyteDBContainerTestBase {
     configBuilder.with(YugabyteDBConnectorConfig.CDC_POLL_INTERVAL_MS, 10_000);
     configBuilder.with(YugabyteDBConnectorConfig.CONNECTOR_RETRY_DELAY_MS, 10000);
 
-    start(YugabyteDBConnector.class, configBuilder.build(), (success, message, error) -> {
+    startEngine(configBuilder, (success, message, error) -> {
       assertTrue(success);
     });
 
@@ -256,7 +256,7 @@ public class YugabyteDBSchemaEvolutionTest extends YugabyteDBContainerTestBase {
           Awaitility.await()
               .atMost(Duration.ofSeconds(seconds))
               .until(() -> {
-                  int consumed = super.consumeAvailableRecords(record -> {
+                  int consumed = consumeAvailableRecords(record -> {
                       LOGGER.debug("The record being consumed is " + record);
                       records.add(record);
                   });

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotResumeTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotResumeTest.java
@@ -65,7 +65,7 @@ public class YugabyteDBSnapshotResumeTest extends YugabyteDBContainerTestBase {
 		String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
 		Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
 		configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE, YugabyteDBConnectorConfig.SnapshotMode.INITIAL.getValue());
-		start(YugabyteDBConnector.class, configBuilder.build());
+		startEngine(configBuilder);
 		awaitUntilConnectorIsReady();
 
 		// Consume whatever records are available.
@@ -83,7 +83,7 @@ public class YugabyteDBSnapshotResumeTest extends YugabyteDBContainerTestBase {
 
 		// Start the connector again - this step will ensure that the connector is resuming the snapshot
 		// and only starting the consumption from the point it left.
-		start(YugabyteDBConnector.class, configBuilder.build());
+		startEngine(configBuilder);
 		awaitUntilConnectorIsReady();
 
 		// Only verifying the record count since the snapshot records are not ordered, so it may be
@@ -118,7 +118,7 @@ public class YugabyteDBSnapshotResumeTest extends YugabyteDBContainerTestBase {
 			Awaitility.await()
 				.atMost(Duration.ofSeconds(seconds))
 				.until(() -> {
-					int consumed = super.consumeAvailableRecords(record -> {
+					int consumed = consumeAvailableRecords(record -> {
 						LOGGER.debug("The record being consumed is " + record);
 						records.add(record);
 					});
@@ -141,7 +141,7 @@ public class YugabyteDBSnapshotResumeTest extends YugabyteDBContainerTestBase {
 		Awaitility.await()
 			.atMost(Duration.ofSeconds(60))
 			.until(() -> {
-				int consumed = super.consumeAvailableRecords(record -> {
+				int consumed = consumeAvailableRecords(record -> {
 					LOGGER.debug("The record being consumed is " + record);
 				});
 				if (consumed > 0) {

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
  */
-public class YugabyteDBSnapshotTest extends YugabytedTestBase {
+public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
     @BeforeAll
     public static void beforeClass() throws Exception {
         initializeYBContainer();
@@ -65,7 +65,7 @@ public class YugabyteDBSnapshotTest extends YugabytedTestBase {
         Configuration.Builder configBuilder =
           TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME, "public.test_1", dbStreamId);
         configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE, YugabyteDBConnectorConfig.SnapshotMode.INITIAL.getValue());
-        start(YugabyteDBConnector.class, configBuilder.build());
+        startEngine(configBuilder);
 
         awaitUntilConnectorIsReady();
 
@@ -98,7 +98,7 @@ public class YugabyteDBSnapshotTest extends YugabytedTestBase {
         configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE, "initial");
         configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE_TABLES, "public.test_1");
 
-        start(YugabyteDBConnector.class, configBuilder.build());
+        startEngine(configBuilder);
 
         awaitUntilConnectorIsReady();
 
@@ -132,7 +132,7 @@ public class YugabyteDBSnapshotTest extends YugabytedTestBase {
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME, "public.test_1", dbStreamId);
         configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE, "initial");
 
-        start(YugabyteDBConnector.class, configBuilder.build());
+        startEngine(configBuilder);
 
         awaitUntilConnectorIsReady();
 
@@ -168,7 +168,7 @@ public class YugabyteDBSnapshotTest extends YugabytedTestBase {
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME, "public.test_1", dbStreamId);
         configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE, "initial");
 
-        start(YugabyteDBConnector.class, configBuilder.build());
+        startEngine(configBuilder);
 
         awaitUntilConnectorIsReady();
 
@@ -203,7 +203,7 @@ public class YugabyteDBSnapshotTest extends YugabytedTestBase {
         Configuration.Builder configBuilder =
           TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME, "public.test_1,public.test_2,public.test_3", dbStreamId);
         configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE, YugabyteDBConnectorConfig.SnapshotMode.INITIAL.getValue());
-        start(YugabyteDBConnector.class, configBuilder.build());
+        startEngine(configBuilder);
 
         awaitUntilConnectorIsReady();
 
@@ -250,7 +250,7 @@ public class YugabyteDBSnapshotTest extends YugabytedTestBase {
         Configuration.Builder configBuilder =
           TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME, "public.test_1,public.test_2,public.test_3,public.test_no_colocated", dbStreamId);
         configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE, YugabyteDBConnectorConfig.SnapshotMode.INITIAL.getValue());
-        start(YugabyteDBConnector.class, configBuilder.build());
+        startEngine(configBuilder);
 
         awaitUntilConnectorIsReady();
 
@@ -300,7 +300,7 @@ public class YugabyteDBSnapshotTest extends YugabytedTestBase {
         Configuration.Builder configBuilder =
           TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME, "public.test_1,public.test_2,public.test_3,public.test_no_colocated", dbStreamId);
         configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE, YugabyteDBConnectorConfig.SnapshotMode.INITIAL.getValue());
-        start(YugabyteDBConnector.class, configBuilder.build());
+        startEngine(configBuilder);
 
         awaitUntilConnectorIsReady();
 
@@ -404,7 +404,7 @@ public class YugabyteDBSnapshotTest extends YugabytedTestBase {
             Awaitility.await()
               .atMost(Duration.ofSeconds(seconds))
               .until(() -> {
-                  int consumed = super.consumeAvailableRecords(record -> {
+                  int consumed = consumeAvailableRecords(record -> {
                       LOGGER.debug("The record being consumed is " + record);
                       records.add(record);
                   });

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -105,7 +105,7 @@ public class YugabyteDBSnapshotTest extends YugabytedTestBase {
         // Dummy wait condition to wait for another 15 seconds
         TestHelper.waitFor(Duration.ofSeconds(15));
 
-        SourceRecords records = consumeRecordsByTopic(recordCountT1);
+        SourceRecords records = consumeByTopic(recordCountT1);
 
         assertNotNull(records);
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
  */
-public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
+public class YugabyteDBSnapshotTest extends YugabytedTestBase {
     @BeforeAll
     public static void beforeClass() throws Exception {
         initializeYBContainer();

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTabletSplitTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTabletSplitTest.java
@@ -109,7 +109,7 @@ public class YugabyteDBTabletSplitTest extends YugabyteDBContainerTestBase {
     }
 
     // Consume the records now - there will be 100 records in total.
-    SourceRecords records = consumeRecordsByTopic(100);
+    SourceRecords records = consumeByTopic(100);
     
     // Verify that the records are there in the topic.
     assertEquals(100, records.recordsForTopic("test_server.public.t1").size());

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTabletSplitTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTabletSplitTest.java
@@ -63,7 +63,7 @@ public class YugabyteDBTabletSplitTest extends YugabyteDBContainerTestBase {
     String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
     Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
 
-    start(YugabyteDBConnector.class, configBuilder.build(), (success, message, error) -> {
+    startEngine(configBuilder, (success, message, error) -> {
       assertTrue(success);
     });
 
@@ -175,7 +175,7 @@ public class YugabyteDBTabletSplitTest extends YugabyteDBContainerTestBase {
     String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
     Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
 
-    start(YugabyteDBConnector.class, configBuilder.build(), (success, message, error) -> {
+    startEngine(configBuilder, (success, message, error) -> {
       assertTrue(success);
     });
 
@@ -206,7 +206,7 @@ public class YugabyteDBTabletSplitTest extends YugabyteDBContainerTestBase {
     Set<Integer> recordKeySet = new HashSet<>();
     int failureCounter = 0;
     while (recordKeySet.size() < recordsCount) {
-        int consumed = super.consumeAvailableRecords(record -> {
+        int consumed = consumeAvailableRecords(record -> {
             Struct s = (Struct) record.key();
             int value = s.getStruct("id").getInt32("value");
             recordKeySet.add(value);

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionMetadataTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionMetadataTest.java
@@ -60,7 +60,7 @@ public class YugabyteDBTransactionMetadataTest extends YugabyteDBContainerTestBa
 			configBuilder.with(YugabyteDBConnectorConfig.TRANSACTION_TOPIC, transactionTopicName);
 		}
 
-		start(YugabyteDBConnector.class, configBuilder.build());
+		startEngine(configBuilder);
 		awaitUntilConnectorIsReady();
 
 		TestHelper.execute(String.format(INSERT_FORMAT, 1, 5));
@@ -87,7 +87,7 @@ public class YugabyteDBTransactionMetadataTest extends YugabyteDBContainerTestBa
 
 		String transactionTopicName = TestHelper.TEST_SERVER + ".transaction";
 
-		start(YugabyteDBConnector.class, configBuilder.build());
+		startEngine(configBuilder);
 		awaitUntilConnectorIsReady();
 
 		TestHelper.execute(String.format(INSERT_FORMAT, 1, 5));
@@ -132,7 +132,7 @@ public class YugabyteDBTransactionMetadataTest extends YugabyteDBContainerTestBa
 
 		String transactionTopicName = TestHelper.TEST_SERVER + ".transaction";
 
-		start(YugabyteDBConnector.class, configBuilder.build());
+		startEngine(configBuilder);
 		awaitUntilConnectorIsReady();
 
 		final String statementBatch = "BEGIN; " 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionMetadataTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionMetadataTest.java
@@ -98,7 +98,7 @@ public class YugabyteDBTransactionMetadataTest extends YugabyteDBContainerTestBa
 		waitForAvailableRecords(10000, TimeUnit.MILLISECONDS);
 
 		// Consume records
-		SourceRecords records = consumeRecordsByTopic(
+		SourceRecords records = consumeByTopic(
 			24 /* BEGIN + 5 INSERT + COMMIT + BEGIN + 15 INSERT + COMMIT*/);
 
 		// Assert for records in the transaction topic.
@@ -143,7 +143,7 @@ public class YugabyteDBTransactionMetadataTest extends YugabyteDBContainerTestBa
 		waitForAvailableRecords(15000, TimeUnit.MILLISECONDS);
 
 		// Consume records
-		SourceRecords records = consumeRecordsByTopic(24 /* BEGIN + 20 INSERT + COMMIT*/);
+		SourceRecords records = consumeByTopic(24 /* BEGIN + 20 INSERT + COMMIT*/);
 
 		// Assert for records in the transaction topic.
 		List<SourceRecord> metadataRecords = records.recordsForTopic(transactionTopicName);

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionMetadataTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionMetadataTest.java
@@ -69,7 +69,7 @@ public class YugabyteDBTransactionMetadataTest extends YugabyteDBContainerTestBa
 		waitForAvailableRecords(10000, TimeUnit.MILLISECONDS);
 
 		// Consume records
-		SourceRecords records = consumeRecordsByTopic(7 /* BEGIN + 5 INSERT + COMMIT */);
+		SourceRecords records = consumeByTopic(7 /* BEGIN + 5 INSERT + COMMIT */);
 
 		// Assert for records in the transaction topic.
 		List<SourceRecord> metadataRecords = records.recordsForTopic(transactionTopicName);

--- a/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
@@ -138,7 +138,7 @@ public class TestBaseClass extends AbstractConnectorTest {
                           DebeziumEngine.CompletionCallback callback) {
     configBuilder
       .with(EmbeddedEngine.ENGINE_NAME, "test-connector")
-      .with(EmbeddedEngine.OFFSET_STORAGE, MemoryOffsetBackingStore.class.getSimpleName())
+      .with(EmbeddedEngine.OFFSET_STORAGE, MemoryOffsetBackingStore.class.getName())
       .with(EmbeddedEngine.OFFSET_FLUSH_INTERVAL_MS, 0)
       .with(EmbeddedEngine.CONNECTOR_CLASS, YugabyteDBConnector.class);
 

--- a/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
@@ -29,6 +29,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -206,6 +207,24 @@ public class TestBaseClass extends AbstractConnectorTest {
     }
 
     return records;
+  }
+
+  @Override
+  protected void assertNoRecordsToConsume() {
+    assertTrue(consumedLines.isEmpty());
+  }
+
+  @Override
+  protected boolean waitForAvailableRecords(long timeout, TimeUnit unit) {
+    assertTrue(timeout >= 0);
+    long now = System.currentTimeMillis();
+    long stop = now + unit.toMillis(timeout);
+    while (System.currentTimeMillis() < stop) {
+        if (!consumedLines.isEmpty()) {
+            break;
+        }
+    }
+    return !consumedLines.isEmpty();
   }
 
   protected class SourceRecords {

--- a/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
@@ -63,9 +63,7 @@ public class TestBaseClass extends AbstractConnectorTest {
   @BeforeAll
   public static void initializeTestFramework() {
     LoggingContext.forConnector(YugabyteDBConnector.class.getSimpleName(), "", "test");
-        consumedLines = new ArrayBlockingQueue<>(getMaximumRecordCount());
-        Testing.Files.delete(OFFSET_STORE_PATH);
-        OFFSET_STORE_PATH.getParent().toFile().mkdirs();
+    consumedLines = new ArrayBlockingQueue<>(getMaximumRecordCount());
   }
 
   protected static int getMaximumRecordCount() {
@@ -171,6 +169,7 @@ public class TestBaseClass extends AbstractConnectorTest {
                .using(this.getClass().getClassLoader())
                .notifying((records, committer) -> {
                  for (SourceRecord record: records) {
+                   consumedLines.offer(record);
                    committer.markProcessed(record);
 
                    offsetMapForRecords = record.sourceOffset();
@@ -195,5 +194,5 @@ public class TestBaseClass extends AbstractConnectorTest {
         records.forEach(recordConsumer);
     }
     return records.size();
-}
+  }
 }

--- a/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
@@ -1,9 +1,16 @@
 package io.debezium.connector.yugabytedb.common;
 
+import io.debezium.config.Configuration;
 import io.debezium.connector.yugabytedb.container.YugabyteCustomContainer;
 import io.debezium.connector.yugabytedb.rules.YugabyteDBLogTestName;
 import io.debezium.embedded.AbstractConnectorTest;
+import io.debezium.embedded.EmbeddedEngine;
+import io.debezium.engine.DebeziumEngine;
+import io.debezium.engine.spi.OffsetCommitPolicy;
+import io.debezium.util.LoggingContext;
+import io.debezium.util.Testing;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceConnector;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.awaitility.Awaitility;
 
@@ -13,6 +20,11 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.YugabyteYSQLContainer;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -25,10 +37,12 @@ import static org.junit.jupiter.api.Assertions.*;
 public class TestBaseClass extends AbstractConnectorTest {
     public Logger LOGGER = LoggerFactory.getLogger(getClass());
     protected static YugabyteCustomContainer ybContainer;
-
+    protected CountDownLatch countDownLatch;
     protected final String DEFAULT_DB_NAME = "yugabyte";
     protected final String DEFAULT_COLOCATED_DB_NAME = "colocated_database";
     protected static String yugabytedStartCommand = "";
+    protected Map<String, ?> offsetMapForRecords = new HashMap<>();
+    protected ExecutorService engineExecutor;
 
     protected void awaitUntilConnectorIsReady() throws Exception {
         Awaitility.await()
@@ -92,5 +106,60 @@ public class TestBaseClass extends AbstractConnectorTest {
 
   protected static String getYugabytedStartCommand() {
         return yugabytedStartCommand;
-    }
+  }
+
+  public void startEngine(Class<? extends SourceConnector> connectorClass, Configuration configuration) {
+    startEngine(connectorClass, configuration, (success, message, error) -> {});
+  }
+
+  public void startEngine(Class<? extends SourceConnector> connectorClass,
+                          Configuration configuration,
+                          DebeziumEngine.CompletionCallback callback) {
+    countDownLatch = new CountDownLatch(1);
+    DebeziumEngine.CompletionCallback wrapperCallback = (success, msg, error) -> {
+      try {
+        if (callback != null) {
+          callback.handle(success, msg, error);
+        }
+      }
+      finally {
+        if (!success) {
+          // we only unblock if there was an error; in all other cases we're unblocking when a task has been started
+          countDownLatch.countDown();
+        }
+      }
+      Testing.debug("Stopped connector");
+    };
+
+    DebeziumEngine.ConnectorCallback connectorCallback = new DebeziumEngine.ConnectorCallback() {
+      @Override
+      public void taskStarted() {
+        // if this is called, it means a task has been started successfully so we can continue
+        countDownLatch.countDown();
+      }
+    };
+
+    engine = (EmbeddedEngine) EmbeddedEngine.create()
+               .using(OffsetCommitPolicy.always())
+               .using(wrapperCallback)
+               .using(connectorCallback)
+               .using(this.getClass().getClassLoader())
+               .notifying((records, committer) -> {
+                 for (SourceRecord record: records) {
+                   committer.markProcessed(record);
+
+                   offsetMapForRecords = record.sourceOffset();
+                 }
+
+                 // This method here is responsible for calling the commit() method which later
+                 // invokes commitOffset() in the change event source classes.
+                 committer.markBatchFinished();
+               }).build();
+
+    engineExecutor = Executors.newFixedThreadPool(1);
+    engineExecutor.submit(() -> {
+      LoggingContext.forConnector(getClass().getSimpleName(), "", "engine");
+      engine.run();
+    });
+  }
 }

--- a/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
@@ -2,7 +2,6 @@ package io.debezium.connector.yugabytedb.common;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.yugabytedb.YugabyteDBConnector;
-import io.debezium.connector.yugabytedb.YugabyteDBConnectorConfig;
 import io.debezium.connector.yugabytedb.container.YugabyteCustomContainer;
 import io.debezium.connector.yugabytedb.rules.YugabyteDBLogTestName;
 import io.debezium.embedded.AbstractConnectorTest;
@@ -13,7 +12,6 @@ import io.debezium.util.LoggingContext;
 import io.debezium.util.Testing;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
-import org.apache.kafka.connect.source.SourceConnector;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.awaitility.Awaitility;
 


### PR DESCRIPTION
This PR modifies the following things:
1. Converts all tests to use EXPLICIT checkpointing
    a. Added custom engine implementation to use a record committer
    b. Overridden some test functions because the super class members were `private`
2. Fixed an error faced while running tests for snapshot with explicit checkpointing 