### PR TITLE
[yugabyte/yugabyte-db#18655] Added the redirect flag for curl commands used to add Jars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,10 @@ COPY target/debezium-connector-yugabytedb-*.jar $KAFKA_CONNECT_YB_DIR/
 ENV KAFKA_OPTS="-Djdk.tls.client.protocols=TLSv1.2"
 
 # Add the required jar files to be packaged with the base connector
-RUN cd $KAFKA_CONNECT_YB_DIR && curl -so kafka-connect-jdbc-10.6.5.jar https://github.com/yugabyte/kafka-connect-jdbc/releases/download/10.6.5-CUSTOM/kafka-connect-jdbc-10.6.5.jar
-RUN cd $KAFKA_CONNECT_YB_DIR && curl -so jdbc-yugabytedb-42.3.5-yb-1.jar https://repo1.maven.org/maven2/com/yugabyte/jdbc-yugabytedb/42.3.5-yb-1/jdbc-yugabytedb-42.3.5-yb-1.jar
-RUN cd $KAFKA_CONNECT_YB_DIR && curl -so mysql-connector-java-8.0.30.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.30/mysql-connector-java-8.0.30.jar
-RUN cd $KAFKA_CONNECT_YB_DIR && curl -so postgresql-42.5.1.jar https://repo1.maven.org/maven2/org/postgresql/postgresql/42.5.1/postgresql-42.5.1.jar
+RUN cd $KAFKA_CONNECT_YB_DIR && curl -sLo kafka-connect-jdbc-10.6.5.jar https://github.com/yugabyte/kafka-connect-jdbc/releases/download/10.6.5-CUSTOM/kafka-connect-jdbc-10.6.5.jar
+RUN cd $KAFKA_CONNECT_YB_DIR && curl -sLo jdbc-yugabytedb-42.3.5-yb-1.jar https://repo1.maven.org/maven2/com/yugabyte/jdbc-yugabytedb/42.3.5-yb-1/jdbc-yugabytedb-42.3.5-yb-1.jar
+RUN cd $KAFKA_CONNECT_YB_DIR && curl -sLo mysql-connector-java-8.0.30.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.30/mysql-connector-java-8.0.30.jar
+RUN cd $KAFKA_CONNECT_YB_DIR && curl -sLo postgresql-42.5.1.jar https://repo1.maven.org/maven2/org/postgresql/postgresql/42.5.1/postgresql-42.5.1.jar
 
 # Add Jmx agent and metrics pattern file to expose the metrics info
 RUN mkdir /kafka/etc && cd /kafka/etc && curl -so jmx_prometheus_javaagent-0.17.2.jar https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.17.2/jmx_prometheus_javaagent-0.17.2.jar


### PR DESCRIPTION
## Problem


It was noticed that whenever cdc pipeline was run using the compiled jar for connector, the deployment of sink connectors failed. Upon investigation it was found that the kafka-connect-jdbc jar downloaded inside the Dockerfile was blank. This was caused because the curl commands in the Dockerfile which download the required jars did not have the `redirect` flag enabled.

The previous flow resulted in following error when trying to deploy sink connectors:
```
{"error_code":500,"message":"Failed to find any class that implements Connector and which name matches io.confluent.connect.jdbc.JdbcSinkConnector, available connectors are: PluginDesc{klass=class io.debezium.connector.db2.Db2Connector, name='io.debezium.connector.db2.Db2Connector', version='1.9.5.Final', encodedVersion=1.9.5.Final, type=source, typeName='source', location='file:/kafka/connect/debezium-connector-db2/'}, PluginDesc{klass=class io.debezium.connector.mongodb.MongoDbConnector, name='io.debezium.connector.mongodb.MongoDbConnector', version='1.9.5.Final', encodedVersion=1.9.5.Final, type=source, typeName='source', location='file:/kafka/connect/debezium-connector-mongodb/'}, PluginDesc{klass=class io.debezium.connector.mysql.MySqlConnector, name='io.debezium.connector.mysql.MySqlConnector', version='1.9.5.Final', encodedVersion=1.9.5.Final, type=source, typeName='source', location='file:/kafka/connect/debezium-connector-mysql/'}, PluginDesc{klass=class io.debezium.connector.oracle.OracleConnector, name='io.debezium.connector.oracle.OracleConnector', version='1.9.5.Final', encodedVersion=1.9.5.Final, type=source, typeName='source', location='file:/kafka/connect/debezium-connector-oracle/'}, PluginDesc{klass=class io.debezium.connector.postgresql.PostgresConnector, name='io.debezium.connector.postgresql.PostgresConnector', version='1.9.5.Final', encodedVersion=1.9.5.Final, type=source, typeName='source', location='file:/kafka/connect/debezium-connector-postgres/'}, PluginDesc{klass=class io.debezium.connector.sqlserver.SqlServerConnector, name='io.debezium.connector.sqlserver.SqlServerConnector', version='1.9.5.Final', encodedVersion=1.9.5.Final, type=source, typeName='source', location='file:/kafka/connect/debezium-connector-sqlserver/'}, PluginDesc{klass=class io.debezium.connector.vitess.VitessConnector, name='io.debezium.connector.vitess.VitessConnector', version='1.9.5.Final', encodedVersion=1.9.5.Final, type=source, typeName='source', location='file:/kafka/connect/debezium-connector-vitess/'}, PluginDesc{klass=class io.debezium.connector.yugabytedb.YugabyteDBConnector, name='io.debezium.connector.yugabytedb.YugabyteDBConnector', version='1.9.5.y.34-SNAPSHOT', encodedVersion=1.9.5.y.34-SNAPSHOT, type=source, typeName='source', location='file:/kafka/connect/debezium-connector-yugabytedb/'}, PluginDesc{klass=class org.apache.kafka.connect.mirror.MirrorCheckpointConnector, name='org.apache.kafka.connect.mirror.MirrorCheckpointConnector', version='3.2.0', encodedVersion=3.2.0, type=source, typeName='source', location='classpath'}, PluginDesc{klass=class org.apache.kafka.connect.mirror.MirrorHeartbeatConnector, name='org.apache.kafka.connect.mirror.MirrorHeartbeatConnector', version='3.2.0', encodedVersion=3.2.0, type=source, typeName='source', location='classpath'}, PluginDesc{klass=class org.apache.kafka.connect.mirror.MirrorSourceConnector, name='org.apache.kafka.connect.mirror.MirrorSourceConnector', version='3.2.0', encodedVersion=3.2.0, type=source, typeName='source', location='classpath'}, PluginDesc{klass=class org.apache.kafka.connect.tools.MockSinkConnector, name='org.apache.kafka.connect.tools.MockSinkConnector', version='3.2.0', encodedVersion=3.2.0, type=sink, typeName='sink', location='classpath'}, PluginDesc{klass=class org.apache.kafka.connect.tools.MockSourceConnector, name='org.apache.kafka.connect.tools.MockSourceConnector', version='3.2.0', encodedVersion=3.2.0, type=source, typeName='source', location='classpath'}, PluginDesc{klass=class org.apache.kafka.connect.tools.SchemaSourceConnector, name='org.apache.kafka.connect.tools.SchemaSourceConnector', version='3.2.0', encodedVersion=3.2.0, type=source, typeName='source', location='classpath'}, PluginDesc{klass=class org.apache.kafka.connect.tools.VerifiableSinkConnector, name='org.apache.kafka.connect.tools.VerifiableSinkConnector', version='3.2.0', encodedVersion=3.2.0, type=sink, typeName='sink', location='classpath'}, PluginDesc{klass=class org.apache.kafka.connect.tools.VerifiableSourceConnector, name='org.apache.kafka.connect.tools.VerifiableSourceConnector', version='3.2.0', encodedVersion=3.2.0, type=source, typeName='source', location='classpath'}"}HTTP/1.1 100 Continue

HTTP/1.1 500 Internal Server Error
Date: Fri, 18 Aug 2023 04:55:08 GMT
Content-Type: application/json
Content-Length: 4212
Server: Jetty(9.4.44.v20210927)
``` 


## Solution

To solve this issue this PR adds the `redirect` flag to the curl commands so that the requirred jars are downloaded properly.

## Test Plan

Manually tested out the cdc-pipeline by running the [cdc-example](https://github.com/yugabyte/cdc-examples/tree/main/cdc-quickstart-kafka-connect)