### PR TITLE
[yugabyte/yugabyte-db#18542] Fix NPE and incorrect reinitialisation of set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@ COPY target/debezium-connector-yugabytedb-*.jar $KAFKA_CONNECT_YB_DIR/
 ENV KAFKA_OPTS="-Djdk.tls.client.protocols=TLSv1.2"
 
 # Add the required jar files to be packaged with the base connector
-#RUN cd $KAFKA_CONNECT_YB_DIR && curl -so kafka-connect-jdbc-10.6.5.jar https://github.com/yugabyte/kafka-connect-jdbc/releases/download/10.6.5-CUSTOM/kafka-connect-jdbc-10.6.5.jar
-COPY kafka-connect-jdbc-10.6.5.jar $KAFKA_CONNECT_YB_DIR/
+RUN cd $KAFKA_CONNECT_YB_DIR && curl -so kafka-connect-jdbc-10.6.5.jar https://github.com/yugabyte/kafka-connect-jdbc/releases/download/10.6.5-CUSTOM/kafka-connect-jdbc-10.6.5.jar
 RUN cd $KAFKA_CONNECT_YB_DIR && curl -so jdbc-yugabytedb-42.3.5-yb-1.jar https://repo1.maven.org/maven2/com/yugabyte/jdbc-yugabytedb/42.3.5-yb-1/jdbc-yugabytedb-42.3.5-yb-1.jar
 RUN cd $KAFKA_CONNECT_YB_DIR && curl -so mysql-connector-java-8.0.30.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.30/mysql-connector-java-8.0.30.jar
 RUN cd $KAFKA_CONNECT_YB_DIR && curl -so postgresql-42.5.1.jar https://repo1.maven.org/maven2/org/postgresql/postgresql/42.5.1/postgresql-42.5.1.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ COPY target/debezium-connector-yugabytedb-*.jar $KAFKA_CONNECT_YB_DIR/
 ENV KAFKA_OPTS="-Djdk.tls.client.protocols=TLSv1.2"
 
 # Add the required jar files to be packaged with the base connector
-RUN cd $KAFKA_CONNECT_YB_DIR && curl -so kafka-connect-jdbc-10.6.5.jar https://github.com/yugabyte/kafka-connect-jdbc/releases/download/10.6.5-CUSTOM/kafka-connect-jdbc-10.6.5.jar
+#RUN cd $KAFKA_CONNECT_YB_DIR && curl -so kafka-connect-jdbc-10.6.5.jar https://github.com/yugabyte/kafka-connect-jdbc/releases/download/10.6.5-CUSTOM/kafka-connect-jdbc-10.6.5.jar
+COPY kafka-connect-jdbc-10.6.5.jar $KAFKA_CONNECT_YB_DIR/
 RUN cd $KAFKA_CONNECT_YB_DIR && curl -so jdbc-yugabytedb-42.3.5-yb-1.jar https://repo1.maven.org/maven2/com/yugabyte/jdbc-yugabytedb/42.3.5-yb-1/jdbc-yugabytedb-42.3.5-yb-1.jar
 RUN cd $KAFKA_CONNECT_YB_DIR && curl -so mysql-connector-java-8.0.30.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.30/mysql-connector-java-8.0.30.jar
 RUN cd $KAFKA_CONNECT_YB_DIR && curl -so postgresql-42.5.1.jar https://repo1.maven.org/maven2/org/postgresql/postgresql/42.5.1/postgresql-42.5.1.jar

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -392,10 +392,10 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
 
                 OpId cp = previousOffset.snapshotLSN(part);
 
-                if (LOGGER.isDebugEnabled()
+                if (true || LOGGER.isDebugEnabled()
                     || (connectorConfig.logGetChanges() && System.currentTimeMillis() >= (lastLoggedTimeForGetChanges + connectorConfig.logGetChangesIntervalMs()))) {
                   LOGGER.info("Requesting changes for tablet {} from OpId {} for table {} with explicit checkpoint {}",
-                              tabletId, cp, table.getName(), explicitCdcSdkCheckpoint.toString());
+                              tabletId, cp, table.getName(), explicitCdcSdkCheckpoint);
                   lastLoggedTimeForGetChanges = System.currentTimeMillis();
                 }
 
@@ -506,6 +506,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
 
                   OpId lastRecordCheckpoint = sourceInfo.lastRecordCheckpoint();
                   if (sourceInfo.noRecordSeen() || lastRecordCheckpoint.isLesserThanOrEqualTo(explicitCdcSdkCheckpoint)) {
+                    LOGGER.info("Putting explicit checkpoint for partition {} as {}", part.getId(), finalOpId);
                     tabletToExplicitCheckpoint.put(part.getId(), finalOpId.toCdcSdkCheckpoint());
                   }
                 }
@@ -571,6 +572,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                     part.getTabletId(), table.getName(), part.getTableId());
                 }
 
+                LOGGER.info("Updating wal position for partition {} with {}", part.getId(), finalOpId);
                 previousOffset.updateWalPosition(part, finalOpId);
             }
             

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -393,7 +393,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
 
                 OpId cp = previousOffset.snapshotLSN(part);
 
