### PR TITLE
[yugabyte/yugabyte-db#19293] Modify logic to decide whether snapshot is complete

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.kafka>3.3.1</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>
-        <version.ybclient>0.8.62-20230901.095631-3</version.ybclient>
+        <version.ybclient>0.8.64-SNAPSHOT</version.ybclient>
         <version.gson>2.8.9</version.gson>
 
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.kafka>3.3.1</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>
-        <version.ybclient>0.8.64-SNAPSHOT</version.ybclient>
+        <version.ybclient>0.8.64-20230929.065833-2</version.ybclient>
         <version.gson>2.8.9</version.gson>
 
         <!--

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -45,7 +45,11 @@ import io.debezium.util.Strings;
 
 public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeEventSource<YBPartition, YugabyteDBOffsetContext> {
     private static final Logger LOGGER = LoggerFactory.getLogger(YugabyteDBSnapshotChangeEventSource.class);
+
+    // Test only member variables, DO NOT try to modify in the source code.
     public static boolean FAIL_AFTER_BOOTSTRAP_GET_CHANGES;
+    public static boolean FAIL_AFTER_SETTING_INITIAL_CHECKPOINT;
+
     private final YugabyteDBConnectorConfig connectorConfig;
     private final YugabyteDBSchema schema;
     private final SnapshotProgressListener snapshotProgressListener;
@@ -219,26 +223,27 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
       return SnapshotResult.skipped(previousOffset);
     }
 
+    /**
+     * To set the checkpoint on the service indicating that this is the initial checkpoint.
+     * Technically, it means that we are trying to set the active time for the configured
+     * stream ID and the passed tablet ID in the method.
+     * @param tableId
+     * @param tabletId
+     * @throws Exception when the SetCheckpoint RPC fails on the service
+     */
     protected void setCheckpointWithRetryBeforeSnapshot(
-        String tableId, String tabletId, Set<String> snapshotCompletedTablets, 
-        Set<String> snapshotCompletedPreviously) throws Exception {
+      String tableId, String tabletId) throws Exception {
       short retryCount = 0;
       try {
-        if (hasSnapshotCompletedPreviously(tableId, tabletId)) {
-          LOGGER.info("Skipping snapshot for table {} tablet {} since tablet has streamed some data before",
-                      tableId, tabletId);
-          snapshotCompletedTablets.add(tabletId);
-          snapshotCompletedPreviously.add(tabletId);
-        } else {
-          LOGGER.info("Setting checkpoint before snapshot on tablet {} with 0.0", tabletId);
-          YBClientUtils.setCheckpoint(this.syncClient, 
-                                      this.connectorConfig.streamId(), 
-                                      tableId /* tableId */, 
-                                      tabletId /* tabletId */, 
-                                      0 /* term */, 0 /* index */,
-                                      true /* initialCheckpoint */, false /* bootstrap */,
-                                      0 /* invalid cdcsdkSafeTime */);
-        }
+        LOGGER.info("Setting checkpoint before snapshot on tablet {} with 0.0,"
+                    + " will be taking snapshot now", tabletId);
+        YBClientUtils.setCheckpoint(this.syncClient, 
+                                    this.connectorConfig.streamId(), 
+                                    tableId /* tableId */, 
+                                    tabletId /* tabletId */, 
+                                    0 /* term */, 0 /* index */,
+                                    true /* initialCheckpoint */, false /* bootstrap */,
+                                    0 /* invalid cdcsdkSafeTime */);
 
         // Reaching this point would mean that the process went through without failure so reset
         // the retry counter here.
@@ -269,6 +274,32 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
       }
     }
 
+    /**
+     * Decide if we need to take snapshot or do nothing if snapshot has completed previously
+     */
+    protected boolean isSnapshotRequired(GetCheckpointResponse getCheckpointResponse,
+                                         String tableId, String tabletId,
+                                         Set<String> snapshotCompletedTablets,
+                                         Set<String> snapshotCompletedPreviously) 
+                                           throws Exception {
+      if (hasSnapshotCompletedPreviously(getCheckpointResponse)) {
+        LOGGER.info("Skipping snapshot for table {} tablet {} since tablet has streamed some data before",
+                  tableId, tabletId);
+        snapshotCompletedTablets.add(tabletId);
+        snapshotCompletedPreviously.add(tabletId);
+
+        return false;
+      } else {
+        // Set checkpoint with bootstrap and initialCheckpoint as false.
+        // A call to set the checkpoint is required first otherwise we will get an error 
+        // from the server side saying:
+        // INTERNAL_ERROR[code 21]: Stream ID {} is expired for Tablet ID {}
+        setCheckpointWithRetryBeforeSnapshot(tableId, tabletId);
+
+        return true;
+      }
+    }
+
     protected SnapshotResult<YugabyteDBOffsetContext> doExecute(ChangeEventSourceContext context, YBPartition partition, YugabyteDBOffsetContext previousOffset,
                                                                 SnapshotContext<YBPartition, YugabyteDBOffsetContext> snapshotContext,
                                                                 SnapshottingTask snapshottingTask)
@@ -293,6 +324,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
       }
 
       Map<TableId, String> filteredTableIdToUuid = determineTablesForSnapshot(tableIdToTable);
