### PR TITLE
Explicit checkpoint wait on Tablet Split is now based on LastRecordLsn

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
@@ -106,7 +106,6 @@ public final class SourceInfo extends BaseSourceInfo {
      */
     protected SourceInfo updateLastCommit(OpId lsn) {
         this.lastCommitLsn = lsn;
-        this.lsn = lsn;
         return this;
     }
 
@@ -123,6 +122,10 @@ public final class SourceInfo extends BaseSourceInfo {
 
     public OpId lsn() {
         return this.lsn;
+    }
+
+    public OpId lastCommitLsn() {
+        return lastCommitLsn;
     }
 
     public String sequence() {

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
@@ -138,4 +138,14 @@ public class OpId implements Comparable<OpId> {
     public CdcSdkCheckpoint toCdcSdkCheckpoint() {
         return new CdcSdkCheckpoint(this.term, this.index, this.key, this.write_id, this.time);
     }
+
+    /**
+     * Verify the equality of OpId with the given {@link CdcSdkCheckpoint}
+     * @param checkpoint
+     * @return true if the term and index of this {@link OpId} are equal to the ones in
+     * {@link CdcSdkCheckpoint}
+     */
+    public boolean equals(CdcSdkCheckpoint checkpoint) {
+        return (this.term == checkpoint.getTerm()) && (this.index == checkpoint.getIndex());
+    }
 }

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
@@ -140,12 +140,13 @@ public class OpId implements Comparable<OpId> {
     }
 
     /**
-     * Verify the equality of OpId with the given {@link CdcSdkCheckpoint}
+     * Verify that the OpId is lesser than or equal to the given {@link CdcSdkCheckpoint}
      * @param checkpoint
-     * @return true if the term and index of this {@link OpId} are equal to the ones in
-     * {@link CdcSdkCheckpoint}
+     * @return true if the term and index of time of this {@link OpId} are lesser than or equal to
+     * the corresponding values in {@link CdcSdkCheckpoint}
      */
-    public boolean equals(CdcSdkCheckpoint checkpoint) {
-        return (this.term == checkpoint.getTerm()) && (this.index == checkpoint.getIndex());
+    public boolean isLesserThanOrEqualTo(CdcSdkCheckpoint checkpoint) {
+        return (checkpoint.getTerm() >= this.term && checkpoint.getIndex() >= this.index
+                && checkpoint.getTime() >= this.time);
     }
 }


### PR DESCRIPTION
We will populate the last seen record's checkpoint in the "lastCommitLsn" field. This is meant to have the explicit checkpoint details of the last seen record from any response (i,e the from_op_id and the record’s commit_time). We will try to update this value in every GetChanges call. 

After “lastCommitLsn” is updated as needed, we will then see the response checkpoint from the current GetChanges response. If the response checkpoint is higher : 
1. We will store the response’s checkpoint, if the response’s checkpoint is higher than “lastReadRecordCheckpoint”
2. We will add this tablet to a wait-list, where we will first wait until the ExplicitCheckpoint of the tablet is equal to: “lastReadRecordCheckpoint”.
3. After the ExplicitCheckpoint was equal to “lastReadRecordCheckpoint”, then we can update the ExplicitCheckpoint value of the tablet to the response’s checkpoint i.e directly update ExplicitCheckpoint in the “tabletToExplicitCheckpoint“ map.  

This will take care of updating the ExplicitCheckpoint in cases of NoOp messages in the RAFT WAL , and also take care of tablets splitting right after a previous split in which case there will be no records to checkpoint. 
