### PR TITLE
[yugabyte/yugabyte-db#12751] Changes to add configurable rpc retry attempts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.kafka>3.3.1</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>
-        <version.ybclient>0.8.67-SNAPSHOT</version.ybclient>
+        <version.ybclient>0.8.67-20231010.165133-1</version.ybclient>
         <version.gson>2.8.9</version.gson>
 
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.kafka>3.3.1</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>
-        <version.ybclient>0.8.64-20230929.065833-2</version.ybclient>
+        <version.ybclient>0.8.65-SNAPSHOT</version.ybclient>
         <version.gson>2.8.9</version.gson>
 
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.kafka>3.3.1</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>
-        <version.ybclient>0.8.65-SNAPSHOT</version.ybclient>
+        <version.ybclient>0.8.67-SNAPSHOT</version.ybclient>
         <version.gson>2.8.9</version.gson>
 
         <!--

--- a/src/main/java/io/debezium/connector/yugabytedb/YBClientUtils.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YBClientUtils.java
@@ -227,7 +227,8 @@ public class YBClientUtils {
                                   .numTablets(connectorConfig.maxNumTablets())
                                   .sslCertFile(connectorConfig.sslRootCert())
                                   .sslClientCertFiles(connectorConfig.sslClientCert(), connectorConfig.sslClientKey())
-                                  .maxAttempts(connectorConfig.maxRPCRetryAttempts())
+                                  .maxRpcAttempts(connectorConfig.maxRPCRetryAttempts())
+                                  .sleepTime(connectorConfig.rpcRetrySleepTime())
                                   .build();
     return new YBClient(asyncClient);
   }

--- a/src/main/java/io/debezium/connector/yugabytedb/YBClientUtils.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YBClientUtils.java
@@ -227,6 +227,7 @@ public class YBClientUtils {
                                   .numTablets(connectorConfig.maxNumTablets())
                                   .sslCertFile(connectorConfig.sslRootCert())
                                   .sslClientCertFiles(connectorConfig.sslClientCert(), connectorConfig.sslClientKey())
+                                  .maxAttempts(connectorConfig.maxRPCRetryAttempts())
                                   .build();
     return new YBClient(asyncClient);
   }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
@@ -201,7 +201,7 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
     }
 
     private YBClient getYBClientBase(String hostAddress, long adminTimeout, long operationTimeout, long socketReadTimeout,
-                                     int maxNumTablets, String certFile, String clientCert, String clientKey) {
+                                     int maxNumTablets, String certFile, String clientCert, String clientKey, int maxAttempts) {
         if (maxNumTablets == -1) {
             maxNumTablets = yugabyteDBConnectorConfig.maxNumTablets();
         }
@@ -225,6 +225,7 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
                 .numTablets(maxNumTablets)
                 .sslCertFile(certFile)
                 .sslClientCertFiles(clientCert, clientKey)
+                .maxAttempts(maxAttempts)
                 .build();
 
         return new YBClient(asyncClient);
@@ -306,7 +307,8 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
                 yugabyteDBConnectorConfig.maxNumTablets(),
                 yugabyteDBConnectorConfig.sslRootCert(),
                 yugabyteDBConnectorConfig.sslClientCert(),
-                yugabyteDBConnectorConfig.sslClientKey()); // always passing the ssl root certs,
+                yugabyteDBConnectorConfig.sslClientKey(), // always passing the ssl root certs,
+                yugabyteDBConnectorConfig.maxRPCRetryAttempts()); 
         // so whenever they are null, they will just be ignored
         LOGGER.debug("The master host address is " + hostAddress);
         HostAndPort masterHostPort = ybClient.getLeaderMasterHostAndPort();

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -632,7 +632,7 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
             .withImportance(Importance.LOW)
             .withDefault(DEFAULT_MAX_RPC_RETRY_ATTEMPTS);
 
