### PR TITLE
Added retry mechanism for setCheckpoint in snapshot

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -234,42 +234,93 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
     protected void setCheckpointWithRetryBeforeSnapshot(
       String tableId, String tabletId) throws Exception {
       short retryCount = 0;
-      try {
-        LOGGER.info("Setting checkpoint before snapshot on tablet {} with 0.0,"
-                    + " will be taking snapshot now", tabletId);
-        YBClientUtils.setCheckpoint(this.syncClient, 
-                                    this.connectorConfig.streamId(), 
-                                    tableId /* tableId */, 
-                                    tabletId /* tabletId */, 
-                                    0 /* term */, 0 /* index */,
-                                    true /* initialCheckpoint */, false /* bootstrap */,
-                                    0 /* invalid cdcsdkSafeTime */);
 
-        // Reaching this point would mean that the process went through without failure so reset
-        // the retry counter here.
-        retryCount = 0;
-      } catch (Exception e) {
-        ++retryCount;
+      // The SetCDCCheckPoint RPC, relies on a cache to obtain a list of all the tservers.
+      // In case of multi host port connection url, if one of the DB node goes down,
+      // it takes some time for the cache to refresh and return correct tserver list.
+      // This refresh time may be longer and hence we need additional number of retries here.
+      int totalRetries = this.connectorConfig.maxConnectorRetries() * 5;
 
-        if (retryCount > this.connectorConfig.maxConnectorRetries()) {
-          LOGGER.error("Too many errors while trying to set checkpoint, "
-                        + "all {} retries failed.", this.connectorConfig.maxConnectorRetries());
-
-          throw e;
-        }
-
-        LOGGER.warn("Error while trying to set the checkpoint; will attempt " 
-                    + "retry {} of {} after {} milli-seconds. Exception message: {}", retryCount, 
-                      this.connectorConfig.maxConnectorRetries(), 
-                      this.connectorConfig.connectorRetryDelayMs(), e.getMessage());
-        LOGGER.debug("Stacktrace: ", e);
-
+      while(retryCount <= totalRetries) {
         try {
-          final Metronome retryMetronome = Metronome.parker(Duration.ofMillis(connectorConfig.connectorRetryDelayMs()), Clock.SYSTEM);
-          retryMetronome.pause();
-        } catch (InterruptedException ie) {
-          LOGGER.warn("Connector retry sleep interrupted by exception: {}", ie);
-          Thread.currentThread().interrupt();
+          LOGGER.info("Setting checkpoint before snapshot on tablet {} with 0.0,"
+                      + " will be taking snapshot now", tabletId);
+          YBClientUtils.setCheckpoint(this.syncClient, 
+                                      this.connectorConfig.streamId(), 
+                                      tableId /* tableId */, 
+                                      tabletId /* tabletId */, 
+                                      0 /* term */, 0 /* index */,
+                                      true /* initialCheckpoint */, false /* bootstrap */,
+                                      0 /* invalid cdcsdkSafeTime */);
+
+          // Reaching this point would mean that the process went through without failure 
+          return;
+        } catch (Exception e) {
+          ++retryCount;
+
+          if (retryCount > totalRetries) {
+            LOGGER.error("Too many errors while trying to set checkpoint, "
+                          + "all {} retries failed.", totalRetries);
+
+            throw e;
+          }
+
+          LOGGER.warn("Error while trying to set the checkpoint; will attempt " 
+                      + "retry {} of {} after {} milli-seconds. Exception message: {}", retryCount, 
+                        totalRetries, 
+                        this.connectorConfig.connectorRetryDelayMs(), e.getMessage());
+          LOGGER.debug("Stacktrace: ", e);
+
+          try {
+            final Metronome retryMetronome = Metronome.parker(Duration.ofMillis(connectorConfig.connectorRetryDelayMs()), Clock.SYSTEM);
+            retryMetronome.pause();
+          } catch (InterruptedException ie) {
+            LOGGER.warn("Connector retry sleep interrupted by exception: {}", ie);
+            Thread.currentThread().interrupt();
+          }
+        }
+      }
+    }
+
+    protected void setCheckpointWithRetry(String tableId, String tabletId, long term, long index, boolean initialCheckpoint, boolean bootstap) throws Exception {
+      short retryCount = 0;
+
+      // The SetCDCCheckPoint RPC, relies on a cache to obtain a list of all the tservers.
+      // In case of multi host port connection url, if one of the DB node goes down,
+      // it takes some time for the cache to refresh and return correct tserver list.
+      // This refresh time may be longer and hence we need additional number of retries here.
+      int totalRetries = this.connectorConfig.maxConnectorRetries() * 5;
+
+      while(retryCount <= totalRetries) {
+        try {
+          LOGGER.info("Setting checkpoint on tablet {} with {}.{},"
+              + " will be taking snapshot now", tabletId, term, index);
+          YBClientUtils.setCheckpoint(this.syncClient, this.connectorConfig.streamId(), tableId, tabletId, term, index,
+              initialCheckpoint, bootstap);
+
+          // Reaching this point would mean that the process went through without failure
+          return;
+        } catch (Exception e) {
+          if (retryCount > totalRetries) {
+            LOGGER.error("Too many errors while trying to set checkpoint, "
+                + "all {} retries failed.", totalRetries);
+
+            throw e;
+          }
+          LOGGER.warn("Error while trying to set the checkpoint; will attempt "
+              + "retry {} of {} after {} milli-seconds. Exception message: {}", retryCount,
+              totalRetries,
+              this.connectorConfig.connectorRetryDelayMs(), e.getMessage());
+          LOGGER.debug("Stacktrace: ", e);
+
+          try {
+            final Metronome retryMetronome = Metronome
+                .parker(Duration.ofMillis(connectorConfig.connectorRetryDelayMs()), Clock.SYSTEM);
+            retryMetronome.pause();
+          } catch (InterruptedException ie) {
+            LOGGER.warn("Connector retry sleep interrupted by exception: {}", ie);
+            Thread.currentThread().interrupt();
+          }
         }
       }
     }
@@ -401,9 +452,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
           // for streaming.
           LOGGER.info("Skipping the table {} tablet {} since it is not a part of the"
                       + " snapshot.include.collection.list", entry.getKey(), entry.getValue());
-          YBClientUtils.setCheckpoint(this.syncClient, this.connectorConfig.streamId(), 
-                                      tableId, tabletId, -1 /* term */, -1 /* index */,
-                                      true /* initialCheckpoint */, true /* bootstrap */);
+          setCheckpointWithRetry(tableId, tabletId, -1, -1, true, true);
         }
 
         previousOffset.initSourceInfo(p, this.connectorConfig, startLsn);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -240,11 +240,11 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
       // This refresh time may be longer and hence we need additional number of retries here.
       int totalRetries = this.connectorConfig.maxConnectorRetries() * 5;
 
