### PR TITLE
Handle NO_OP messages from CDC service and add transform for Kafka-connect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.kafka>3.3.1</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>
-        <version.ybclient>0.8.64-20230929.065833-2</version.ybclient>
+        <version.ybclient>0.8.66-20231006.090638-2</version.ybclient>
         <version.gson>2.8.9</version.gson>
 
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -47,13 +47,13 @@
         <version.kafka>3.3.1</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>
-        <version.ybclient>0.8.64-20230929.065833-2</version.ybclient>
+        <version.ybclient>0.8.65-SNAPSHOT</version.ybclient>
         <version.gson>2.8.9</version.gson>
 
         <!--
           Specify the properties that will be used for setting up the integration tests' Docker container.
           Note that the `dockerhost.ip` property is computed from the IP address of DOCKER_HOST, which will
-          work on all platforms. We'll set some of these as system properties during integration testing.
+          work on all platforms. We'll set some of these as system properties during integration testing. 0.8.64-20230929.065833-2
         -->
 
         <protobuf.output.directory>${project.basedir}/generated-sources</protobuf.output.directory>

--- a/pom.xml
+++ b/pom.xml
@@ -47,13 +47,13 @@
         <version.kafka>3.3.1</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>
-        <version.ybclient>0.8.65-SNAPSHOT</version.ybclient>
+        <version.ybclient>0.8.64-20230929.065833-2</version.ybclient>
         <version.gson>2.8.9</version.gson>
 
         <!--
           Specify the properties that will be used for setting up the integration tests' Docker container.
           Note that the `dockerhost.ip` property is computed from the IP address of DOCKER_HOST, which will
-          work on all platforms. We'll set some of these as system properties during integration testing. 0.8.64-20230929.065833-2
+          work on all platforms. We'll set some of these as system properties during integration testing.
         -->
 
         <protobuf.output.directory>${project.basedir}/generated-sources</protobuf.output.directory>

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeRecordEmitter.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeRecordEmitter.java
@@ -85,6 +85,7 @@ public class YugabyteDBChangeRecordEmitter extends RelationalChangeRecordEmitter
             case DELETE:
                 return Operation.DELETE;
             case READ:
+            case NOOP:
                 return Operation.READ;
             case TRUNCATE:
                 return Operation.TRUNCATE;

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBEventDispatcher.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBEventDispatcher.java
@@ -31,7 +31,6 @@ import io.debezium.pipeline.spi.ChangeEventCreator;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.Partition;
 import io.debezium.util.SchemaNameAdjuster;
-import io.debezium.connector.yugabytedb.transforms.FilterNoOp;
 
 import java.util.EnumSet;
 import java.util.Objects;

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBEventDispatcher.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBEventDispatcher.java
@@ -210,7 +210,7 @@ public class YugabyteDBEventDispatcher<T extends DataCollectionId> extends Event
             // Truncate events must have null key schema as they are sent to table topics without keys
             Schema keySchema = (key == null && (operation == Envelope.Operation.TRUNCATE || isNOOP)) ? null
                                  : dataCollectionSchema.keySchema();
-            String topicName = isNOOP ? null : topicSelector.topicNameFor((T) dataCollectionSchema.id());
+            String topicName = topicSelector.topicNameFor((T) dataCollectionSchema.id());
 
             SourceRecord record;
 
@@ -232,7 +232,7 @@ public class YugabyteDBEventDispatcher<T extends DataCollectionId> extends Event
                     null,
                     null,
                     headers);
-                LOGGER.info("Created a NOOP record");
+                LOGGER.info("Created a NO_OP record");
             }
 
             queue.enqueue(changeEventCreator.createDataChangeEvent(record));

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -528,7 +528,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                                     LOGGER.info("Explicit checkpoint same as last seen record's checkpoint, handling tablet split immediately for partition {}, explicit checkpoint {}:{}:{} lastRecordCheckpoint: {}.{}.{}",
                                                 part.getId(), explicitCheckpoint.getTerm(), explicitCheckpoint.getIndex(), explicitCheckpoint.getTime(), lastRecordCheckpoint.getTerm(), lastRecordCheckpoint.getIndex(), lastRecordCheckpoint.getTime());
 