-    public static final Field RPC_RETRY_SLEEP_TIME = Field.create("rpc.retry.sleep.time")
+    public static final Field RPC_RETRY_SLEEP_TIME = Field.create("rpc.retry.sleep.time.ms")
             .withDisplayName("The base sleep time used for back-offs during rpc retries")
             .withType(Type.INT)
             .withImportance(Importance.LOW)

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -553,6 +553,7 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
     protected static final long DEFAULT_OPERATION_TIMEOUT_MS = 900000;  //15 minutes
     protected static final long DEFAULT_SOCKET_READ_TIMEOUT_MS = 60000;
     protected static final int DEFAULT_MAX_RPC_RETRY_ATTEMPTS = 1800; // Number of retries, large enough, to last till timeout
+    protected static final int DEFAULT_RPC_RETRY_SLEEP_TIME_MS = 500;
     protected static final long DEFAULT_CDC_POLL_INTERVAL_MS = 500;
     protected static final int DEFAULT_MAX_CONNECTOR_RETRIES = 5;
     protected static final long DEFAULT_CONNECTOR_RETRY_DELAY_MS = 60000;
@@ -630,6 +631,12 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
             .withType(Type.INT)
             .withImportance(Importance.LOW)
             .withDefault(DEFAULT_MAX_RPC_RETRY_ATTEMPTS);
+
+    public static final Field RPC_RETRY_SLEEP_TIME = Field.create("rpc.retry.sleep.time")
+            .withDisplayName("The base sleep time used for back-offs during rpc retries")
+            .withType(Type.INT)
+            .withImportance(Importance.LOW)
+            .withDefault(DEFAULT_RPC_RETRY_SLEEP_TIME_MS);
 
     public static final Field SOCKET_READ_TIMEOUT_MS = Field.create("socket.read.timeout.ms")
             .withDisplayName("Socket read timeout in milliseconds")