+      List<Pair<String, String>> tableToTabletForSnapshot = new ArrayList<>();
 
       Map<String, Boolean> schemaNeeded = new HashMap<>();
       Set<String> snapshotCompletedTablets = new HashSet<>();
@@ -300,54 +332,44 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
 
       for (Pair<String, String> entry : tableToTabletIds) {
         // We can use tableIdToTable.get(entry.getKey()).isColocated() to get actual status.
-        YBPartition p = new YBPartition(entry.getKey() /* tableId */,
-                                        entry.getValue() /* tabletId */, true /* colocated */);
+        String tableId = entry.getKey();
+        String tabletId = entry.getValue();
+        YBPartition p = new YBPartition(tableId, tabletId, true /* colocated */);
 
         GetCheckpointResponse resp = this.syncClient.getCheckpoint(
-          tableIdToTable.get(entry.getKey()), this.connectorConfig.streamId(), entry.getValue());
-        LOGGER.debug("The response received has term {} index {} key {} and time {}",
-                     resp.getTerm(), resp.getIndex(), resp.getSnapshotKey(),
-                     resp.getSnapshotTime());
+          tableIdToTable.get(tableId), this.connectorConfig.streamId(), tabletId);
+        LOGGER.info("Checkpoint before snapshotting tablet {}: Term {} Index {} SnapshotKey: {}",
+                    tabletId, resp.getTerm(), resp.getIndex(),
+                    resp.hasSnapshotKey() ? resp.getSnapshotKey() : "null");
 
-        OpId startLsn = (resp.getSnapshotKey().length == 0) ?
-                            YugabyteDBOffsetContext.snapshotStartLsn() : OpId.from(resp);
+        OpId startLsn = OpId.from(resp);
+        if (filteredTableIdToUuid.containsValue(tableId)) {
+          // We need to take the snapshot for this table.
+          tableToTabletForSnapshot.add(entry);
+
+          if (isSnapshotRequired(resp, tableId, tabletId, snapshotCompletedTablets, snapshotCompletedPreviously)) {
+            startLsn = YugabyteDBOffsetContext.snapshotStartLsn();
+          }
+        } else {
+          // At this stage we know that the particular table is not a part of the
+          // snapshot.include.collection.list so we simply need to bootstrap the tablet
+          // for streaming.
+          LOGGER.info("Skipping the table {} tablet {} since it is not a part of the"
+                      + " snapshot.include.collection.list", entry.getKey(), entry.getValue());
+          YBClientUtils.setCheckpoint(this.syncClient, this.connectorConfig.streamId(), 
+                                      tableId, tabletId, -1 /* term */, -1 /* index */,
+                                      true /* initialCheckpoint */, true /* bootstrap */);
+        }
+
         previousOffset.initSourceInfo(p, this.connectorConfig, startLsn);
         schemaNeeded.put(p.getId(), Boolean.TRUE);
         shouldWaitForCallback.add(p.getId());
-        LOGGER.debug("Previous offset for table {} tablet {} is {}", p.getTableId(),
+        LOGGER.info("Previous offset for table {} tablet {} is {}", p.getTableId(),
                      p.getTabletId(), previousOffset.toString());
       }
 
