### PR TITLE
[#222] Fix test infra error of not consuming records

### DIFF
--- a/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
@@ -181,17 +181,15 @@ public class TestBaseClass extends AbstractConnectorTest {
   }
 
   protected int consumeAvailableRecords(Consumer<SourceRecord> recordConsumer) {
-    List<SourceRecord> records = new LinkedList<>();
-
-    // Add all the consumed records to the list.
-    while (!consumedLines.isEmpty()) {
-      records.add(consumedLines.poll());
-    }
-
     if (recordConsumer != null) {
-        records.forEach(recordConsumer);
+        consumedLines.forEach(recordConsumer);
     }
-    return records.size();
+
+    // Read the size of the queue to return later and clear it.
+    final int queueSize = consumedLines.size();
+    consumedLines.clear();
+
+    return queueSize;
   }
 
   protected SourceRecords consumeByTopic(int numRecords) throws InterruptedException {


### PR DESCRIPTION
After recent changes where we migrated all the test infra to use explicit checkpointing, it was observed that in the infra was returning inconsistent consumed records intermittently.

Upon investigation, it was discovered that the queue we are using to hold the records can only hold certain number of records at a time which was the culprit. This PR adds a fix by removing the upper limit on the count of records.

Additionally, this closes #222 