-                                    handleTabletSplit(part.getTabletId(), tabletPairList, offsetContext, streamId, schemaNeeded);
+                                    handleTabletSplit(cdcException, tabletPairList, offsetContext, streamId, schemaNeeded);
                                 } else {
                                     // Add the tablet for being processed later, this will mark the tablet as locked. There is a chance that explicit checkpoint may
                                     // be null, in that case, just to avoid NullPointerException in the log, simply log a null value.
@@ -538,7 +538,10 @@ public class YugabyteDBStreamingChangeEventSource implements
                                     splitTabletsWaitingForCallback.add(part.getId());
                                 }
                             } else {
-                                handleTabletSplit(part.getTabletId(), tabletPairList, offsetContext, streamId, schemaNeeded);
+                                // TODO Vaibhav: Since we have access to tablet ID at this stage, and we can assume that we will only receive
+                                // tablet split error message on the tablet we will call GetChanges on, then instead of passing the exception
+                                // we can directly pass the tablet ID of the split tablet.
+                                handleTabletSplit(cdcException, tabletPairList, offsetContext, streamId, schemaNeeded);
                             }
 
                             // Break out of the loop so that the iteration can start afresh on the modified list.
@@ -555,14 +558,14 @@ public class YugabyteDBStreamingChangeEventSource implements
                                 .getResp()
                                 .getCdcSdkProtoRecordsList()) {
                             CdcService.RowMessage m = record.getRowMessage();
-                            YbProtoReplicationMessage message = new YbProtoReplicationMessage(
-                                    m, this.yugabyteDBTypeRegistry);
 
-                            // Ignore safepoint record as they are not meant to be processed here.
+                            // Ignore safepoint record as they are not meant to be processed here.        
                             if (m.getOp() == Op.SAFEPOINT) {
                                 continue;
                             }
 
+                            YbProtoReplicationMessage message = new YbProtoReplicationMessage(
+                                    m, this.yugabyteDBTypeRegistry);
                             String pgSchemaNameInRecord = m.getPgschemaName();
 
                             // This is a hack to skip tables in case of colocated tables
@@ -676,21 +679,42 @@ public class YugabyteDBStreamingChangeEventSource implements
                                         schema.refreshSchemaWithTabletId(tableId, message.getSchema(), pgSchemaNameInRecord, tabletId);
                                     }
                                 }
