### PR TITLE
Test infra changes to fix flakiness

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -601,7 +601,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                                         Objects.requireNonNull(tableId);
                                     }
                                     // If you need to print the received record, change debug level to info
-                                    LOGGER.info("Received DML record {}", record);
+                                    LOGGER.debug("Received DML record {}", record);
 
                                     offsetContext.updateWalPosition(part, lsn, lastCompletelyProcessedLsn, message.getCommitTime(),
                                             String.valueOf(message.getTransactionId()), tableId, null/* taskContext.getSlotXmin(connection) */);


### PR DESCRIPTION
This PR changes the type for the object the test infra uses to store the consumed records from the connector. Simultaneously, this renames the object so that it doesn't conflict with the super object.