### PR TITLE
[yugabyte/yugabyte-db#18279] Retry logic for `GetCheckpoint` RPC

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -183,12 +183,42 @@ public class YugabyteDBStreamingChangeEventSource implements
                                             Map<String, YBTable> tableIdToTable) throws Exception {
         Set<String> tabletsWithoutBootstrap = new HashSet<>();
         for (Pair<String, String> entry : tabletPairList) {
-            GetCheckpointResponse resp = this.syncClient.getCheckpoint(tableIdToTable.get(entry.getKey()), connectorConfig.streamId(), entry.getValue());
-            if (resp.getTerm() == -1 && resp.getIndex() == -1) {
-                LOGGER.debug("Bootstrap required for table {} tablet {} as it has checkpoint -1.-1", entry.getKey(), entry.getValue());
-            } else {
-                LOGGER.info("No bootstrap needed for tablet {} with checkpoint {}.{}", entry.getValue(), resp.getTerm(), resp.getIndex());
-                tabletsWithoutBootstrap.add(entry.getValue() /* tabletId */ );
+            boolean shouldRetry = true;
+            short retryCountForGetCheckpoint = 0;
+            while (retryCountForGetCheckpoint <= connectorConfig.maxConnectorRetries() && shouldRetry) {
+                try {
+                    GetCheckpointResponse resp = this.syncClient.getCheckpoint(tableIdToTable.get(entry.getKey()), connectorConfig.streamId(), entry.getValue());
+                    if (resp.getTerm() == -1 && resp.getIndex() == -1) {
+                        LOGGER.debug("Bootstrap required for table {} tablet {} as it has checkpoint -1.-1", entry.getKey(), entry.getValue());
+                    } else {
+                        LOGGER.info("No bootstrap needed for tablet {} with checkpoint {}.{}", entry.getValue(), resp.getTerm(), resp.getIndex());
+                        tabletsWithoutBootstrap.add(entry.getValue() /* tabletId */ );
+                    }
+
+                    // Reset the flag to retry.
+                    shouldRetry = false;
+                } catch (Exception e) {
+                    ++retryCountForGetCheckpoint;
+
+                    shouldRetry = true;
+
+                    if (retryCountForGetCheckpoint > connectorConfig.maxConnectorRetries()) {
+                        LOGGER.error("Failed to get checkpoint for tablet {} after {} retries", entry.getValue(), connectorConfig.maxConnectorRetries());
+                        throw e;
+                    }
+
+                    // If there are retries left, perform them after the specified delay.
+                    LOGGER.warn("Error while trying to get the checkpoint for tablet {}; will attempt retry {} of {} after {} milli-seconds. Exception message: {}",
+                            entry.getValue(), retryCountForGetCheckpoint, connectorConfig.maxConnectorRetries(), connectorConfig.connectorRetryDelayMs(), e.getMessage());
+
+                    try {
+                        final Metronome retryMetronome = Metronome.parker(Duration.ofMillis(connectorConfig.connectorRetryDelayMs()), Clock.SYSTEM);
+                        retryMetronome.pause();
+                    } catch (InterruptedException ie) {
+                        LOGGER.warn("Connector retry sleep interrupted by exception: {}", ie);
+                        Thread.currentThread().interrupt();
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Problem

In one part of the code, we are calling the `GetCheckpoint` RPC on the service using `YBClient` - however, when the RPC fails, we do not have a mechanism to retry it or handle the exception at that level. This has consistently led to failure in the stress runs with exceptions similar to the following:

```
org.yb.client.CDCErrorException: Server[eea52488ba11431ba0d0dfcf2bdbd7b7] LEADER_NOT_READY_TO_SERVE[code 23]: Not ready to serve
```

## Solution

This PR adds a retry logic to the RPC call so that if there are any failures, they are retried for a configured number of times before throwing the exception ultimately.

This PR is a part of the fix for yugabyte/yugabyte-db#18279