-                                // DML event
-                                else {
+                                // NO_OP event
+                                else if (message.isUnknownMessage()) {
                                     TableId tableId = null;
-                                    if (message.getOperation() != Operation.NOOP) {
-                                        tableId = YugabyteDBSchema.parseWithSchema(message.getTable(), pgSchemaNameInRecord);
-                                        Objects.requireNonNull(tableId);
-                                    }
+                                    LOGGER.info("Received a NOOP message for table {}", message.getTable());
+                                    tableId = YugabyteDBSchema.parseWithSchema(message.getTable(), pgSchemaNameInRecord);
+                                    Objects.requireNonNull(tableId);
                                     // If you need to print the received record, change debug level to info
-                                    LOGGER.debug("Received DML record {}", record);
+                                    LOGGER.debug("Received record {}", record);
 
                                     offsetContext.updateRecordPosition(part, lsn, lastCompletelyProcessedLsn, message.getRawCommitTime(),
                                             String.valueOf(message.getTransactionId()), tableId, message.getRecordTime());
 
-                                    boolean dispatched = message.getOperation() != Operation.NOOP
-                                            && dispatcher.dispatchDataChangeEvent(part, tableId, new YugabyteDBChangeRecordEmitter(part, offsetContext, clock, connectorConfig,
+                                    dispatcher.setIsNOOP(true);
+                                    boolean dispatched = dispatcher.dispatchDataChangeEvent(part, tableId, new YugabyteDBChangeRecordEmitter(part, offsetContext, clock, connectorConfig,
+                                                    schema, connection, tableId, message, pgSchemaNameInRecord, tabletId, taskContext.isBeforeImageEnabled()));
+                                    dispatcher.setIsNOOP(false); 
+
+                                    if (recordsInTransactionalBlock.containsKey(part.getId())) {
+                                        recordsInTransactionalBlock.merge(part.getId(), 1, Integer::sum);
+                                    }
+
+                                    maybeWarnAboutGrowingWalBacklog(dispatched);
+                                }
+                                // DML event
+                                else {
+                                    TableId tableId = null;
+                                    tableId = YugabyteDBSchema.parseWithSchema(message.getTable(), pgSchemaNameInRecord);
+                                    Objects.requireNonNull(tableId);
+
+                                    // If you need to print the received record, change debug level to info
+                                    LOGGER.debug("Received record {}", record);
+                                    
+                                    offsetContext.updateRecordPosition(part, lsn, lastCompletelyProcessedLsn, message.getRawCommitTime(),
+                                            String.valueOf(message.getTransactionId()), tableId, message.getRecordTime());
+                                    dispatcher.setIsNOOP(false);
+                                    boolean dispatched = dispatcher.dispatchDataChangeEvent(part, tableId, new YugabyteDBChangeRecordEmitter(part, offsetContext, clock, connectorConfig,
                                                     schema, connection, tableId, message, pgSchemaNameInRecord, tabletId, taskContext.isBeforeImageEnabled()));
 
                                     if (recordsInTransactionalBlock.containsKey(part.getId())) {
@@ -872,7 +896,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                 // TODO: The transaction_id field is getting populated somewhere and see if it can
                 // be removed or blocked from getting added to this map.
                 if (!entry.getKey().equals("transaction_id")) {
-                    LOGGER.debug("Tablet: {} OpId: {}", entry.getKey(), entry.getValue());
+                    LOGGER.info("Tablet: {} OpId: {}", entry.getKey(), entry.getValue());
 
                     // Parse the string to get the OpId object.
                     OpId tempOpId = OpId.valueOf((String) entry.getValue());
@@ -938,6 +962,19 @@ public class YugabyteDBStreamingChangeEventSource implements
     }
 
     /**
+     * Parse the message from the {@link CDCErrorException} to obtain the tablet ID of the tablet.
+     * which has been split
+     * @param message the exception message to parse
+     * @return the tablet UUID of the tablet which has been split
+     */
+    private String getTabletIdFromSplitMessage(String message) {
+        // Note that the message is of the form: Tablet Split detected on <tablet-ID>
+        // So the last element is the tablet ID to be split.
+        String[] splitWords = message.split("\\s+");
+        return splitWords[splitWords.length - 1];
+    }
+
+    /**
      * Add the tablet from the provided tablet checkpoint pair to the list of tablets to poll from
      * if it is not present there
      * @param tabletPairList the list of tablets to poll from - list having Pair<tableId, tabletId>
@@ -976,6 +1013,15 @@ public class YugabyteDBStreamingChangeEventSource implements
             // Add the flag to indicate that we need the schema for the new tablets so that the schema can be registered.
             schemaNeeded.put(p.getId(), Boolean.TRUE);
         }
+    }
+
+    protected void handleTabletSplit(
+      CDCErrorException cdcErrorException, List<Pair<String,String>> tabletPairList,
+      YugabyteDBOffsetContext offsetContext, String streamId,
+      Map<String, Boolean> schemaNeeded) throws Exception {
+        // Obtain the tablet ID of the split tablet from the exception.
+        String splitTabletId = getTabletIdFromSplitMessage(cdcErrorException.getMessage());
+        handleTabletSplit(splitTabletId, tabletPairList, offsetContext, streamId, schemaNeeded);
     }
 
     protected void handleTabletSplit(String splitTabletId,

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -528,7 +528,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                                     LOGGER.info("Explicit checkpoint same as last seen record's checkpoint, handling tablet split immediately for partition {}, explicit checkpoint {}:{}:{} lastRecordCheckpoint: {}.{}.{}",
                                                 part.getId(), explicitCheckpoint.getTerm(), explicitCheckpoint.getIndex(), explicitCheckpoint.getTime(), lastRecordCheckpoint.getTerm(), lastRecordCheckpoint.getIndex(), lastRecordCheckpoint.getTime());
 
-                                    handleTabletSplit(cdcException, tabletPairList, offsetContext, streamId, schemaNeeded);
+                                    handleTabletSplit(part.getTabletId(), tabletPairList, offsetContext, streamId, schemaNeeded);
                                 } else {
                                     // Add the tablet for being processed later, this will mark the tablet as locked. There is a chance that explicit checkpoint may
                                     // be null, in that case, just to avoid NullPointerException in the log, simply log a null value.
@@ -538,10 +538,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                                     splitTabletsWaitingForCallback.add(part.getId());
                                 }
                             } else {
-                                // TODO Vaibhav: Since we have access to tablet ID at this stage, and we can assume that we will only receive
-                                // tablet split error message on the tablet we will call GetChanges on, then instead of passing the exception
-                                // we can directly pass the tablet ID of the split tablet.
-                                handleTabletSplit(cdcException, tabletPairList, offsetContext, streamId, schemaNeeded);
+                                handleTabletSplit(part.getTabletId(), tabletPairList, offsetContext, streamId, schemaNeeded);
                             }
 
                             // Break out of the loop so that the iteration can start afresh on the modified list.
@@ -962,19 +959,6 @@ public class YugabyteDBStreamingChangeEventSource implements
     }
 
     /**
-     * Parse the message from the {@link CDCErrorException} to obtain the tablet ID of the tablet.
-     * which has been split
-     * @param message the exception message to parse
-     * @return the tablet UUID of the tablet which has been split
-     */
-    private String getTabletIdFromSplitMessage(String message) {
-        // Note that the message is of the form: Tablet Split detected on <tablet-ID>
-        // So the last element is the tablet ID to be split.
-        String[] splitWords = message.split("\\s+");
-        return splitWords[splitWords.length - 1];
-    }
-
-    /**
      * Add the tablet from the provided tablet checkpoint pair to the list of tablets to poll from
      * if it is not present there
      * @param tabletPairList the list of tablets to poll from - list having Pair<tableId, tabletId>
@@ -1013,15 +997,6 @@ public class YugabyteDBStreamingChangeEventSource implements
             // Add the flag to indicate that we need the schema for the new tablets so that the schema can be registered.
             schemaNeeded.put(p.getId(), Boolean.TRUE);
         }
-    }
-
-    protected void handleTabletSplit(
-      CDCErrorException cdcErrorException, List<Pair<String,String>> tabletPairList,
-      YugabyteDBOffsetContext offsetContext, String streamId,
-      Map<String, Boolean> schemaNeeded) throws Exception {
-        // Obtain the tablet ID of the split tablet from the exception.
-        String splitTabletId = getTabletIdFromSplitMessage(cdcErrorException.getMessage());
-        handleTabletSplit(splitTabletId, tabletPairList, offsetContext, streamId, schemaNeeded);
     }
 
     protected void handleTabletSplit(String splitTabletId,

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/ReplicationMessage.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/ReplicationMessage.java
@@ -197,6 +197,10 @@ public interface ReplicationMessage {
         return getOperation() == Operation.DDL;
     }
 
+    default boolean isUnknownMessage() {
+        return getOperation() == Operation.NOOP;
+    }
+
     /**
      * A special message type that is used to replace event filtered already at {@link MessageDecoder}.
      * Enables {@link YugabyteDBStreamingChangeEventSource} to advance LSN forward even in case of such messages.

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/pgproto/YbProtoReplicationMessage.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/pgproto/YbProtoReplicationMessage.java
@@ -61,6 +61,8 @@ public class YbProtoReplicationMessage implements ReplicationMessage {
                 return Operation.COMMIT;
             case DDL:
                 return Operation.DDL;
+            case UNKNOWN:
+                return Operation.NOOP;
         }
         throw new IllegalArgumentException(
                 "Unknown operation '" + rawMessage.getOp() + "' in replication stream message " + rawMessage);

--- a/src/main/java/io/debezium/connector/yugabytedb/consistent/Message.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/consistent/Message.java
@@ -170,7 +170,7 @@ public class Message implements Comparable<Message> {
      * Return a BigInteger equal to the unsigned value of the argument.
      * Code taken from <a href="https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/master/src/java.base/share/classes/java/lang/Long.java#L241">Long.java</a>
      */
-    protected static BigInteger toUnsignedBigInteger(long i) {
+    public static BigInteger toUnsignedBigInteger(long i) {
         if (i >= 0L)
             return BigInteger.valueOf(i);
         else {

--- a/src/main/java/io/debezium/connector/yugabytedb/transforms/FilterNoOp.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/transforms/FilterNoOp.java
@@ -1,0 +1,36 @@
+package io.debezium.connector.yugabytedb.transforms;
+
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FilterNoOp<R extends ConnectRecord<R>> implements Transformation<R>  {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FilterNoOp.class);
+
+    @Override
+    public R apply(final R record) {
+        if (record.value() == null && record.key() == null && record.keySchema() == null && record.valueSchema() == null) {
+            LOGGER.info("Found a NO_OP record, filtering it out!");
+            return null;
+        } else {
+            return record;
+        }
+     }
+
+    @Override
+    public ConfigDef config() {
+        return new ConfigDef();
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public void configure(Map<String, ?> map) {
+    }
+}

--- a/src/test/java/io/debezium/connector/yugabytedb/common/YugabytedTestBase.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/YugabytedTestBase.java
@@ -31,7 +31,7 @@ public class YugabytedTestBase extends TestBaseClass {
         // Do nothing.
     }
 
-    public String getMasterAddress() {
+    public static String getMasterAddress() {
         return "127.0.0.1:7100";
     }
 


### PR DESCRIPTION
## Problem
We were facing data loss issue in master stress test cases.

## Solution
Have tweaked the CDC service so that even `UNKNOWN` records are sent to connector, which passes them to Kafka-connect. Kafka-connect then filters these kind of records using an SMT `FilterNoOp`

### Test Plan
Added test for confirming that `NO_OP` records are being filtered by `FilterNoOp` transform.

`mvn clean test -Dtest=YugabyteDBTabletSplitTest#checkNoOpAfterTabletSplit`