### PR TITLE
[yugabyte/yugabyte-db#18239] Add consistency configuration properties

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeEventSourceFactory.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeEventSourceFactory.java
@@ -85,8 +85,8 @@ public class YugabyteDBChangeEventSourceFactory implements ChangeEventSourceFact
 
     @Override
     public StreamingChangeEventSource<YBPartition, YugabyteDBOffsetContext> getStreamingChangeEventSource() {
-        LOGGER.info("Consistency mode is {}", configuration.consistencyMode().getValue());
-        if (configuration.consistencyMode() == YugabyteDBConnectorConfig.ConsistencyMode.DEFAULT) {
+        LOGGER.info("Transaction ordering enabled: {}", configuration.transactionOrdering());
+        if (configuration.transactionOrdering()) {
             LOGGER.info("Instantiating Vanilla Streaming Source");
             return new YugabyteDBStreamingChangeEventSource(
                     configuration,

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -964,6 +964,15 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
                     "'skip' to skip / ignore TRUNCATE events (default), " +
                     "'include' to handle and include TRUNCATE events");
 
+    public static final Field TRANSACTION_ORDERING = Field.create("transaction.ordering")
+           .withDisplayName("Order transactions")
+           .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR, 23))
+           .withImportance(Importance.HIGH)
+           .withDefault(false)
+           .withType(Type.BOOLEAN)
+           .withValidation(Field::isBoolean)
+           .withDescription("Specify whether the transactions need to be ordered");
+
     public static final Field CONSISTENCY_MODE = Field.create("consistency.mode")
             .withDisplayName("Transaction Consistency mode")
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR, 23))
@@ -1229,6 +1238,9 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
         return truncateHandlingMode;
     }
 
+    public boolean transactionOrdering() {
+        return getConfig().getBoolean(TRANSACTION_ORDERING);
+    }
     public ConsistencyMode consistencyMode() {
         return consistencyMode;
     }
@@ -1330,7 +1342,8 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
                     INTERVAL_HANDLING_MODE,
                     SCHEMA_REFRESH_MODE,
                     TRUNCATE_HANDLING_MODE,
-                    INCREMENTAL_SNAPSHOT_CHUNK_SIZE)
+                    INCREMENTAL_SNAPSHOT_CHUNK_SIZE,
+                    TRANSACTION_ORDERING)
             .excluding(INCLUDE_SCHEMA_CHANGES)
             .create();
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConfigTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConfigTest.java
@@ -288,7 +288,7 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
         TestHelper.execute("CREATE TABLE dummy_table (id INT PRIMARY KEY);");
         final String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "dummy_table", false, false);
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.dummy_table", dbStreamId);
-        configBuilder.with(YugabyteDBConnectorConfig.CONSISTENCY_MODE, "global");
+        configBuilder.with(YugabyteDBConnectorConfig.TRANSACTION_ORDERING, true);
 
         start(YugabyteDBConnector.class, configBuilder.build(), (success, message, error) -> {
            assertFalse(success);

--- a/src/test/java/io/debezium/connector/yugabytedb/consistent/YugabyteDBConsistencyWithColocatedTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/consistent/YugabyteDBConsistencyWithColocatedTest.java
@@ -140,7 +140,7 @@ public class YugabyteDBConsistencyWithColocatedTest extends YugabyteDBContainerT
 
     private Configuration.Builder getConsistentConfigurationBuilder(String databaseName, String tableIncludeList, String dbStreamId) throws Exception {
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder(databaseName, tableIncludeList, dbStreamId);
-        configBuilder.with(YugabyteDBConnectorConfig.CONSISTENCY_MODE, "global");
+        configBuilder.with(YugabyteDBConnectorConfig.TRANSACTION_ORDERING, true);
         configBuilder.with("transforms", "Reroute");
         configBuilder.with("transforms.Reroute.type", "io.debezium.transforms.ByLogicalTableRouter");
         configBuilder.with("transforms.Reroute.topic.regex", "(.*)");

--- a/src/test/java/io/debezium/connector/yugabytedb/consistent/YugabyteDBStreamConsistencyTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/consistent/YugabyteDBStreamConsistencyTest.java
@@ -84,7 +84,7 @@ public class YugabyteDBStreamConsistencyTest extends YugabyteDBContainerTestBase
 
         String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "department");
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.department,public.employee", dbStreamId);
-        configBuilder.with(YugabyteDBConnectorConfig.CONSISTENCY_MODE, "global");
+        configBuilder.with(YugabyteDBConnectorConfig.TRANSACTION_ORDERING, true);
         configBuilder.with("transforms", "Reroute");
         configBuilder.with("transforms.Reroute.type", "io.debezium.transforms.ByLogicalTableRouter");
         configBuilder.with("transforms.Reroute.topic.regex", "(.*)");
@@ -200,7 +200,7 @@ public class YugabyteDBStreamConsistencyTest extends YugabyteDBContainerTestBase
 
         String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "department", false, true);
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.department,public.employee,public.contract,public.address,public.locality", dbStreamId);
-        configBuilder.with(YugabyteDBConnectorConfig.CONSISTENCY_MODE, "global");
+        configBuilder.with(YugabyteDBConnectorConfig.TRANSACTION_ORDERING, true);
         configBuilder.with("transforms", "Reroute");
         configBuilder.with("transforms.Reroute.type", "io.debezium.transforms.ByLogicalTableRouter");
         configBuilder.with("transforms.Reroute.topic.regex", "(.*)");
@@ -339,7 +339,7 @@ public class YugabyteDBStreamConsistencyTest extends YugabyteDBContainerTestBase
 
         final String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "department");
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.department", dbStreamId);
-        configBuilder.with(YugabyteDBConnectorConfig.CONSISTENCY_MODE, "global");
+        configBuilder.with(YugabyteDBConnectorConfig.TRANSACTION_ORDERING, true);
         configBuilder.with("transforms", "Reroute");
         configBuilder.with("transforms.Reroute.type", "io.debezium.transforms.ByLogicalTableRouter");
         configBuilder.with("transforms.Reroute.topic.regex", "(.*)");
