### PR TITLE
Add `walSegmentIndex` parameter while requesting changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.kafka>3.3.1</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>
-        <version.ybclient>0.8.52-SNAPSHOT</version.ybclient>
+        <version.ybclient>0.8.56-20230615.071435-1</version.ybclient>
         <version.gson>2.8.9</version.gson>
 
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.kafka>3.3.1</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>
-        <version.ybclient>0.8.54-20230522.234617-1</version.ybclient>
+        <version.ybclient>0.8.52-SNAPSHOT</version.ybclient>
         <version.gson>2.8.9</version.gson>
 
         <!--

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -97,6 +97,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
         this.transactionContext = new YugabyteDBTransactionContext();
         this.incrementalSnapshotContext = new SignalBasedIncrementalSnapshotContext<>();
         this.connectorConfig = config;
+        this.tabletWalSegmentIndex = new ConcurrentHashMap<>();
     }
 
     public static YugabyteDBOffsetContext initialContextForSnapshot(YugabyteDBConnectorConfig connectorConfig,

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -192,7 +192,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
     }
 
     public Integer getWalSegmentIndex(YBPartition partition) {
-        return this.tabletWalSegmentIndex.get(partition.getId());
+        return this.tabletWalSegmentIndex.getOrDefault(partition.getId(), 0);
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -45,6 +45,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
     private YugabyteDBTransactionContext transactionContext;
     private IncrementalSnapshotContext<TableId> incrementalSnapshotContext;
     private YugabyteDBConnectorConfig connectorConfig;
+    private final Map<String, Integer> tabletWalSegmentIndex;
 
     private YugabyteDBOffsetContext(YugabyteDBConnectorConfig connectorConfig,
                                     OpId lsn, OpId lastCompletelyProcessedLsn,
@@ -73,6 +74,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
         this.transactionContext = transactionContext;
         this.incrementalSnapshotContext = incrementalSnapshotContext;
         this.connectorConfig = connectorConfig;
+        this.tabletWalSegmentIndex = new ConcurrentHashMap<>();
     }
 
     public YugabyteDBOffsetContext(Offsets<YBPartition, YugabyteDBOffsetContext> previousOffsets,
@@ -182,6 +184,14 @@ public class YugabyteDBOffsetContext implements OffsetContext {
 
     public Struct getSourceInfoForTablet(YBPartition partition) {
         return this.tabletSourceInfo.get(partition.getId()).struct();
+    }
+
+    public void updateWalSegmentIndex(YBPartition partition, int index) {
+        this.tabletWalSegmentIndex.put(partition.getId(), index);
+    }
+
+    public Integer getWalSegmentIndex(YBPartition partition) {
+        return this.tabletWalSegmentIndex.get(partition.getId());
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -399,7 +399,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                     connectorConfig.streamId(), tabletId, cp.getTerm(), cp.getIndex(), cp.getKey(),
                     cp.getWrite_id(), cp.getTime(), schemaNeeded.get(part.getId()),
                     taskContext.shouldEnableExplicitCheckpointing() ? tabletToExplicitCheckpoint.get(part.getId()) : null,
-                    tabletSafeTime.getOrDefault(part.getId(), -1L), previousOffset.getWalSegmentIndex(part));
+                    tabletSafeTime.getOrDefault(part.getId(), -1L));
 
                 tabletSafeTime.put(part.getId(), resp.getResp().getSafeHybridTime());
 
@@ -535,7 +535,6 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                 }
 
                 previousOffset.getSourceInfo(part).updateLastCommit(finalOpId);
-                previousOffset.updateWalSegmentIndex(part, resp.getResp().getWalSegmentIndex());
             }
             
             // Reset the retry count here indicating that if the flow has reached here then

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -399,7 +399,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                     connectorConfig.streamId(), tabletId, cp.getTerm(), cp.getIndex(), cp.getKey(),
                     cp.getWrite_id(), cp.getTime(), schemaNeeded.get(part.getId()),
                     taskContext.shouldEnableExplicitCheckpointing() ? tabletToExplicitCheckpoint.get(part.getId()) : null,
-                    tabletSafeTime.getOrDefault(part.getId(), -1L));
+                    tabletSafeTime.getOrDefault(part.getId(), -1L), previousOffset.getWalSegmentIndex(part));
 
                 tabletSafeTime.put(part.getId(), resp.getResp().getSafeHybridTime());
 
@@ -535,6 +535,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                 }
 
                 previousOffset.getSourceInfo(part).updateLastCommit(finalOpId);
