### PR TITLE
Changing logging information and levels

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorTask.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorTask.java
@@ -73,16 +73,6 @@ public class YugabyteDBConnectorTask
 
         LOGGER.debug("The config is " + config);
 
-        String tabletList = config.getString(YugabyteDBConnectorConfig.TABLET_LIST);
-        List<Pair<String, String>> tabletPairList = null;
-        try {
-            tabletPairList = (List<Pair<String, String>>) ObjectUtil.deserializeObjectFromString(tabletList);
-            LOGGER.debug("The tablet list is " + tabletPairList);
-        } catch (IOException | ClassNotFoundException e) {
-            LOGGER.error("Error while deserializing tablet list", e);
-            throw new RuntimeException(e);
-        }
-
         if (snapshotter == null) {
             throw new ConnectException("Unable to load snapshotter, if using custom snapshot mode," +
                     " double check your settings");
@@ -134,6 +124,16 @@ public class YugabyteDBConnectorTask
         boolean sendBeforeImage = config.getBoolean(YugabyteDBConnectorConfig.SEND_BEFORE_IMAGE.toString());
         boolean enableExplicitCheckpointing = config.getBoolean(YugabyteDBConnectorConfig.ENABLE_EXPLICIT_CHECKPOINTING.toString());
         this.taskContext = new YugabyteDBTaskContext(connectorConfig, schema, topicSelector, taskId, sendBeforeImage, enableExplicitCheckpointing);
+
+        String tabletList = config.getString(YugabyteDBConnectorConfig.TABLET_LIST);
+        List<Pair<String, String>> tabletPairList = null;
+        try {
+            tabletPairList = (List<Pair<String, String>>) ObjectUtil.deserializeObjectFromString(tabletList);
+            LOGGER.info("Task {}: The tablet list is {}", taskId, tabletPairList);
+        } catch (IOException | ClassNotFoundException e) {
+            LOGGER.error("Error while deserializing tablet list", e);
+            throw new RuntimeException(e);
+        }
 
         // Get the tablet ids and load the offsets
         final Offsets<YBPartition, YugabyteDBOffsetContext> previousOffsets =

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -223,7 +223,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
           snapshotCompletedTablets.add(tabletId);
           snapshotCompletedPreviously.add(tabletId);
         } else {
-          LOGGER.debug("Setting checkpoint on tablet {} with 0.0");
+          LOGGER.info("Setting checkpoint before snapshot on tablet {} with 0.0", tabletId);
           YBClientUtils.setCheckpoint(this.syncClient, 
                                       this.connectorConfig.streamId(), 
                                       tableId /* tableId */, 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -505,7 +505,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                             // Break out of the loop so that the iteration can start afresh on the modified list.
                             break;
                         } else {
-                            LOGGER.warn("Throwing error because error code did not match. Code received: {}", cdcException.getCDCError().getCode());
+                            LOGGER.debug("Throwing error because error code did not match. Code received: {}", cdcException.getCDCError().getCode());
                             throw cdcException;
                         }
                       }


### PR DESCRIPTION
Changes included in this PR:
1. Setting a log from `DEBUG` to `INFO` to log the tablet list each task has at the startup level.
2. Suppressing an unnecessary log to `DEBUG` level.