### PR TITLE
[yugabyte/yugabyte-db#19260] Add support for NOTHING and DEFAULT on connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.kafka>3.3.1</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>
-        <version.ybclient>0.8.67-20231010.165133-1</version.ybclient>
+        <version.ybclient>0.8.72-20231120.043131-1</version.ybclient>
         <version.gson>2.8.9</version.gson>
 
         <!--

--- a/src/main/java/io/debezium/connector/yugabytedb/HelperBeforeImageModes.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/HelperBeforeImageModes.java
@@ -4,53 +4,53 @@ import io.debezium.config.EnumeratedValue;
 public class HelperBeforeImageModes {
 
     public enum BeforeImageMode implements EnumeratedValue {
-      /**
-       * [Old type that is no longer allowed to be created] ALL mode, both old and new images of the
-       * item
-       */
-      ALL("ALL"),
+        /**
+         * [Old type that is no longer allowed to be created] ALL mode, both old and new images of the
+         * item
+         */
+        ALL("ALL"),
 
-      /**
-       * CHANGE mode (default), only the changed columns
-       */
-      CHANGE("CHANGE"),
+        /**
+         * CHANGE mode (default), only the changed columns
+         */
+        CHANGE("CHANGE"),
 
-      /**
-       * [Old type that is no longer allowed to be created] FULL_ROW_NEW_IMAGE mode, the entire
-       * updated row as new image, entire row as old image for DELETE
-       */
-      FULL_ROW_NEW_IMAGE("FULL_ROW_NEW_IMAGE"),
+        /**
+         * [Old type that is no longer allowed to be created] FULL_ROW_NEW_IMAGE mode, the entire
+         * updated row as new image, entire row as old image for DELETE
+         */
+        FULL_ROW_NEW_IMAGE("FULL_ROW_NEW_IMAGE"),
 
-      /**
-       * [Old type that is no longer allowed to be created] MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES
-       * mode, old and new images of modified column
-       */
-      MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES("MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES"),
+        /**
+         * [Old type that is no longer allowed to be created] MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES
+         * mode, old and new images of modified column
+         */
+        MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES("MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES"),
 
-      /**
-       * FULL mode, both old and new images of the item
-       */
-      FULL("FULL"),
+        /**
+         * FULL mode, both old and new images of the item
+         */
+        FULL("FULL"),
 
-      /**
-       * CHANGE_OLD_NEW mode, old and new images of modified column
-       */
-      CHANGE_OLD_NEW("CHANGE_OLD_NEW"),
+        /**
+         * CHANGE_OLD_NEW mode, old and new images of modified column
+         */
+        CHANGE_OLD_NEW("CHANGE_OLD_NEW"),
 
-      /**
-       * DEFAULT mode, entire updated row as new image, only key as old image for DELETE
-       */
-      DEFAULT("DEFAULT"),
+        /**
+         * DEFAULT mode, entire updated row as new image, only key as old image for DELETE
+         */
+        DEFAULT("DEFAULT"),
 
-      /**
-       * NOTHING mode, No old image for any operation
-       */
-      NOTHING("NOTHING");
+        /**
+         * NOTHING mode, No old image for any operation
+         */
+        NOTHING("NOTHING");
 
-      private final String value;
+        private final String value;
 
-      BeforeImageMode(String value) {
-        this.value = value;
+        BeforeImageMode(String value) {
+            this.value = value;
         }
 
         @Override

--- a/src/main/java/io/debezium/connector/yugabytedb/HelperBeforeImageModes.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/HelperBeforeImageModes.java
@@ -8,7 +8,7 @@ public class HelperBeforeImageModes {
         /**
          * ALL mode, both old and new images of the item
          */
-        ALL("ALL"),
+        FULL("FULL"),
 
         /**
          * CHANGE mode (default), only the changed columns
@@ -21,9 +21,19 @@ public class HelperBeforeImageModes {
         FULL_ROW_NEW_IMAGE("FULL_ROW_NEW_IMAGE"),
 
         /**
-         * MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES mode, old and new images of modified column
+         * CHANGE_OLD_NEW mode, old and new images of modified column
          */
-        MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES("MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES");
+        CHANGE_OLD_NEW("CHANGE_OLD_NEW"),
+
+        /**
+         * DEFAULT mode, entire updated row as new image, only key as old image for DELETE
+         */
+        DEFAULT("DEFAULT"),
+
+        /**
+         * NOTHING mode, No old image for any operation
+         */
+        NOTHING("NOTHING");
 
         private final String value;
 

--- a/src/main/java/io/debezium/connector/yugabytedb/HelperBeforeImageModes.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/HelperBeforeImageModes.java
@@ -28,24 +28,24 @@ public class HelperBeforeImageModes {
       MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES("MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES"),
 
       /**
-       * PG_FULL mode, both old and new images of the item
+       * FULL mode, both old and new images of the item
        */
-      PG_FULL("PG_FULL"),
+      FULL("FULL"),
 
       /**
-       * PG_CHANGE_OLD_NEW mode, old and new images of modified column
+       * CHANGE_OLD_NEW mode, old and new images of modified column
        */
-      PG_CHANGE_OLD_NEW("PG_CHANGE_OLD_NEW"),
+      CHANGE_OLD_NEW("CHANGE_OLD_NEW"),
 
       /**
-       * PG_DEFAULT mode, entire updated row as new image, only key as old image for DELETE
+       * DEFAULT mode, entire updated row as new image, only key as old image for DELETE
        */
-      PG_DEFAULT("PG_DEFAULT"),
+      DEFAULT("DEFAULT"),
 
       /**
-       * PG_NOTHING mode, No old image for any operation
+       * NOTHING mode, No old image for any operation
        */
-      PG_NOTHING("PG_NOTHING");
+      NOTHING("NOTHING");
 
       private final String value;
 

--- a/src/main/java/io/debezium/connector/yugabytedb/HelperBeforeImageModes.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/HelperBeforeImageModes.java
@@ -6,9 +6,9 @@ public class HelperBeforeImageModes {
     public enum BeforeImageMode implements EnumeratedValue {
 
         /**
-         * ALL mode, both old and new images of the item
+         * [Deprecated] ALL mode, both old and new images of the item
          */
-        FULL("FULL"),
+        ALL("ALL"),
 
         /**
          * CHANGE mode (default), only the changed columns
@@ -19,6 +19,16 @@ public class HelperBeforeImageModes {
          * FULL_ROW_NEW_IMAGE mode, the entire updated row as new image
          */
         FULL_ROW_NEW_IMAGE("FULL_ROW_NEW_IMAGE"),
+
+        /**
+         * [Deprecated] MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES mode, old and new images of modified column
+         */
+        MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES("MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES"),
+
+        /**
+         * FULL mode, both old and new images of the item
+         */
+        FULL("FULL"),
 
         /**
          * CHANGE_OLD_NEW mode, old and new images of modified column

--- a/src/main/java/io/debezium/connector/yugabytedb/HelperBeforeImageModes.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/HelperBeforeImageModes.java
@@ -4,51 +4,53 @@ import io.debezium.config.EnumeratedValue;
 public class HelperBeforeImageModes {
 
     public enum BeforeImageMode implements EnumeratedValue {
+      /**
+       * [Old type that is no longer allowed to be created] ALL mode, both old and new images of the
+       * item
+       */
+      ALL("ALL"),
 
-        /**
-         * [Deprecated] ALL mode, both old and new images of the item
-         */
-        ALL("ALL"),
+      /**
+       * CHANGE mode (default), only the changed columns
+       */
+      CHANGE("CHANGE"),
 
-        /**
-         * CHANGE mode (default), only the changed columns
-         */
-        CHANGE("CHANGE"),
+      /**
+       * [Old type that is no longer allowed to be created] FULL_ROW_NEW_IMAGE mode, the entire
+       * updated row as new image, entire row as old image for DELETE
+       */
+      FULL_ROW_NEW_IMAGE("FULL_ROW_NEW_IMAGE"),
 
-        /**
-         * FULL_ROW_NEW_IMAGE mode, the entire updated row as new image
-         */
-        FULL_ROW_NEW_IMAGE("FULL_ROW_NEW_IMAGE"),
+      /**
+       * [Old type that is no longer allowed to be created] MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES
+       * mode, old and new images of modified column
+       */
+      MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES("MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES"),
 
-        /**
-         * [Deprecated] MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES mode, old and new images of modified column
-         */
-        MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES("MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES"),
+      /**
+       * PG_FULL mode, both old and new images of the item
+       */
+      PG_FULL("PG_FULL"),
 
-        /**
-         * FULL mode, both old and new images of the item
-         */
-        FULL("FULL"),
+      /**
+       * PG_CHANGE_OLD_NEW mode, old and new images of modified column
+       */
+      PG_CHANGE_OLD_NEW("PG_CHANGE_OLD_NEW"),
 
-        /**
-         * CHANGE_OLD_NEW mode, old and new images of modified column
-         */
-        CHANGE_OLD_NEW("CHANGE_OLD_NEW"),
+      /**
+       * PG_DEFAULT mode, entire updated row as new image, only key as old image for DELETE
+       */
+      PG_DEFAULT("PG_DEFAULT"),
 
-        /**
-         * DEFAULT mode, entire updated row as new image, only key as old image for DELETE
-         */
-        DEFAULT("DEFAULT"),
+      /**
+       * PG_NOTHING mode, No old image for any operation
+       */
+      PG_NOTHING("PG_NOTHING");
 
-        /**
-         * NOTHING mode, No old image for any operation
-         */
-        NOTHING("NOTHING");
+      private final String value;
 
-        private final String value;
-
-        BeforeImageMode(String value) {
-            this.value = value;
+      BeforeImageMode(String value) {
+        this.value = value;
         }
 
         @Override

--- a/src/main/java/io/debezium/connector/yugabytedb/YBClientUtils.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YBClientUtils.java
@@ -309,8 +309,8 @@ public class YBClientUtils {
 
     return (cdcStreamInfo.getOptions().get("record_type").equals(CDCRecordType.ALL.name())
            || cdcStreamInfo.getOptions().get("record_type").equals(CDCRecordType.MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES.name()))
-           || (cdcStreamInfo.getOptions().get("record_type").equals(CDCRecordType.FULL.name())
-           || cdcStreamInfo.getOptions().get("record_type").equals(CDCRecordType.CHANGE_OLD_NEW.name()));
+           || (cdcStreamInfo.getOptions().get("record_type").equals(CDCRecordType.PG_FULL.name())
+           || cdcStreamInfo.getOptions().get("record_type").equals(CDCRecordType.PG_CHANGE_OLD_NEW.name()));
   }
 
   /**

--- a/src/main/java/io/debezium/connector/yugabytedb/YBClientUtils.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YBClientUtils.java
@@ -307,7 +307,9 @@ public class YBClientUtils {
       return false;
     }
 
-    return (cdcStreamInfo.getOptions().get("record_type").equals(CDCRecordType.FULL.name())
+    return (cdcStreamInfo.getOptions().get("record_type").equals(CDCRecordType.ALL.name())
+           || cdcStreamInfo.getOptions().get("record_type").equals(CDCRecordType.MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES.name()))
+           || (cdcStreamInfo.getOptions().get("record_type").equals(CDCRecordType.FULL.name())
            || cdcStreamInfo.getOptions().get("record_type").equals(CDCRecordType.CHANGE_OLD_NEW.name()));
   }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YBClientUtils.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YBClientUtils.java
@@ -307,8 +307,8 @@ public class YBClientUtils {
       return false;
     }
 
-    return (cdcStreamInfo.getOptions().get("record_type").equals(CDCRecordType.ALL.name())
-           || cdcStreamInfo.getOptions().get("record_type").equals(CDCRecordType.MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES.name()));
+    return (cdcStreamInfo.getOptions().get("record_type").equals(CDCRecordType.FULL.name())
+           || cdcStreamInfo.getOptions().get("record_type").equals(CDCRecordType.CHANGE_OLD_NEW.name()));
   }
 
   /**

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeRecordEmitter.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeRecordEmitter.java
@@ -377,7 +377,7 @@ public class YugabyteDBChangeRecordEmitter extends RelationalChangeRecordEmitter
         Struct oldKey = tableSchema.keyFromColumnData(oldColumnValues);
         Struct oldValue = tableSchema.valueFromColumnData(oldColumnValues);
 
-        if (skipEmptyMessages() && (oldColumnValues == null || oldColumnValues.length == 0)) {
+        if (skipEmptyMessages() && (oldColumnValues == null || oldColumnValues.length == 0) && shouldSendBeforeImage) {
             LOGGER.warn("no old values found for table '{}' from delete message at '{}'; skipping record", tableSchema, offsetContext.getSourceInfoForTablet(getPartition()));
             return;
         }

--- a/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
@@ -55,7 +55,6 @@ import io.debezium.connector.yugabytedb.connection.YugabyteDBConnection;
 import io.debezium.connector.yugabytedb.connection.YugabyteDBConnection.YugabyteDBValueConverterBuilder;
 import io.debezium.connector.yugabytedb.container.CustomContainerWaitStrategy;
 import io.debezium.connector.yugabytedb.container.YugabyteCustomContainer;
-import io.debezium.connector.yugabytedb.HelperBeforeImageModes.BeforeImageMode;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBBeforeImageTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBBeforeImageTest.java
@@ -82,6 +82,42 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
       TestHelper.initDB("yugabyte_create_tables.ddl");
 
       String dbStreamId = TestHelper.getNewDbStreamId(
+          "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.ALL);
+      Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
+      startEngine(configBuilder);
+
+      awaitUntilConnectorIsReady();
+
+      // Insert a record and update it.
+      TestHelper.execute(String.format(formatInsertString, 1));
+      TestHelper.execute("UPDATE t1 SET last_name='some_last_name' where id = 1;");
+      TestHelper.execute("UPDATE t1 SET first_name='V', last_name='K', hours=0.05 where id = 1;");
+
+      // Consume the records and verify that the records should have the relevant information.
+      List<SourceRecord> records = new ArrayList<>();
+      CompletableFuture.runAsync(() -> getRecords(records, 3, 20000)).get();
+
+      // The first record is an insert record with before image as null.
+      SourceRecord insertRecord = records.get(0);
+      assertValueField(insertRecord, "before", null);
+      assertAfterImage(insertRecord, 1, "Vaibhav", "Kushwaha", 12.345);
+
+      // The second record will be an update record having a before image.
+      SourceRecord updateRecord = records.get(1);
+      assertBeforeImage(updateRecord, 1, "Vaibhav", "Kushwaha", 12.345);
+      assertAfterImage(updateRecord, 1, "Vaibhav", "some_last_name", 12.345);
+
+      // The third record will be an update record too.
+      SourceRecord updateRecord2 = records.get(2);
+      assertBeforeImage(updateRecord2, 1, "Vaibhav", "some_last_name", 12.345);
+      assertAfterImage(updateRecord2, 1, "V", "K", 0.05);
+  }
+
+  @Test
+  public void consecutiveSingleShardTransactionsForFull() throws Exception {
+      TestHelper.initDB("yugabyte_create_tables.ddl");
+
+      String dbStreamId = TestHelper.getNewDbStreamId(
           "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.FULL);
       Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
       startEngine(configBuilder);
@@ -181,6 +217,44 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
       // The third record will be a delete record.
       SourceRecord deleteRecord = records.get(2);
       assertBeforeImage(deleteRecord, 1, "Vaibhav", "some_last_name", 12.345);
+      assertValueField(deleteRecord, "after", null);
+  }
+
+  @Test
+  public void consecutiveSingleShardTransactionsForModifiedColumnsOldAndNewImages() throws Exception {
+      TestHelper.initDB("yugabyte_create_tables.ddl");
+
+      String dbStreamId = TestHelper.getNewDbStreamId(
+          "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES);
+      Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
+      startEngine(configBuilder);
+
+      awaitUntilConnectorIsReady();
+
+      // Insert a record and update it.
+      TestHelper.execute(String.format(formatInsertString, 1));
+      TestHelper.execute("UPDATE t1 SET last_name='some_last_name' where id = 1;");
+      TestHelper.execute("DELETE from t1 WHERE id = 1;");
+
+      // Consume the records and verify that the records should have the relevant information.
+      List<SourceRecord> records = new ArrayList<>();
+      CompletableFuture.runAsync(() -> getRecords(records, 4, 20000)).get();
+
+      // The first record is an insert record with before image as null.
+      SourceRecord insertRecord = records.get(0);
+      assertValueField(insertRecord, "before", null);
+      assertAfterImage(insertRecord, 1, "Vaibhav", "Kushwaha", 12.345);
+
+      // The second record will be an update record having no before image.
+      SourceRecord updateRecord = records.get(1);
+      assertValueField(updateRecord, "before/id/value", 1);
+      assertValueField(updateRecord, "before/last_name/value", "Kushwaha");
+      assertValueField(updateRecord, "after/id/value", 1);
+      assertValueField(updateRecord, "after/last_name/value", "some_last_name");
+
+      // The third record will be a delete record.
+      SourceRecord deleteRecord = records.get(2);
+      assertValueField(deleteRecord, "before/id/value", 1);
       assertValueField(deleteRecord, "after", null);
   }
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBBeforeImageTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBBeforeImageTest.java
@@ -53,7 +53,7 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
       TestHelper.initDB("yugabyte_create_tables.ddl");
 
       String dbStreamId = TestHelper.getNewDbStreamId(
-          "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.PG_FULL);
+          "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.FULL);
       Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
       startEngine(configBuilder);
 
@@ -83,7 +83,7 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
       TestHelper.initDB("yugabyte_create_tables.ddl");
 
       String dbStreamId = TestHelper.getNewDbStreamId(
-          "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.PG_FULL);
+          "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.FULL);
       Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
       startEngine(configBuilder);
 
@@ -155,7 +155,7 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
       TestHelper.initDB("yugabyte_create_tables.ddl");
 
       String dbStreamId = TestHelper.getNewDbStreamId(
-          "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.PG_CHANGE_OLD_NEW);
+          "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.CHANGE_OLD_NEW);
       Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
       startEngine(configBuilder);
 
@@ -193,7 +193,7 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
       TestHelper.initDB("yugabyte_create_tables.ddl");
 
       String dbStreamId = TestHelper.getNewDbStreamId(
-          "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.PG_DEFAULT);
+          "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.DEFAULT);
       Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
       startEngine(configBuilder);
 
@@ -229,7 +229,7 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
       TestHelper.initDB("yugabyte_create_tables.ddl");
 
       String dbStreamId = TestHelper.getNewDbStreamId(
-          "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.PG_NOTHING);
+          "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.NOTHING);
       Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
       startEngine(configBuilder);
 
@@ -265,7 +265,7 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
     TestHelper.initDB("yugabyte_create_tables.ddl");
 
     String dbStreamId = TestHelper.getNewDbStreamId(
-        "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.PG_FULL);
+        "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.FULL);
     Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
     startEngine(configBuilder);
 
@@ -324,7 +324,7 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
     TestHelper.initDB("yugabyte_create_tables.ddl");
 
     String dbStreamId = TestHelper.getNewDbStreamId(
-        "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.PG_FULL);
+        "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.FULL);
     Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
     startEngine(configBuilder);
 
@@ -357,7 +357,7 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
     TestHelper.initDB("yugabyte_create_tables.ddl");
 
     String dbStreamId = TestHelper.getNewDbStreamId(
-        "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.PG_FULL);
+        "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.FULL);
     Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
     startEngine(configBuilder);
 
@@ -405,7 +405,7 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
                        + " hours DOUBLE PRECISION DEFAULT 12.345);");
 
     String dbStreamId = TestHelper.getNewDbStreamId(
-        "yugabyte", "table_with_defaults", true /* withBeforeImage */, true, BeforeImageMode.PG_FULL);
+        "yugabyte", "table_with_defaults", true /* withBeforeImage */, true, BeforeImageMode.FULL);
     Configuration.Builder configBuilder =
         TestHelper.getConfigBuilder("public.table_with_defaults", dbStreamId);
     startEngine(configBuilder);


### PR DESCRIPTION
Adding support for two new record types: `DEFAULT` and `NOTHING` based on Postgres replica identity types. Their behaviour for the basic queries listed below is as follows:

**Queries**:
```
CREATE TABLE t1(id INT PRIMARY KEY, v1 INT, v2 INT);
INSERT INTO t1 VALUES (1,2,3);
# Perform an update
UPDATE t1 SET v1 = 3 WHERE id = 1;
# Perform a delete
DELETE from t1 WHERE id = 1;
```

| `RECORD_TYPE` | OPERATION | OLD_IMAGE | NEW_IMAGE  |
| ----------------- | ------------ | ------------ | -------------  | 
| `DEFAULT`           | UPDATE        | `{{}}`            | `{{1},{3},{3}}` |
|                               | DELETE        | `{{1}}`           | `{{}}`              |
| `NOTHING`          | UPDATE        | `{{}}`            | `{{1},{3},{3}}` |
|                               | DELETE        | `{{}}`            | `{{}}`               |

Also, the `ALL` and `MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES` modes have been renamed to `FULL` and `CHANGE_OLD_NEW` respectively.

Have kept the old `ALL` and `MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES` to maintain backward compatibility.

### Test Plan
Added tests for `NOTHING` and `DEFAULT` modes
- `mvn clean test -Dtest=YugabyteDBBeforeImageTest#consecutiveSingleShardTransactionsForDefault`
- `mvn clean test -Dtest=YugabyteDBBeforeImageTest#consecutiveSingleShardTransactionsForNothing`