-      while(retryCount <= totalRetries) {
+      while (retryCount <= totalRetries) {
         try {
           LOGGER.info("Setting checkpoint on tablet {} with {}.{},"
               + " will be taking snapshot now", tabletId, term, index);
-          if(cdcsdkSafeTime.equals(null)) {
+          if (cdcsdkSafeTime.equals(null)) {
             YBClientUtils.setCheckpoint(this.syncClient, this.connectorConfig.streamId(), tableId, tabletId, term, index,
                 initialCheckpoint, bootstap);
           } else {
@@ -413,7 +413,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
           // for streaming.
           LOGGER.info("Skipping the table {} tablet {} since it is not a part of the"
                       + " snapshot.include.collection.list", entry.getKey(), entry.getValue());
-          setCheckpointWithRetry(tableId, tabletId, -1, -1, true, true,null);
+          setCheckpointWithRetry(tableId, tabletId, -1, -1, true, true, null);
         }
 
         previousOffset.initSourceInfo(p, this.connectorConfig, startLsn);


### PR DESCRIPTION
## Problem
The setCheckpoint call in snapshot did not have proper retry mechanism in case of failure. As a result, in case of multi node connection when one of the node is down, the `setCheckpoint` call would fail.

## Solution
Added the requirred retry mechanism for `setCheckpoint` call.