### PR TITLE
Do not read the split tablet ID from the exception message

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
@@ -206,7 +206,7 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
                                         cdcException.printStackTrace();
                                     }
 
-                                    handleTabletSplit(cdcException, tabletPairList, offsetContext, streamId, schemaNeeded);
+                                    handleTabletSplit(part.getTabletId(), tabletPairList, offsetContext, streamId, schemaNeeded);
 
                                     // Break out of the loop so that the iteration can start afresh on the modified list.
                                     break;

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -528,7 +528,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                                     LOGGER.info("Explicit checkpoint same as last seen record's checkpoint, handling tablet split immediately for partition {}, explicit checkpoint {}:{}:{} lastRecordCheckpoint: {}.{}.{}",
                                                 part.getId(), explicitCheckpoint.getTerm(), explicitCheckpoint.getIndex(), explicitCheckpoint.getTime(), lastRecordCheckpoint.getTerm(), lastRecordCheckpoint.getIndex(), lastRecordCheckpoint.getTime());
 
-                                    handleTabletSplit(cdcException, tabletPairList, offsetContext, streamId, schemaNeeded);
+                                    handleTabletSplit(part.getTabletId(), tabletPairList, offsetContext, streamId, schemaNeeded);
                                 } else {
                                     // Add the tablet for being processed later, this will mark the tablet as locked. There is a chance that explicit checkpoint may
                                     // be null, in that case, just to avoid NullPointerException in the log, simply log a null value.
@@ -538,10 +538,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                                     splitTabletsWaitingForCallback.add(part.getId());
                                 }
                             } else {
-                                // TODO Vaibhav: Since we have access to tablet ID at this stage, and we can assume that we will only receive
-                                // tablet split error message on the tablet we will call GetChanges on, then instead of passing the exception
-                                // we can directly pass the tablet ID of the split tablet.
-                                handleTabletSplit(cdcException, tabletPairList, offsetContext, streamId, schemaNeeded);
+                                handleTabletSplit(part.getTabletId(), tabletPairList, offsetContext, streamId, schemaNeeded);
                             }
 
                             // Break out of the loop so that the iteration can start afresh on the modified list.
@@ -941,19 +938,6 @@ public class YugabyteDBStreamingChangeEventSource implements
     }
 
     /**
-     * Parse the message from the {@link CDCErrorException} to obtain the tablet ID of the tablet.
-     * which has been split
-     * @param message the exception message to parse
-     * @return the tablet UUID of the tablet which has been split
-     */
-    private String getTabletIdFromSplitMessage(String message) {
-        // Note that the message is of the form: Tablet Split detected on <tablet-ID>
-        // So the last element is the tablet ID to be split.
-        String[] splitWords = message.split("\\s+");
-        return splitWords[splitWords.length - 1];
-    }
-
-    /**
      * Add the tablet from the provided tablet checkpoint pair to the list of tablets to poll from
      * if it is not present there
      * @param tabletPairList the list of tablets to poll from - list having Pair<tableId, tabletId>
@@ -992,15 +976,6 @@ public class YugabyteDBStreamingChangeEventSource implements
             // Add the flag to indicate that we need the schema for the new tablets so that the schema can be registered.
             schemaNeeded.put(p.getId(), Boolean.TRUE);
         }
-    }
-
-    protected void handleTabletSplit(
-      CDCErrorException cdcErrorException, List<Pair<String,String>> tabletPairList,
-      YugabyteDBOffsetContext offsetContext, String streamId,
-      Map<String, Boolean> schemaNeeded) throws Exception {
-        // Obtain the tablet ID of the split tablet from the exception.
-        String splitTabletId = getTabletIdFromSplitMessage(cdcErrorException.getMessage());
-        handleTabletSplit(splitTabletId, tabletPairList, offsetContext, streamId, schemaNeeded);
     }
 
     protected void handleTabletSplit(String splitTabletId,


### PR DESCRIPTION
## Problem

Before this change, we parse the `CDCErrorException` and try to read the split tablet ID from the exception itself, but the parsing can not be relied upon and we will end up reading the wrong value as tablet ID.

## Solution

Since we know what tablet the connector is polling on, we also know we will only get tablet split exception on the same, so we can use the same tablet ID as the split parent tablet ID while handling tablet split.