### PR TITLE
[yugabyte/yugabyte-db#18661] Throw error if incorrect task size specified with transaction ordering

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.connector.Task;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yb.cdc.CdcService.TabletCheckpointPair;
@@ -77,6 +78,11 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
         tableMonitorThread = new YugabyteDBTablePoller(yugabyteDBConnectorConfig, context);
         if (this.yugabyteDBConnectorConfig.autoAddNewTables()) {
             tableMonitorThread.start();
+        }
+
+        if (this.yugabyteDBConnectorConfig.transactionOrdering() && config.getInteger("tasks.max") != 1) {
+            throw new ConnectException("Transaction ordering is only supported with 1 task, "
+                                        + "change number of tasks and try again");
         }
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
@@ -80,6 +80,8 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
             tableMonitorThread.start();
         }
 
+        // This guard is to disallow users to deploy a connector with more than a single task when
+        // transaction ordering is enabled
         if (this.yugabyteDBConnectorConfig.transactionOrdering() && config.getInteger("tasks.max") != 1) {
             throw new ConnectException("Transaction ordering is only supported with 1 task, "
                                         + "change number of tasks and try again");


### PR DESCRIPTION
## Problem

The connector allows users to deploy with configuration where the maximum task size can be anything i.e. `tasks.max`, but in case of `transaction.ordering:true` this will lead to problems since the records will not be ordered correctly, thus causing further issues in downstream sinks.

## Solution

This PR adds a guard logic which throws an error if the user tries to deploy a connector where `transaction.ordering` is set to `true` and `tasks.max` has any value other than `1`.