+                previousOffset.updateWalSegmentIndex(part, resp.getResp().getWalSegmentIndex());
             }
             
             // Reset the retry count here indicating that if the flow has reached here then

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -366,7 +366,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                                 GetChangesResponse resp = this.syncClient.getChangesCDCSDK(
                                   tableIdToTable.get(part.getTableId()), streamId, tabletId, cp.getTerm(), cp.getIndex(), cp.getKey(),
                                   cp.getWrite_id(), cp.getTime(), schemaNeeded.get(part.getId()), explicitCheckpoint,
-                                  tabletSafeTime.getOrDefault(part.getId(), -1L));
+                                  tabletSafeTime.getOrDefault(part.getId(), -1L), offsetContext.getWalSegmentIndex(part));
 
                                 // We do not update the tablet safetime we get from the response at this
                                 // point because the previous GetChanges call is supposed to throw
@@ -638,6 +638,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                                 response.getWriteId(),
                                 response.getSnapshotTime());
                         offsetContext.getSourceInfo(part).updateLastCommit(finalOpid);
+                        offsetContext.updateWalSegmentIndex(part, response.getResp().getWalSegmentIndex());
 
                         LOGGER.debug("The final opid is " + finalOpid);
                     }

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/pgproto/YbProtoColumnValue.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/pgproto/YbProtoColumnValue.java
@@ -21,7 +21,7 @@ import org.postgresql.jdbc.PgArray;
 import org.postgresql.util.PGmoney;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.yb.Value;
+import org.yb.Common;
 
 import io.debezium.connector.yugabytedb.PgOid;
 import io.debezium.connector.yugabytedb.YugabyteDBStreamingChangeEventSource.PgConnectionSupplier;
@@ -38,7 +38,7 @@ import io.debezium.time.Conversions;
  *
  * @author Chris Cranford
  */
-public class YbProtoColumnValue extends AbstractColumnValue<Value.DatumMessagePB> {
+public class YbProtoColumnValue extends AbstractColumnValue<Common.DatumMessagePB> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(YbProtoColumnValue.class);
 
@@ -54,14 +54,14 @@ public class YbProtoColumnValue extends AbstractColumnValue<Value.DatumMessagePB
      */
     private static final long TIMESTAMP_MAX = 9223371331200000000L;
 
-    private Value.DatumMessagePB value;
+    private Common.DatumMessagePB value;
 
-    public YbProtoColumnValue(Value.DatumMessagePB value) {
+    public YbProtoColumnValue(Common.DatumMessagePB value) {
         this.value = value;
     }
 
     @Override
-    public Value.DatumMessagePB getRawValue() {
+    public Common.DatumMessagePB getRawValue() {
         return value;
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/pgproto/YbProtoReplicationMessage.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/pgproto/YbProtoReplicationMessage.java
@@ -15,7 +15,7 @@ import java.util.stream.IntStream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.yb.Value;
+import org.yb.Common;
 import org.yb.cdc.CdcService;
 
 import io.debezium.connector.yugabytedb.YugabyteDBStreamingChangeEventSource.PgConnectionSupplier;
@@ -97,11 +97,11 @@ public class YbProtoReplicationMessage implements ReplicationMessage {
         return !(rawMessage.getNewTypeinfoList() == null || rawMessage.getNewTypeinfoList().isEmpty());
     }
 
-    private List<ReplicationMessage.Column> transform(List<Value.DatumMessagePB> messageList,
+    private List<ReplicationMessage.Column> transform(List<Common.DatumMessagePB> messageList,
                                                       List<CdcService.TypeInfo> typeInfoList) {
         return IntStream.range(0, messageList.size())
                 .mapToObj(index -> {
-                    final Value.DatumMessagePB datum = messageList.get(index);
+                    final Common.DatumMessagePB datum = messageList.get(index);
                     final Optional<CdcService.TypeInfo> typeInfo = Optional.ofNullable(hasTypeMetadata() && typeInfoList != null ? typeInfoList.get(index) : null);
                     final String columnName = Strings.unquoteIdentifierPart(datum.getColumnName());
                     final YugabyteDBType type = yugabyteDBTypeRegistry.get((int) datum.getColumnType());
@@ -132,7 +132,7 @@ public class YbProtoReplicationMessage implements ReplicationMessage {
     }
 
     public Object getValue(String columnName, YugabyteDBType type, String fullType,
-                           Value.DatumMessagePB datumMessage,
+                           Common.DatumMessagePB datumMessage,
                            final PgConnectionSupplier connection,
                            boolean includeUnknownDatatypes) {
         final YbProtoColumnValue columnValue = new YbProtoColumnValue(datumMessage);


### PR DESCRIPTION
This PR uses an additional parameter called `walSegmentIndex` while calling the API to get the changes.

For testing of this PR, consistency tests have been run separately to make sure we are getting records properly.