-      List<Pair<String, String>> tableToTabletForSnapshot = new ArrayList<>();
-      List<Pair<String, String>> tableToTabletNoSnapshot = new ArrayList<>();
-
-      for (Pair<String, String> entry : tableToTabletIds) {
-        String tableUuid = entry.getKey();
-        String tabletUuid = entry.getValue();
-
-        if (filteredTableIdToUuid.containsValue(tableUuid)) {
-          // This means we need to add this table/tablet for snapshotting
-          tableToTabletForSnapshot.add(entry);
-        } else {
-          tableToTabletNoSnapshot.add(entry);
-          // Bootstrap the tablets if they need not be snapshotted
-          LOGGER.info(
-            "Skipping the tablet {} since it is not a part of the snapshot collection include list",
-            tabletUuid);
-          YBClientUtils.setCheckpoint(this.syncClient, this.connectorConfig.streamId(), 
-                                      tableUuid, tabletUuid, -1, -1, true, true);
-        }
-      }
-
-      // Set checkpoint with bootstrap and initialCheckpoint as false.
-      // A call to set the checkpoint is required first otherwise we will get an error 
-      // from the server side saying:
-      // INTERNAL_ERROR[code 21]: Stream ID {} is expired for Tablet ID {}
-      for (Pair<String, String> entry : tableToTabletForSnapshot) {
-        setCheckpointWithRetryBeforeSnapshot(entry.getKey() /*tableId*/,
-                                             entry.getValue() /*tabletId*/,
-                                             snapshotCompletedTablets,
-                                             snapshotCompletedPreviously);
+      if (FAIL_AFTER_SETTING_INITIAL_CHECKPOINT) {
+        throw new RuntimeException("[TEST ONLY] Throwing error explicitly after setting initial checkpoint");
       }
 
       short retryCount = 0;
@@ -773,22 +795,10 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
     /**
      * Check on the server side if the tablet already has some checkpoint, if it does then do
      * not take a snapshot for it again since some data has already been streamed out of it
-     * @param tableId the UUID of the table
-     * @param tabletId the UUID of the tablet
-     * @return true if snapshot has been taken or some data has streamed already
-     * @throws Exception if checkpoint cannot be retreived from server side
+     * @param getCheckpointResponse
      */
-    protected boolean hasSnapshotCompletedPreviously(String tableId, String tabletId) 
-        throws Exception {
-      GetCheckpointResponse resp = this.syncClient.getCheckpoint(
-                                       this.syncClient.openTableByUUID(tableId), 
-                                       this.connectorConfig.streamId(), tabletId);
-
-      LOGGER.info("Checkpoint before snapshotting tablet {}: Term {} Index {} SnapshotKey: {}",
-                  tabletId, resp.getTerm(), resp.getIndex(),
-                  resp.hasSnapshotKey() ? resp.getSnapshotKey() : "null");
-
-      if (resp.hasSnapshotKey()) {
+    protected boolean hasSnapshotCompletedPreviously(GetCheckpointResponse getCheckpointResponse) {
+      if (getCheckpointResponse.hasSnapshotKey()) {
         // This indicates that snapshot key is present and the connector is either in the middle
         // of the snapshot or snapshot has just been bootstrapped and we haven't called further
         // GetChanges on the tablet.
@@ -800,7 +810,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
       // If no snapshot key is present then it could be either of the two cases:
       // 1. Snapshot hasn't been initiated (so snapshot incomplete) -> indicated by invalid OpId 
       // 2. Snapshot is complete and tablet is in streaming mode -> OpId is valid
-      return OpId.isValid(resp.getTerm(), resp.getIndex());
+      return OpId.isValid(getCheckpointResponse.getTerm(), getCheckpointResponse.getIndex());
     }
 
     protected Set<TableId> getAllTableIds(RelationalSnapshotChangeEventSource.RelationalSnapshotContext<YBPartition, YugabyteDBOffsetContext> ctx)

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -364,7 +364,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
         previousOffset.initSourceInfo(p, this.connectorConfig, startLsn);
         schemaNeeded.put(p.getId(), Boolean.TRUE);
         shouldWaitForCallback.add(p.getId());
-        LOGGER.info("Previous offset for table {} tablet {} is {}", p.getTableId(),
+        LOGGER.debug("Previous offset for table {} tablet {} is {}", p.getTableId(),
                      p.getTabletId(), previousOffset.toString());
       }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -339,8 +339,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
         GetCheckpointResponse resp = this.syncClient.getCheckpoint(
           tableIdToTable.get(tableId), this.connectorConfig.streamId(), tabletId);
         LOGGER.info("Checkpoint before snapshotting tablet {}: Term {} Index {} SnapshotKey: {}",
-                    tabletId, resp.getTerm(), resp.getIndex(),
-                    resp.hasSnapshotKey() ? resp.getSnapshotKey() : "null");
+                    tabletId, resp.getTerm(), resp.getIndex(), resp.getSnapshotKey());
 
         OpId startLsn = OpId.from(resp);
         if (filteredTableIdToUuid.containsValue(tableId)) {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -798,7 +798,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
      * @param getCheckpointResponse
      */
     protected boolean hasSnapshotCompletedPreviously(GetCheckpointResponse getCheckpointResponse) {
-      if (getCheckpointResponse.hasSnapshotKey()) {
+      if (getCheckpointResponse.getSnapshotKey() != null) {
         // This indicates that snapshot key is present and the connector is either in the middle
         // of the snapshot or snapshot has just been bootstrapped and we haven't called further
         // GetChanges on the tablet.

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
@@ -153,4 +153,14 @@ public class OpId implements Comparable<OpId> {
         return (checkpoint != null && this.term <= checkpoint.getTerm()
                 && this.index <= checkpoint.getIndex() && this.time <= checkpoint.getTime());
     }
+
+    /**
+     * Check whether the passed OpId is valid.
+     * @param term
+     * @param index
+     * @return true if OpId is valid, false otherwise
+     */
+    public static boolean isValid(long term, long index) {
+        return (term != -1) && (index != -1);
+    }
 }


### PR DESCRIPTION
 ## Problem

The first GetChanges call in snapshot only tells the service to mark the snapshot boundary i.e. the snapshot is bootstrapped.  When snapshot is bootstrapped, the service marks certain `OpId` value in the `cdc_state` table to indicate snapshot end boundary.

Now if the connector fails just after the bootstrap GetChanges call and is restarted, it executes a `GetCheckpoint` RPC call to decide whether or not to take a snapshot, before this PR, the logic was solely based on the presence of a non-empty snapshot key and invalid checkpoint as follows:
1. If there is a non-empty snapshot key then snapshot is not completed and we need to continue taking snapshot, otherwise check for condition 2.
2. If the `OpId` is invalid i.e. term=-1 and index = -1 then take snapshot, otherwise the assumption is that the snapshot is complete.

However, the condition 2 was also true for cases where a snapshot was just bootstrapped and the connector skips the snapshot this time and proceeds to streaming.

## Solution

The fix is to change the logic which we use to decide whether or not to take snapshot:
1. If snapshot key is present in the response (`snapshot_key != null`) - we need to proceed for snapshot.
2. If it is not present (`snaphshot_key == null`), then check if it is invalid, if yes, then take snapshot, otherwise we know that the tablet is already in the streaming mode.

Additionally, the flow has been refactored a little to increase readability, changes include:
1. `hasSnapshotCompletedPreviously` now only takes the `GetCheckpointResponse` called previously - effectively reducing the `GetCheckpoint` RPC calls to half
2. The complete evaluation logic whether to snapshot completed earlier or we need to take snapshot after calling `SetCheckpoint` RPC has been refactored to a method `isSnapshotRequired`
3. Effectively, the flow is now:
    a. Filter tables/tablets based on `snapshot.include.collection.list`
    b. Iterate over the complete tablet list
        i. If table is in the filtered list then check if we need to take snapshot using the method `isSnapshotRequired`
        ii. If table is not in the filtered list, then simply bootstrap the tablet for streaming
    c. Start polling for snapshot on the tablet list for snapshot

### Related service diff

https://phorge.dev.yugabyte.com/D28814

### Test Plan

Added tests:
1. YugabyteDBSnapshotTest#shouldSnapshotWithFailureAfterBootstrapSnapshotCall
2. YugabyteDBSnapshotTest#shouldSnapshotWithFailureAfterSettingInitialCheckpoint
3. YugabyteDBSnapshotTest#shouldNotSnapshotAgainIfSnapshotCompletedOnce
4. YugabyteDBSnapshotTest#shouldContinueStreamingInNeverAfterSnapshotCompleteInInitialOnly

To run the tests, following command can be used:

```
mvn clean test -Dtest=YugabyteDBSnapshotTest#shouldSnapshotWithFailureAfterBootstrapSnapshotCall

mvn clean test -Dtest=YugabyteDBSnapshotTest#shouldSnapshotWithFailureAfterSettingInitialCheckpoint

mvn clean test -Dtest=YugabyteDBSnapshotTest#shouldNotSnapshotAgainIfSnapshotCompletedOnce

mvn clean test -Dtest=YugabyteDBSnapshotTest#shouldContinueStreamingInNeverAfterSnapshotCompleteInInitialOnly
```

This PR closes yugabyte/yugabyte-db#19293