### PR TITLE
[yugabyte/yugabyte-db#18245] Use `lastRecordCheckpoint` to detect empty snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.kafka>3.3.1</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>
-        <version.ybclient>0.8.56-20230623.112806-3</version.ybclient>
+        <version.ybclient>0.8.62-20230718.133435-1</version.ybclient>
         <version.gson>2.8.9</version.gson>
 
         <!--

--- a/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
@@ -184,6 +184,13 @@ public final class SourceInfo extends BaseSourceInfo {
         return this.tableUUID;
     }
 
+    protected boolean noRecordSeen() {
+        // The theory of having this is that the object lastRecordCheckpoint will be updated as soon
+        // as it sees even 1 change record, so in case the connector hasn't received any record
+        // this will stay null.
+        return lastRecordCheckpoint == null;
+    }
+
     @Override
     public SnapshotRecord snapshot() {
         return super.snapshot();

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -385,6 +385,11 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                   continue;
                 }
 
+                CdcSdkCheckpoint explicitCdcSdkCheckpoint = null;
+                if (taskContext.shouldEnableExplicitCheckpointing()) {
+                  explicitCdcSdkCheckpoint = tabletToExplicitCheckpoint.get(part.getId());
+                }
+
                 OpId cp = previousOffset.snapshotLSN(part);
 
                 if (LOGGER.isDebugEnabled()
@@ -402,17 +407,10 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                 GetChangesResponse resp = this.syncClient.getChangesCDCSDK(table,
                     connectorConfig.streamId(), tabletId, cp.getTerm(), cp.getIndex(), cp.getKey(),
                     cp.getWrite_id(), cp.getTime(), schemaNeeded.get(part.getId()),
-                    taskContext.shouldEnableExplicitCheckpointing() ? tabletToExplicitCheckpoint.get(part.getId()) : null,
+                    explicitCdcSdkCheckpoint,
                     tabletSafeTime.getOrDefault(part.getId(), -1L));
 
                 tabletSafeTime.put(part.getId(), resp.getResp().getSafeHybridTime());
-
-                // If the response doesn't have any record, it is safe to assume that we should not wait
-                // for the callback to come and that we can proceed further in processing this particular tablet.
-                if (resp.getResp().getCdcSdkProtoRecordsCount() == 0) {
-                  LOGGER.info("Should not wait for callback on tablet {}", part.getId());
-                  shouldWaitForCallback.put(part.getId(), Boolean.FALSE);
-                }
 
                 // Process the response
                 for (CdcService.CDCSDKProtoRecordPB record :
@@ -494,6 +492,23 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                 OpId finalOpId = new OpId(resp.getTerm(), resp.getIndex(), resp.getKey(),
                                           resp.getWriteId(), resp.getSnapshotTime());
                 LOGGER.debug("Final OpId for tablet {} is {}", part.getId(), finalOpId);
+
+                // In cases where the tablet is empty, the response checkpoint can still move ahead and we should
+                // also move the explicit checkpoint forward, given that it was already greater than the lsn of the last seen valid record.
+                // Otherwise, we will be stuck waiting for callback on an empty tablet.
+                if (taskContext.shouldEnableExplicitCheckpointing()) {
+                  // If the response doesn't have any record and we got the snapshot end marker, we know the snapshot.
+                  SourceInfo sourceInfo = previousOffset.getSourceInfo(part);
+                  if (isSnapshotCompleteMarker(finalOpId) && sourceInfo.noRecordSeen()) {
+                    LOGGER.info("Should not wait for callback on tablet {}", part.getId());
+                    shouldWaitForCallback.put(part.getId(), Boolean.FALSE);
+                  }
+
+                  OpId lastRecordCheckpoint = sourceInfo.lastRecordCheckpoint();
+                  if (sourceInfo.noRecordSeen() || lastRecordCheckpoint.isLesserThanOrEqualTo(explicitCdcSdkCheckpoint)) {
+                    tabletToExplicitCheckpoint.put(part.getId(), finalOpId.toCdcSdkCheckpoint());
+                  }
+                }
 
                 /*
                    This block checks and validates for two scenarios:

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -497,7 +497,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                 // also move the explicit checkpoint forward, given that it was already greater than the lsn of the last seen valid record.
                 // Otherwise, we will be stuck waiting for callback on an empty tablet.
                 if (taskContext.shouldEnableExplicitCheckpointing()) {
-                  // If the response doesn't have any record and we got the snapshot end marker, we know the snapshot.
+                  // If the response doesn't have any record and we got the snapshot end marker, we know the snapshot is empty.
                   SourceInfo sourceInfo = previousOffset.getSourceInfo(part);
                   if (isSnapshotCompleteMarker(finalOpId) && sourceInfo.noRecordSeen()) {
                     LOGGER.info("Should not wait for callback on tablet {}", part.getId());

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -394,8 +394,8 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
 
                 if (LOGGER.isDebugEnabled()
                     || (connectorConfig.logGetChanges() && System.currentTimeMillis() >= (lastLoggedTimeForGetChanges + connectorConfig.logGetChangesIntervalMs()))) {
-                  LOGGER.info("Requesting changes for tablet {} from OpId {} for table {}",
-                              tabletId, cp, table.getName());
+                  LOGGER.info("Requesting changes for tablet {} from OpId {} for table {} with explicit checkpoint {}",
+                              tabletId, cp, table.getName(), explicitCdcSdkCheckpoint.toString());
                   lastLoggedTimeForGetChanges = System.currentTimeMillis();
                 }
 


### PR DESCRIPTION
## Problem

Today, in order to check if a tablet has empty snapshot, we just rely on the response size i.e. `GetChangesResponse` will have an empty record list, or in other terms a list of size 0. However, this logic is not enough for all the conditions where we genuinely can have empty responses, for example:
1. The first `GetChanges` call in cases of snapshot - this is only used to bootstrap snapshot on service.
2. Empty responses because of network or intermittent service issues.

## Solution

This PR adds the following changes to fix the problem described:
1. Adds a getter in `SourceInfo` to check if we haven't seen any record yet.
3. Disallows waiting for callback if the tablet has no data to snapshot, this is checked if the following conditions are met
    a. The `OpId` in `GetChangesResponse` is the snapshot complete marker.
    b. We haven't seen any record in snapshot (checked using the getter method)

### Misc changes

1. Upgraded `yb-client` version.
2. Changed a log to print the explicit checkpoint value as well.