### PR TITLE
Unset time from children tablets upon initialization

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -183,42 +183,12 @@ public class YugabyteDBStreamingChangeEventSource implements
                                             Map<String, YBTable> tableIdToTable) throws Exception {
         Set<String> tabletsWithoutBootstrap = new HashSet<>();
         for (Pair<String, String> entry : tabletPairList) {
-            boolean shouldRetry = true;
-            short retryCountForGetCheckpoint = 0;
-            while (retryCountForGetCheckpoint <= connectorConfig.maxConnectorRetries() && shouldRetry) {
-                try {
-                    GetCheckpointResponse resp = this.syncClient.getCheckpoint(tableIdToTable.get(entry.getKey()), connectorConfig.streamId(), entry.getValue());
-                    if (resp.getTerm() == -1 && resp.getIndex() == -1) {
-                        LOGGER.debug("Bootstrap required for table {} tablet {} as it has checkpoint -1.-1", entry.getKey(), entry.getValue());
-                    } else {
-                        LOGGER.info("No bootstrap needed for tablet {} with checkpoint {}.{}", entry.getValue(), resp.getTerm(), resp.getIndex());
-                        tabletsWithoutBootstrap.add(entry.getValue() /* tabletId */ );
-                    }
-
-                    // Reset the flag to retry.
-                    shouldRetry = false;
-                } catch (Exception e) {
-                    ++retryCountForGetCheckpoint;
-
-                    shouldRetry = true;
-
-                    if (retryCountForGetCheckpoint > connectorConfig.maxConnectorRetries()) {
-                        LOGGER.error("Failed to get checkpoint for tablet {} after {} retries", entry.getValue(), connectorConfig.maxConnectorRetries());
-                        throw e;
-                    }
-
-                    // If there are retries left, perform them after the specified delay.
-                    LOGGER.warn("Error while trying to get the checkpoint for tablet {}; will attempt retry {} of {} after {} milli-seconds. Exception message: {}",
-                            entry.getValue(), retryCountForGetCheckpoint, connectorConfig.maxConnectorRetries(), connectorConfig.connectorRetryDelayMs(), e.getMessage());
-
-                    try {
-                        final Metronome retryMetronome = Metronome.parker(Duration.ofMillis(connectorConfig.connectorRetryDelayMs()), Clock.SYSTEM);
-                        retryMetronome.pause();
-                    } catch (InterruptedException ie) {
-                        LOGGER.warn("Connector retry sleep interrupted by exception: {}", ie);
-                        Thread.currentThread().interrupt();
-                    }
-                }
+            GetCheckpointResponse resp = this.syncClient.getCheckpoint(tableIdToTable.get(entry.getKey()), connectorConfig.streamId(), entry.getValue());
+            if (resp.getTerm() == -1 && resp.getIndex() == -1) {
+                LOGGER.debug("Bootstrap required for table {} tablet {} as it has checkpoint -1.-1", entry.getKey(), entry.getValue());
+            } else {
+                LOGGER.info("No bootstrap needed for tablet {} with checkpoint {}.{}", entry.getValue(), resp.getTerm(), resp.getIndex());
+                tabletsWithoutBootstrap.add(entry.getValue() /* tabletId */ );
             }
         }
 
@@ -958,7 +928,6 @@ public class YugabyteDBStreamingChangeEventSource implements
             // would be all non-colocated.
             YBPartition p = new YBPartition(tableId, tabletId, false /* colocated */);
             OpId checkpoint = OpId.from(pair.getCdcSdkCheckpoint());
-            checkpoint.unsetTime();
             offsetContext.initSourceInfo(p, this.connectorConfig, checkpoint);
             tabletToExplicitCheckpoint.put(p.getId(), checkpoint.toCdcSdkCheckpoint());
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -927,11 +927,16 @@ public class YugabyteDBStreamingChangeEventSource implements
             // is not possible on colocated tables, it is safe to assume that the tablets here
             // would be all non-colocated.
             YBPartition p = new YBPartition(tableId, tabletId, false /* colocated */);
+            
+            // Get the checkpoint for child tablet and unset its time.
             OpId checkpoint = OpId.from(pair.getCdcSdkCheckpoint());
+            checkpoint.unsetTime();
+            
             offsetContext.initSourceInfo(p, this.connectorConfig, checkpoint);
+            
             tabletToExplicitCheckpoint.put(p.getId(), checkpoint.toCdcSdkCheckpoint());
 
-            LOGGER.info("Initialized offset context for tablet {} with OpId {}", tabletId, OpId.from(pair.getCdcSdkCheckpoint()));
+            LOGGER.info("Initialized offset context for tablet {} with OpId {}", tabletId, checkpoint);
 
             // Add the flag to indicate that we need the schema for the new tablets so that the schema can be registered.
             schemaNeeded.put(p.getId(), Boolean.TRUE);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -927,13 +927,13 @@ public class YugabyteDBStreamingChangeEventSource implements
             // is not possible on colocated tables, it is safe to assume that the tablets here
             // would be all non-colocated.
             YBPartition p = new YBPartition(tableId, tabletId, false /* colocated */);
-            
+
             // Get the checkpoint for child tablet and unset its time.
             OpId checkpoint = OpId.from(pair.getCdcSdkCheckpoint());
             checkpoint.unsetTime();
-            
+
             offsetContext.initSourceInfo(p, this.connectorConfig, checkpoint);
-            
+
             tabletToExplicitCheckpoint.put(p.getId(), checkpoint.toCdcSdkCheckpoint());
 
             LOGGER.info("Initialized offset context for tablet {} with OpId {}", tabletId, checkpoint);

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
@@ -45,6 +45,10 @@ public class OpId implements Comparable<OpId> {
         return time;
     }
 
+    public void unsetTime() {
+        this.time = 0;
+    }
+
     public static OpId valueOf(String stringId) {
         if (stringId != null && !stringId.isEmpty()) {
             String[] arr = stringId.split(":");

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
@@ -45,10 +45,6 @@ public class OpId implements Comparable<OpId> {
         return time;
     }
 
-    public void unsetTime() {
-        this.time = 0;
-    }
-
     public static OpId valueOf(String stringId) {
         if (stringId != null && !stringId.isEmpty()) {
             String[] arr = stringId.split(":");


### PR DESCRIPTION
## Problem

It is possible for a transaction which is committed on a parent tablet that its `APPLY` records are distributed on both the children tablets after split. Now this `APPLY` record can have a lower commit time than the change records we receive from the parent tablets.

So after https://phorge.dev.yugabyte.com/D25399 was merged, if we do not reset the time for children tablets, we will end up filtering some records and end up in a data loss situation.

## Solution

While adding the children tablets for polling, we are now simply resetting/unsetting the time back to 0 so that when the first `GetChanges` call happens, it uses this default value only.