### PR TITLE
Close YBClient after the snapshot is completed

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -162,7 +162,14 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
         finally {
             LOGGER.info("Snapshot - Final stage");
             complete(ctx);
-
+            if (syncClient != null) {
+                try {
+                    LOGGER.info(" Closing the client after the snapshot completed.");
+                    syncClient.close();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
             if (completedSuccessfully) {
                 snapshotProgressListener.snapshotCompleted(partition);
             }


### PR DESCRIPTION
Not closing it leads to resource leak in case of task and connector restart as just the garbage collection is not releasing the netty resources