-                if (true || LOGGER.isDebugEnabled()
+                if (LOGGER.isDebugEnabled()
                     || (connectorConfig.logGetChanges() && System.currentTimeMillis() >= (lastLoggedTimeForGetChanges + connectorConfig.logGetChangesIntervalMs()))) {
                   LOGGER.info("Requesting changes for tablet {} from OpId {} for table {} with explicit checkpoint {}",
                               tabletId, cp, table.getName(), explicitCdcSdkCheckpoint);
@@ -507,7 +507,6 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
 
                   OpId lastRecordCheckpoint = sourceInfo.lastRecordCheckpoint();
                   if (sourceInfo.noRecordSeen() || lastRecordCheckpoint.isLesserThanOrEqualTo(explicitCdcSdkCheckpoint)) {
-                    LOGGER.info("Putting explicit checkpoint for partition {} as {}", part.getId(), finalOpId);
                     tabletToExplicitCheckpoint.put(part.getId(), finalOpId.toCdcSdkCheckpoint());
                   }
                 }
@@ -573,7 +572,6 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                     part.getTabletId(), table.getName(), part.getTableId());
                 }
 
-                LOGGER.info("Updating wal position for partition {} with {}", part.getId(), finalOpId);
                 previousOffset.updateWalPosition(part, finalOpId);
             }
             
@@ -638,7 +636,6 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
       if (this.tabletToExplicitCheckpoint.get(partition.getId()) == null) {
         // If we have no OpId stored in the explicit checkpoint map then that would indicate that
         // we haven't yet received any callback from Kafka even once and we should wait more.
-        // LOGGER.info("Explicit checkpoint is null for partition {}", partition.getId());
         return;
       }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -383,7 +383,6 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                   if (!snapshotCompletedTablets.contains(part.getId()) && taskContext.shouldEnableExplicitCheckpointing()) {
                     doSnapshotCompletionCheck(part, snapshotCompletedTablets, tabletsWaitingForCallback, previousOffset);
                   }
-                  LOGGER.info("Skipping the loop for tablet {}", part.getId());
                   continue;
                 }
 
@@ -639,6 +638,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
       if (this.tabletToExplicitCheckpoint.get(partition.getId()) == null) {
         // If we have no OpId stored in the explicit checkpoint map then that would indicate that
         // we haven't yet received any callback from Kafka even once and we should wait more.
+        // LOGGER.info("Explicit checkpoint is null for partition {}", partition.getId());
         return;
       }
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -44,6 +44,7 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         dropAllTables();
         TestHelper.executeDDL("drop_tables_and_databases.ddl");
         TestHelper.dropAllSchemas();
+        resetCommitCallbackDelay();
     }
 
     @AfterAll
@@ -54,6 +55,7 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
     @ParameterizedTest
     @ValueSource(booleans = {false})
     public void testSnapshotRecordConsumption(boolean colocation) throws Exception {
+        setCommitCallbackDelay(10000);
         createTables(colocation);
         final int recordsCount = 5000;
         insertBulkRecords(recordsCount, "public.test_1");

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -52,7 +52,7 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
     }
 
     @ParameterizedTest
-    @ValueSource(booleans = {true, false})
+    @ValueSource(booleans = {false})
     public void testSnapshotRecordConsumption(boolean colocation) throws Exception {
         createTables(colocation);
         final int recordsCount = 5000;

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -53,7 +53,7 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
     }
 
     @ParameterizedTest
-    @ValueSource(booleans = {false})
+    @ValueSource(booleans = {true, false})
     public void testSnapshotRecordConsumption(boolean colocation) throws Exception {
         setCommitCallbackDelay(10000);
         createTables(colocation);


### PR DESCRIPTION
## Problem

1. There is a log line where we are accessing the `toString()` method on an object which can be null which in turn is throwing a `NullPointerException` with a similar stacktrace as

```
Caused by: java.lang.NullPointerException
         at io.debezium.connector.yugabytedb.YugabyteDBSnapshotChangeEventSource.doExecute(YugabyteDBSnapshotChangeEventSource.java:398)
         at io.debezium.connector.yugabytedb.YugabyteDBSnapshotChangeEventSource.execute(YugabyteDBSnapshotChangeEventSource.java:136)
         ... 9 more

```

2. Another issue is the reinitialisation of a set being used to store the list of tablets which should wait for callbacks. Over here, we have a set which is getting reinitialised in every iteration of the loop so the flow is something like:

```
Start Loop:
1. Initialise set
2. Add tablet list to the set
3. Upon loop reiteration, reinitialise - this step is causing a loss of the previous state.
```

So let's say in the previous state, the connector knew it has to wait for callback on some tablet and not call further `GetChanges` until it receives a callback, the state is now gone and the connector will end up calling `GetChanges` with a checkpoint not meant for snapshot - thus in those cases it will also see a `SAFEPOINT` record which shouldn't have been the case as pointed by the ticket yugabyte/yugabyte-db#18464

## Solution
1. Instead of accessing the method `toString()` add the object to the log line directly, this way, Java will itself understand whether to print `null` or call the `toString()` method.
2. Move the initialisation of the set outside of the loop.

### Test Plan

Modified a test by adding a wait time before the commit callback to reproduce the error.