### PR TITLE
Remove guard logic of using the checkpoints sent by server

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -259,7 +259,6 @@ public class YugabyteDBOffsetContext implements OffsetContext {
 
     public void initSourceInfo(YBPartition partition, YugabyteDBConnectorConfig connectorConfig, OpId opId) {
         this.tabletSourceInfo.put(partition.getId(), new SourceInfo(connectorConfig, opId));
-        this.fromLsn.put(partition.getId(), opId);
     }
 
     public Map<String, SourceInfo> getTabletSourceInfo() {


### PR DESCRIPTION
## Problem

A guard logic was added in a previous PR #236 to forcefully use the checkpoints being sent by the service. However, in case of colocated tables, the guard caused issues causing the connector to request changes from an `OpId` previous than what was checkpointed.

## Solution

This PR removes the guard logic causing the issues. Also tracking probable issues in the ticket https://github.com/yugabyte/yugabyte-db/issues/18050 for later discussions around this.

### Test plan

Run the complete test suite.