### PR TITLE
[yugabyte/yugabyte-db#12751] Added support for multi node fail over connection

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -29,6 +29,7 @@ import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.connector.SourceInfoStructMaker;
 import io.debezium.connector.yugabytedb.connection.MessageDecoder;
 import io.debezium.connector.yugabytedb.connection.MessageDecoderContext;
+import io.debezium.connector.yugabytedb.connection.YugabyteDBConnection;
 import io.debezium.connector.yugabytedb.connection.pgproto.YbProtoMessageDecoder;
 import io.debezium.connector.yugabytedb.snapshot.AlwaysSnapshotter;
 import io.debezium.connector.yugabytedb.snapshot.InitialOnlySnapshotter;
@@ -37,7 +38,9 @@ import io.debezium.connector.yugabytedb.snapshot.NeverSnapshotter;
 import io.debezium.connector.yugabytedb.spi.Snapshotter;
 import io.debezium.heartbeat.DatabaseHeartbeatImpl;
 import io.debezium.jdbc.JdbcConfiguration;
+import io.debezium.jdbc.JdbcConnection;
 import io.debezium.jdbc.JdbcValueConverters;
+import io.debezium.jdbc.JdbcConnection.ConnectionFactory;
 import io.debezium.relational.ColumnFilterMode;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.TableId;
@@ -1402,6 +1405,19 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
     @Override
     public String getConnectorName() {
         return Module.name();
+    }
+
+    public ConnectionFactory getConnectionFactory() {
+        String hostName = getJdbcConfig().getHostname();
+        return hostName.contains(":")
+                ? JdbcConnection.patternBasedFactory(YugabyteDBConnection.MULTI_HOST_URL_PATTERN,
+                        org.postgresql.Driver.class.getName(),
+                        YugabyteDBConnection.class.getClassLoader(),
+                        JdbcConfiguration.PORT.withDefault(YugabyteDBConnectorConfig.PORT.defaultValueAsString()))
+                : JdbcConnection.patternBasedFactory(YugabyteDBConnection.SINGLE_HOST_URL_PATTERN,
+                        org.postgresql.Driver.class.getName(),
+                        YugabyteDBConnection.class.getClassLoader(),
+                        JdbcConfiguration.PORT.withDefault(YugabyteDBConnectorConfig.PORT.defaultValueAsString()));
     }
 
     private static class SystemTablesPredicate implements TableFilter {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -222,14 +222,16 @@ public class YugabyteDBStreamingChangeEventSource implements
             }
         }
 
