### PR TITLE
Explicit checkpoint wait on Tablet Split is now based on LastRecordCheckpoint

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
@@ -106,7 +106,6 @@ public final class SourceInfo extends BaseSourceInfo {
      */
     protected SourceInfo updateLastCommit(OpId lsn) {
         this.lastCommitLsn = lsn;
-        this.lsn = lsn;
         return this;
     }
 
@@ -123,6 +122,10 @@ public final class SourceInfo extends BaseSourceInfo {
 
     public OpId lsn() {
         return this.lsn;
+    }
+
+    public OpId lastCommitLsn() {
+        return lastCommitLsn;
     }
 
     public String sequence() {

--- a/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
@@ -45,7 +45,7 @@ public final class SourceInfo extends BaseSourceInfo {
     private final String dbName;
 
     private OpId lsn;
-    private OpId lastCommitLsn;
+    private OpId lastRecordCheckpoint;
     private String txId;
     private Instant timestamp;
     private String schemaName;
@@ -63,7 +63,7 @@ public final class SourceInfo extends BaseSourceInfo {
     protected SourceInfo(YugabyteDBConnectorConfig connectorConfig, OpId lastCommitLsn) {
         super(connectorConfig);
         this.dbName = connectorConfig.databaseName();
-        this.lastCommitLsn = lastCommitLsn;
+        this.lastRecordCheckpoint = lastCommitLsn;
         this.lsn = lastCommitLsn;
     }
 
@@ -105,7 +105,7 @@ public final class SourceInfo extends BaseSourceInfo {
      * Updates the source with the LSN of the last committed transaction.
      */
     protected SourceInfo updateLastCommit(OpId lsn) {
-        this.lastCommitLsn = lsn;
+        this.lastRecordCheckpoint = lsn;
         return this;
     }
 
@@ -124,14 +124,14 @@ public final class SourceInfo extends BaseSourceInfo {
         return this.lsn;
     }
 
-    public OpId lastCommitLsn() {
-        return lastCommitLsn;
+    public OpId lastRecordCheckpoint() {
+        return lastRecordCheckpoint;
     }
 
     public String sequence() {
         List<String> sequence = new ArrayList<String>(2);
-        String lastCommitLsn = (this.lastCommitLsn != null)
-                ? this.lastCommitLsn.toSerString()
+        String lastCommitLsn = (this.lastRecordCheckpoint != null)
+                ? this.lastRecordCheckpoint.toSerString()
                 : null;
         String lsn = (this.lsn != null)
                 ? this.lsn.toSerString()
@@ -200,8 +200,8 @@ public final class SourceInfo extends BaseSourceInfo {
         if (txId != null) {
             sb.append(", txId=").append(txId);
         }
-        if (lastCommitLsn != null) {
-            sb.append(", lastCommitLsn=").append(lastCommitLsn);
+        if (lastRecordCheckpoint != null) {
+            sb.append(", lastCommitLsn=").append(lastRecordCheckpoint);
         }
         if (timestamp != null) {
             sb.append(", timestamp=").append(timestamp);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -277,14 +277,6 @@ public class YugabyteDBOffsetContext implements OffsetContext {
         return this.fromLsn.getOrDefault(partition.getId(), streamingStartLsn());
     }
 
-    /**
-     * Get the LSN of the last seen record from GetChanges
-     * @param partition
-     * @return
-     */
-    OpId commitLsn(YBPartition partition) {
-        return this.tabletSourceInfo.get(partition.getId()).lastCommitLsn();
-    }
 
     /**
      * If a previous OpId is null then we want the server to send the snapshot from the

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -328,6 +328,9 @@ public class YugabyteDBStreamingChangeEventSource implements
             // based on just their tablet IDs - pass false as the 'colocated' flag to enforce the same.
             YBPartition p = new YBPartition(entry.getKey(), entry.getValue(), false /* colocated */);
             offsetContext.initSourceInfo(p, this.connectorConfig, opId);
+            // We can initialise the explicit checkpoint for this tablet to the value returned by
+            // the cdc_service through the 'GetTabletListToPollForCDC' API
+            tabletToExplicitCheckpoint.put(p.getId(), opId.toCdcSdkCheckpoint());
             schemaNeeded.put(p.getId(), Boolean.TRUE);
         }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -405,7 +405,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                             // Call getChanges to make sure checkpoint is set on the cdc_state table.
                             LOGGER.info("Setting explicit checkpoint is set to {}.{}", explicitCheckpoint.getTerm(), explicitCheckpoint.getIndex());
                             setCheckpointWithGetChanges(tableIdToTable.get(part.getTableId()), part,
-                                lastRecordCheckpoint, explicitCheckpoint, schemaNeeded.get(part.getId()),
+                                cp, explicitCheckpoint, schemaNeeded.get(part.getId()),
                                 tabletSafeTime.get(part.getId()), offsetContext.getWalSegmentIndex(part));
 
                             LOGGER.info("Handling tablet split for enqueued tablet {} as we have now received the commit callback",

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
@@ -146,7 +146,7 @@ public class OpId implements Comparable<OpId> {
      * the corresponding values in {@link CdcSdkCheckpoint}
      */
     public boolean isLesserThanOrEqualTo(CdcSdkCheckpoint checkpoint) {
-        return (checkpoint.getTerm() >= this.term && checkpoint.getIndex() >= this.index
-                && checkpoint.getTime() >= this.time);
+        return (checkpoint != null && this.term <= checkpoint.getTerm()
+                && this.index <= checkpoint.getIndex() && this.time <= checkpoint.getTime());
     }
 }

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
@@ -140,12 +140,13 @@ public class OpId implements Comparable<OpId> {
     }
 
     /**
-     * Verify the equality of OpId with the given {@link CdcSdkCheckpoint}
+     * Verify that the OpId is lesser than or equal to the given {@link CdcSdkCheckpoint}
      * @param checkpoint
-     * @return true if the term and index of this {@link OpId} are equal to the ones in
-     * {@link CdcSdkCheckpoint}
+     * @return true if the term and index of time of this {@link OpId} are lesser than or equal to
+     * the corresponding values in {@link CdcSdkCheckpoint}
      */
-    public boolean equals(CdcSdkCheckpoint checkpoint) {
-        return (this.term == checkpoint.getTerm()) && (this.index == checkpoint.getIndex());
+    public boolean isLesserThanOrEqualTo(CdcSdkCheckpoint checkpoint) {
+        return (checkpoint.getTerm() >= this.term && checkpoint.getIndex() >= this.index
+                && checkpoint.getTime() >= this.time);
     }
 }


### PR DESCRIPTION
We will populate the last seen record's checkpoint in the "lastRecordCheckpoint" field. This is meant to have the explicit checkpoint details of the last seen record from any response (i,e the from_op_id and the record’s commit_time). We will try to update this value in every GetChanges call.

After “lastRecordCheckpoint” is updated as needed, we will then see the response checkpoint from the current GetChanges response. If the response checkpoint is higher :

1. We will store the response’s checkpoint, if the response’s checkpoint is higher than “lastReadRecordCheckpoint”
2. We will add this tablet to a wait-list, where we will first wait until the ExplicitCheckpoint of the tablet is equal to: “lastRecordCheckpoint”.
3. After the ExplicitCheckpoint was equal to “lastRecordCheckpoint”, then we can update the ExplicitCheckpoint value of the tablet to the response’s checkpoint i.e directly update ExplicitCheckpoint in the “tabletToExplicitCheckpoint“ map.

This will take care of updating the ExplicitCheckpoint in cases of NoOp messages in the RAFT WAL , and also take care of tablets splitting right after a previous split in which case there will be no records to checkpoint.