@@ -1186,6 +1193,10 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
 
     public int maxRPCRetryAttempts() {
         return getConfig().getInteger(MAX_RPC_RETRY_ATTEMPTS);
+    }
+
+    public int rpcRetrySleepTime() {
+        return getConfig().getInteger(RPC_RETRY_SLEEP_TIME);
     }
 
     public long socketReadTimeoutMs() {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -549,9 +549,10 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
     protected static final int DEFAULT_MASTER_PORT = 7100;
     protected static final String DEFAULT_MASTER_ADDRESS = "127.0.0.1:7100";
     protected static final int DEFAULT_MAX_NUM_TABLETS = 300;
-    protected static final long DEFAULT_ADMIN_OPERATION_TIMEOUT_MS = 60000;
-    protected static final long DEFAULT_OPERATION_TIMEOUT_MS = 60000;
+    protected static final long DEFAULT_ADMIN_OPERATION_TIMEOUT_MS = 900000; //15 minutes
+    protected static final long DEFAULT_OPERATION_TIMEOUT_MS = 900000;  //15 minutes
     protected static final long DEFAULT_SOCKET_READ_TIMEOUT_MS = 60000;
+    protected static final int DEFAULT_MAX_RPC_RETRY_ATTEMPTS = 1800; // Number of retries, large enough, to last till timeout
     protected static final long DEFAULT_CDC_POLL_INTERVAL_MS = 500;
     protected static final int DEFAULT_MAX_CONNECTOR_RETRIES = 5;
     protected static final long DEFAULT_CONNECTOR_RETRY_DELAY_MS = 60000;
@@ -623,6 +624,12 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
             .withType(Type.LONG)
             .withImportance(Importance.LOW)
             .withDefault(DEFAULT_OPERATION_TIMEOUT_MS);
+
+    public static final Field MAX_RPC_RETRY_ATTEMPTS = Field.create("max.rpc.retry.attempts")
+            .withDisplayName("Maximum number of RPC retry attempts")
+            .withType(Type.INT)
+            .withImportance(Importance.LOW)
+            .withDefault(DEFAULT_MAX_RPC_RETRY_ATTEMPTS);
 
     public static final Field SOCKET_READ_TIMEOUT_MS = Field.create("socket.read.timeout.ms")
             .withDisplayName("Socket read timeout in milliseconds")
@@ -1175,6 +1182,10 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
 
     public long operationTimeoutMs() {
         return getConfig().getLong(OPERATION_TIMEOUT_MS);
+    }
+
+    public int maxRPCRetryAttempts() {
+        return getConfig().getInteger(MAX_RPC_RETRY_ATTEMPTS);
     }
 
     public long socketReadTimeoutMs() {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -99,7 +99,8 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
             .numTablets(connectorConfig.maxNumTablets())
             .sslCertFile(connectorConfig.sslRootCert())
             .sslClientCertFiles(connectorConfig.sslClientCert(), connectorConfig.sslClientKey())
-            .maxAttempts(connectorConfig.maxRPCRetryAttempts())
+            .maxRpcAttempts(connectorConfig.maxRPCRetryAttempts())
+            .sleepTime(connectorConfig.rpcRetrySleepTime())
             .build();
         
         this.syncClient = new YBClient(this.asyncClient);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -99,6 +99,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
             .numTablets(connectorConfig.maxNumTablets())
             .sslCertFile(connectorConfig.sslRootCert())
             .sslClientCertFiles(connectorConfig.sslClientCert(), connectorConfig.sslClientKey())
+            .maxAttempts(connectorConfig.maxRPCRetryAttempts())
             .build();
         
         this.syncClient = new YBClient(this.asyncClient);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -118,6 +118,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                 .numTablets(connectorConfig.maxNumTablets())
                 .sslCertFile(connectorConfig.sslRootCert())
                 .sslClientCertFiles(connectorConfig.sslClientCert(), connectorConfig.sslClientKey())
+                .maxAttempts(connectorConfig.maxRPCRetryAttempts())
                 .build();
 
         syncClient = new YBClient(asyncYBClient);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -118,7 +118,8 @@ public class YugabyteDBStreamingChangeEventSource implements
                 .numTablets(connectorConfig.maxNumTablets())
                 .sslCertFile(connectorConfig.sslRootCert())
                 .sslClientCertFiles(connectorConfig.sslClientCert(), connectorConfig.sslClientKey())
-                .maxAttempts(connectorConfig.maxRPCRetryAttempts())
+                .maxRpcAttempts(connectorConfig.maxRPCRetryAttempts())
+                .sleepTime(connectorConfig.rpcRetrySleepTime())
                 .build();
 
         syncClient = new YBClient(asyncYBClient);

--- a/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
@@ -437,7 +437,8 @@ public final class TestHelper {
                 .defaultOperationTimeoutMs(YugabyteDBConnectorConfig.DEFAULT_OPERATION_TIMEOUT_MS)
                 .defaultSocketReadTimeoutMs(YugabyteDBConnectorConfig.DEFAULT_SOCKET_READ_TIMEOUT_MS)
                 .numTablets(YugabyteDBConnectorConfig.DEFAULT_MAX_NUM_TABLETS)
-                .maxAttempts(YugabyteDBConnectorConfig.DEFAULT_MAX_RPC_RETRY_ATTEMPTS)
+                .maxRpcAttempts(YugabyteDBConnectorConfig.DEFAULT_MAX_RPC_RETRY_ATTEMPTS)
+                .sleepTime(YugabyteDBConnectorConfig.DEFAULT_RPC_RETRY_SLEEP_TIME_MS)
                 .build();
 
         return new YBClient(asyncClient);

--- a/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
@@ -437,6 +437,7 @@ public final class TestHelper {
                 .defaultOperationTimeoutMs(YugabyteDBConnectorConfig.DEFAULT_OPERATION_TIMEOUT_MS)
                 .defaultSocketReadTimeoutMs(YugabyteDBConnectorConfig.DEFAULT_SOCKET_READ_TIMEOUT_MS)
                 .numTablets(YugabyteDBConnectorConfig.DEFAULT_MAX_NUM_TABLETS)
+                .maxAttempts(YugabyteDBConnectorConfig.DEFAULT_MAX_RPC_RETRY_ATTEMPTS)
                 .build();
 
         return new YBClient(asyncClient);


### PR DESCRIPTION
Currently, the AsynClient retries an RPC for 100 times within an interval of almost one minute. This results in `Too many attempts` exception much before the specified time out is reached. 

This PR contains changes to add configurable maximum number of rpc retry attempts, while creating `AsyncClient`. The default number of retries have been set to a sufficiently large number, such that all the attempts will not get over much before the specified timeout.