-        short retryCountForBootstrapping = 0;
+        short maxBootstrapRetries = 25;
         for (Pair<String, String> entry : tabletPairList) {
             // entry is a Pair<tableId, tabletId>
             boolean shouldRetry = true;
-            while (retryCountForBootstrapping <= connectorConfig.maxConnectorRetries() && shouldRetry) {
+            short retryCountForBootstrapping = 0;
+            while (retryCountForBootstrapping <= maxBootstrapRetries && shouldRetry) {
                 try {
                     if (!tabletsWithoutBootstrap.contains(entry.getValue())) {
-                        bootstrapTablet(this.syncClient.openTableByUUID(entry.getKey()), entry.getValue());
+                        YBTable table = this.syncClient.openTableByUUID(entry.getKey());
+                        bootstrapTablet(table, entry.getValue());
                     } else {
                         LOGGER.info("Skipping bootstrap for table {} tablet {} as it has a checkpoint", entry.getKey(), entry.getValue());
                     }
@@ -242,14 +244,14 @@ public class YugabyteDBStreamingChangeEventSource implements
                     // The connector should go for a retry if any exception is thrown
                     shouldRetry = true;
 
-                    if (retryCountForBootstrapping > connectorConfig.maxConnectorRetries()) {
-                        LOGGER.error("Failed to bootstrap the tablet {} after {} retries", entry.getValue(), connectorConfig.maxConnectorRetries());
+                    if (retryCountForBootstrapping > maxBootstrapRetries) {
+                        LOGGER.error("Failed to bootstrap the tablet {} after {} retries", entry.getValue(), maxBootstrapRetries);
                         throw e;
                     }
 
                     // If there are retries left, perform them after the specified delay.
                     LOGGER.warn("Error while trying to bootstrap tablet {}; will attempt retry {} of {} after {} milli-seconds. Exception message: {}",
-                            entry.getValue(), retryCountForBootstrapping, connectorConfig.maxConnectorRetries(), connectorConfig.connectorRetryDelayMs(), e.getMessage());
+                            entry.getValue(), retryCountForBootstrapping, maxBootstrapRetries, connectorConfig.connectorRetryDelayMs(), e.getMessage());
 
                     try {
                         final Metronome retryMetronome = Metronome.parker(Duration.ofMillis(connectorConfig.connectorRetryDelayMs()), Clock.SYSTEM);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -222,6 +222,10 @@ public class YugabyteDBStreamingChangeEventSource implements
             }
         }
 
+        // The bootstrap method calls the SetCDCCheckPoint RPC, which relies on a cache to obtain a
+        // list of all the tservers. In case of multi host port connection url, if one of the DB node
+        // goes down, it takes some time for the cache to refresh and return correct tserver list.
+        // This refresh time may be longer and hence we need additional number of retries here.
         int maxBootstrapRetries = connectorConfig.maxConnectorRetries() * 5;
         for (Pair<String, String> entry : tabletPairList) {
             // entry is a Pair<tableId, tabletId>

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -222,7 +222,7 @@ public class YugabyteDBStreamingChangeEventSource implements
             }
         }
 
-        short maxBootstrapRetries = 25;
+        int maxBootstrapRetries = connectorConfig.maxConnectorRetries() * 5;
         for (Pair<String, String> entry : tabletPairList) {
             // entry is a Pair<tableId, tabletId>
             boolean shouldRetry = true;

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/YugabyteDBConnection.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/YugabyteDBConnection.java
@@ -172,7 +172,7 @@ public class YugabyteDBConnection extends JdbcConnection {
      */
     public String connectionString() {
         String hostName = config.getHostname();
-        if(hostName.contains(":")){
+        if (hostName.contains(":")) {
             return connectionString(MULTI_HOST_URL_PATTERN);
         } else {
             return connectionString(SINGLE_HOST_URL_PATTERN);

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/YugabyteDBConnection.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/YugabyteDBConnection.java
@@ -61,8 +61,8 @@ public class YugabyteDBConnection extends JdbcConnection {
 
     private static Logger LOGGER = LoggerFactory.getLogger(YugabyteDBConnection.class);
 
-    private static final String MULTI_HOST_URL_PATTERN = "jdbc:postgresql://${" + JdbcConfiguration.HOSTNAME + "}/${" + JdbcConfiguration.DATABASE + "}";
-    private static final String SINGLE_HOST_URL_PATTERN = "jdbc:postgresql://${" + JdbcConfiguration.HOSTNAME + "}:${"
+    public static final String MULTI_HOST_URL_PATTERN = "jdbc:postgresql://${" + JdbcConfiguration.HOSTNAME + "}/${" + JdbcConfiguration.DATABASE + "}";
+    public static final String SINGLE_HOST_URL_PATTERN = "jdbc:postgresql://${" + JdbcConfiguration.HOSTNAME + "}:${"
             + JdbcConfiguration.PORT + "}/${" + JdbcConfiguration.DATABASE + "}";
 
     protected static ConnectionFactory FACTORY; 
@@ -136,15 +136,7 @@ public class YugabyteDBConnection extends JdbcConnection {
 
     public YugabyteDBConnection(YugabyteDBConnectorConfig config,
                                 YugabyteDBTypeRegistry yugabyteDBTypeRegistry, String connectionUsage) {
-        this(config,yugabyteDBTypeRegistry, connectionUsage, config.getJdbcConfig().getHostname().contains(":")
-                        ? JdbcConnection.patternBasedFactory(MULTI_HOST_URL_PATTERN,
-                            org.postgresql.Driver.class.getName(),
-                            YugabyteDBConnection.class.getClassLoader(),
-                            JdbcConfiguration.PORT.withDefault(YugabyteDBConnectorConfig.PORT.defaultValueAsString()))
-                        : JdbcConnection.patternBasedFactory(SINGLE_HOST_URL_PATTERN,
-                                org.postgresql.Driver.class.getName(),
-                                YugabyteDBConnection.class.getClassLoader(), JdbcConfiguration.PORT
-                                        .withDefault(YugabyteDBConnectorConfig.PORT.defaultValueAsString())));
+        this(config,yugabyteDBTypeRegistry, connectionUsage, config.getConnectionFactory());
     }
 
     /**

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/YugabyteDBConnection.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/YugabyteDBConnection.java
@@ -61,14 +61,16 @@ public class YugabyteDBConnection extends JdbcConnection {
 
     private static Logger LOGGER = LoggerFactory.getLogger(YugabyteDBConnection.class);
 
-    private static final String URL_PATTERN = "jdbc:postgresql://${" + JdbcConfiguration.HOSTNAME + "}:${"
+    private static final String MULTI_HOST_URL_PATTERN = "jdbc:postgresql://${" + JdbcConfiguration.HOSTNAME + "}/${" + JdbcConfiguration.DATABASE + "}";
+    private static final String SINGLE_HOST_URL_PATTERN = "jdbc:postgresql://${" + JdbcConfiguration.HOSTNAME + "}:${"
             + JdbcConfiguration.PORT + "}/${" + JdbcConfiguration.DATABASE + "}";
-    protected static final ConnectionFactory FACTORY = JdbcConnection.patternBasedFactory(URL_PATTERN,
-            org.postgresql.Driver.class.getName(),
-            YugabyteDBConnection.class.getClassLoader(), JdbcConfiguration.PORT.withDefault(YugabyteDBConnectorConfig.PORT.defaultValueAsString()));
+
+    protected static ConnectionFactory FACTORY; 
 
     private final YugabyteDBTypeRegistry yugabyteDBTypeRegistry;
     private final YugabyteDBDefaultValueConverter defaultValueConverter;
+
+    private final JdbcConfiguration config;
 
     /**
      * Creates a Postgres connection using the supplied configuration.
@@ -79,9 +81,11 @@ public class YugabyteDBConnection extends JdbcConnection {
      * @param config {@link Configuration} instance, may not be null.
      * @param valueConverterBuilder supplies a configured {@link YugabyteDBValueConverter} for a given {@link YugabyteDBTypeRegistry}
      */
-    public YugabyteDBConnection(JdbcConfiguration config, YugabyteDBValueConverterBuilder valueConverterBuilder, String connectionUsage) {
-        super(addDefaultSettings(config, connectionUsage) , FACTORY, YugabyteDBConnection::validateServerVersion, null, "\"", "\"");
-
+    public YugabyteDBConnection(JdbcConfiguration config, YugabyteDBValueConverterBuilder valueConverterBuilder, String connectionUsage, ConnectionFactory factory){
+        super(addDefaultSettings(config, connectionUsage), factory, YugabyteDBConnection::validateServerVersion, null,
+                "\"", "\"");
+        YugabyteDBConnection.FACTORY = factory;
+        this.config = config;
         if (Objects.isNull(valueConverterBuilder)) {
             this.yugabyteDBTypeRegistry = null;
             this.defaultValueConverter = null;
@@ -92,6 +96,19 @@ public class YugabyteDBConnection extends JdbcConnection {
             final YugabyteDBValueConverter valueConverter = valueConverterBuilder.build(this.yugabyteDBTypeRegistry);
             this.defaultValueConverter = new YugabyteDBDefaultValueConverter(valueConverter, this.getTimestampUtils());
         }
+
+
+    }
+    public YugabyteDBConnection(JdbcConfiguration config, YugabyteDBValueConverterBuilder valueConverterBuilder, String connectionUsage) {
+        this(config, valueConverterBuilder, connectionUsage, config.getHostname().contains(":")
+                        ? JdbcConnection.patternBasedFactory(MULTI_HOST_URL_PATTERN,
+                            org.postgresql.Driver.class.getName(),
+                            YugabyteDBConnection.class.getClassLoader(),
+                            JdbcConfiguration.PORT.withDefault(YugabyteDBConnectorConfig.PORT.defaultValueAsString()))
+                        : JdbcConnection.patternBasedFactory(SINGLE_HOST_URL_PATTERN,
+                                org.postgresql.Driver.class.getName(),
+                                YugabyteDBConnection.class.getClassLoader(), JdbcConfiguration.PORT
+                                        .withDefault(YugabyteDBConnectorConfig.PORT.defaultValueAsString())));
     }
 
     /**
@@ -100,8 +117,11 @@ public class YugabyteDBConnection extends JdbcConnection {
      * @param yugabyteDBTypeRegistry an existing/already-primed {@link YugabyteDBTypeRegistry} instance
      */
     public YugabyteDBConnection(YugabyteDBConnectorConfig config,
-                                YugabyteDBTypeRegistry yugabyteDBTypeRegistry, String connectionUsage) {
-        super(addDefaultSettings(config.getJdbcConfig(), connectionUsage), FACTORY, YugabyteDBConnection::validateServerVersion, null, "\"", "\"");
+            YugabyteDBTypeRegistry yugabyteDBTypeRegistry, String connectionUsage, ConnectionFactory factory) {
+        super(addDefaultSettings(config.getJdbcConfig(), connectionUsage), factory,
+                YugabyteDBConnection::validateServerVersion, null, "\"", "\"");
+        YugabyteDBConnection.FACTORY = factory;
+        this.config = config.getJdbcConfig();
         if (Objects.isNull(yugabyteDBTypeRegistry)) {
             this.yugabyteDBTypeRegistry = null;
             this.defaultValueConverter = null;
@@ -112,6 +132,19 @@ public class YugabyteDBConnection extends JdbcConnection {
                     yugabyteDBTypeRegistry);
             this.defaultValueConverter = new YugabyteDBDefaultValueConverter(valueConverter, this.getTimestampUtils());
         }
+    }
+
+    public YugabyteDBConnection(YugabyteDBConnectorConfig config,
+                                YugabyteDBTypeRegistry yugabyteDBTypeRegistry, String connectionUsage) {
+        this(config,yugabyteDBTypeRegistry, connectionUsage, config.getJdbcConfig().getHostname().contains(":")
+                        ? JdbcConnection.patternBasedFactory(MULTI_HOST_URL_PATTERN,
+                            org.postgresql.Driver.class.getName(),
+                            YugabyteDBConnection.class.getClassLoader(),
+                            JdbcConfiguration.PORT.withDefault(YugabyteDBConnectorConfig.PORT.defaultValueAsString()))
+                        : JdbcConnection.patternBasedFactory(SINGLE_HOST_URL_PATTERN,
+                                org.postgresql.Driver.class.getName(),
+                                YugabyteDBConnection.class.getClassLoader(), JdbcConfiguration.PORT
+                                        .withDefault(YugabyteDBConnectorConfig.PORT.defaultValueAsString())));
     }
 
     /**
@@ -138,7 +171,12 @@ public class YugabyteDBConnection extends JdbcConnection {
      * @return a {@code String} where the variables in {@code urlPattern} are replaced with values from the configuration
      */
     public String connectionString() {
-        return connectionString(URL_PATTERN);
+        String hostName = config.getHostname();
+        if(hostName.contains(":")){
+            return connectionString(MULTI_HOST_URL_PATTERN);
+        } else {
+            return connectionString(SINGLE_HOST_URL_PATTERN);
+        }
     }
 
     /**

--- a/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
@@ -82,7 +82,7 @@ public final class TestHelper {
     private static String CONTAINER_YSQL_HOST = "127.0.0.1";
     private static int CONTAINER_YSQL_PORT = 5433;
     private static String CONTAINER_MASTER_PORT = "7100";
-    private static String MASTER_ADDRESS = "";
+    private static String MASTER_ADDRESS = "127.0.0.1:7100";
     private static String DEFAULT_DATABASE_NAME = "yugabyte";
 
     /**
@@ -375,7 +375,7 @@ public final class TestHelper {
                 .with(YugabyteDBConnectorConfig.PORT, CONTAINER_YSQL_PORT)
                 .with(YugabyteDBConnectorConfig.SNAPSHOT_MODE, YugabyteDBConnectorConfig.SnapshotMode.NEVER.getValue())
                 .with(YugabyteDBConnectorConfig.DELETE_STREAM_ON_STOP, Boolean.TRUE)
-                .with(YugabyteDBConnectorConfig.MASTER_ADDRESSES, CONTAINER_YSQL_HOST + ":" + CONTAINER_MASTER_PORT)
+                .with(YugabyteDBConnectorConfig.MASTER_ADDRESSES, MASTER_ADDRESS)
                 .with(YugabyteDBConnectorConfig.TABLE_INCLUDE_LIST, fullTableNameWithSchema)
                 .with(YugabyteDBConnectorConfig.STREAM_ID, dbStreamId);
     }


### PR DESCRIPTION
## Problem
Currently, the Debezium Connector for YugabyteDB takes in a `database.hostname` which is the IP of a node where the connector performs a one time operation to validate the user authentication.

This can create a problem as the current setup leads to a hard dependency on the provided node i.e. in case the connector restarts and the DB node crashes at that time then the connector will not be able to validate the connection and as a result of this, it will not proceed forward and fail at the validation step itself.

## Solution
With this PR `database.hostname` config can now take in a comma separated addresses (ex `ip1:port1,ip2:port2, ip3:port3`) of multiple DB nodes. In case a node isn't available at the time of validation, the connector tries to connect to the next node. 
The earlier way of specifying a single IP of a node is also supported.