### PR TITLE
[CDCSDK] Add check to ensure received OpID always more than older checkpoint

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -868,7 +868,9 @@ public class YugabyteDBStreamingChangeEventSource implements
 
                     // Parse the string to get the OpId object.
                     OpId tempOpId = OpId.valueOf((String) entry.getValue());
-                    // Check if the received OpId is less than the checkpoint already present in the map.
+                    // We should check if the received OpId is less than the checkpoint already present
+                    // in the map. If this is so, then we don't update the checkpoint. Updating to a lesser value
+                    // than one already present would throw the error: CDCSDK: Trying to fetch already GCed intents
                     if (this.tabletToExplicitCheckpoint.get(entry.getKey()) != null &&
                             tempOpId.getIndex() < this.tabletToExplicitCheckpoint.get(entry.getKey()).getIndex()) {
                         LOGGER.warn("The received OpId {} is less than the older checkpoint {} for tablet {}",

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -868,6 +868,14 @@ public class YugabyteDBStreamingChangeEventSource implements
 
                     // Parse the string to get the OpId object.
                     OpId tempOpId = OpId.valueOf((String) entry.getValue());
+
+                    if(this.tabletToExplicitCheckpoint.get(entry.getKey()) != null &&
+                            tempOpId.getIndex() < this.tabletToExplicitCheckpoint.get(entry.getKey()).getIndex()) {
+                        LOGGER.warn("The received OpId {} is less than the older checkpoint {} for tablet {}",
+                                    tempOpId.getIndex(), this.tabletToExplicitCheckpoint.get(entry.getKey()).getIndex(), entry.getKey());
+                        continue;
+                    }
+
                     this.tabletToExplicitCheckpoint.put(entry.getKey(), tempOpId.toCdcSdkCheckpoint());
 
                     LOGGER.debug("Committed checkpoint on server for stream ID {} tablet {} with term {} index {}",

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -868,14 +868,13 @@ public class YugabyteDBStreamingChangeEventSource implements
 
                     // Parse the string to get the OpId object.
                     OpId tempOpId = OpId.valueOf((String) entry.getValue());
-
-                    if(this.tabletToExplicitCheckpoint.get(entry.getKey()) != null &&
+                    // Check if the received OpId is less than the checkpoint already present in the map.
+                    if (this.tabletToExplicitCheckpoint.get(entry.getKey()) != null &&
                             tempOpId.getIndex() < this.tabletToExplicitCheckpoint.get(entry.getKey()).getIndex()) {
                         LOGGER.warn("The received OpId {} is less than the older checkpoint {} for tablet {}",
                                     tempOpId.getIndex(), this.tabletToExplicitCheckpoint.get(entry.getKey()).getIndex(), entry.getKey());
                         continue;
                     }
-
                     this.tabletToExplicitCheckpoint.put(entry.getKey(), tempOpId.toCdcSdkCheckpoint());
 
                     LOGGER.debug("Committed checkpoint on server for stream ID {} tablet {} with term {} index {}",


### PR DESCRIPTION
## Problem
We were seeing `CDCSDK Trying to fetch already GCed intents for transaction 86630649-7302-45aa-a2ee-b46c01bdc8d7` on LRU test `test_cdc_lru_nemesis_splitting_postgres_debezium`

Analysis of VLOGS points to the fact that when the connector was erroneously setting OpId lower than the one already available with it in the `tabletToExplicitCheckpoint` map.

So for that particular tablet, `op_id` has been set to an older value, but the checkpoint available to it before callback was already a newer one than this. Since it had a newer checkpoint before this callback, the intents before this (newer) checkpoint were already garbage collected. So when the `GetChangesForCDCSDK` function tries to process the intents for this tablet, based on an older `op_id`, it throws a `Trying to fetch already GCed intents` error.

## Solution
In the `commitOffset` method, we add a check to see if the OpId received is less than the entry which exists in the `tabletToExplicitCheckpoint` map. If this is so, we ignore the OpId. Thus, now we can be sure that the new checkpoint being set is always greater than or equal to the older available checkpoint.