@@ -412,7 +412,7 @@ public class YugabyteDBStreamConsistencyTest extends YugabyteDBContainerTestBase
 
         final String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "department");
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.department", dbStreamId);
-        configBuilder.with(YugabyteDBConnectorConfig.CONSISTENCY_MODE, "global");
+        configBuilder.with(YugabyteDBConnectorConfig.TRANSACTION_ORDERING, true);
         configBuilder.with("transforms", "Reroute");
         configBuilder.with("transforms.Reroute.type", "io.debezium.transforms.ByLogicalTableRouter");
         configBuilder.with("transforms.Reroute.topic.regex", "(.*)");
@@ -491,7 +491,7 @@ public class YugabyteDBStreamConsistencyTest extends YugabyteDBContainerTestBase
 
         final String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "department");
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.department", dbStreamId);
-        configBuilder.with(YugabyteDBConnectorConfig.CONSISTENCY_MODE, "global");
+        configBuilder.with(YugabyteDBConnectorConfig.TRANSACTION_ORDERING, true);
         configBuilder.with("transforms", "Reroute");
         configBuilder.with("transforms.Reroute.type", "io.debezium.transforms.ByLogicalTableRouter");
         configBuilder.with("transforms.Reroute.topic.regex", "(.*)");
@@ -566,7 +566,7 @@ public class YugabyteDBStreamConsistencyTest extends YugabyteDBContainerTestBase
 
         final String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "department");
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.department,public.employee", dbStreamId);
-        configBuilder.with(YugabyteDBConnectorConfig.CONSISTENCY_MODE, "global");
+        configBuilder.with(YugabyteDBConnectorConfig.TRANSACTION_ORDERING, true);
         configBuilder.with("transforms", "Reroute");
         configBuilder.with("transforms.Reroute.type", "io.debezium.transforms.ByLogicalTableRouter");
         configBuilder.with("transforms.Reroute.topic.regex", "(.*)");
@@ -642,7 +642,7 @@ public class YugabyteDBStreamConsistencyTest extends YugabyteDBContainerTestBase
 
         String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "department", false, true);
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.department,public.employee,public.contract,public.address,public.locality", dbStreamId);
-        configBuilder.with(YugabyteDBConnectorConfig.CONSISTENCY_MODE, "global");
+        configBuilder.with(YugabyteDBConnectorConfig.TRANSACTION_ORDERING, true);
         configBuilder.with("transforms", "Reroute");
         configBuilder.with("transforms.Reroute.type", "io.debezium.transforms.ByLogicalTableRouter");
         configBuilder.with("transforms.Reroute.topic.regex", "(.*)");
@@ -1001,7 +1001,7 @@ public class YugabyteDBStreamConsistencyTest extends YugabyteDBContainerTestBase
 
     private Configuration.Builder getConsistentConfigurationBuilder(String databaseName, String tableIncludeList, String dbStreamId) throws Exception {
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder(databaseName, tableIncludeList, dbStreamId);
-        configBuilder.with(YugabyteDBConnectorConfig.CONSISTENCY_MODE, "global");
+        configBuilder.with(YugabyteDBConnectorConfig.TRANSACTION_ORDERING, true);
         configBuilder.with("transforms", "Reroute");
         configBuilder.with("transforms.Reroute.type", "io.debezium.transforms.ByLogicalTableRouter");
         configBuilder.with("transforms.Reroute.topic.regex", "(.*)");


### PR DESCRIPTION
## Additions

This PR adds a configuration property `transaction.ordering` with value type as `BOOLEAN`. When enabled, we will be using the consistent streaming mode.

However, this doesn't remove any existing consistency related configs for future references and usages.