### PR TITLE
[yugabyte/yugabyte-db#19294] Resolved the issue of large input strings getting truncated

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBCQLValueConverter.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBCQLValueConverter.java
@@ -601,13 +601,10 @@ public class YugabyteDBCQLValueConverter implements ValueConverterProvider {
      * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertString(Column column, Field fieldDefn, Object data) {
-        String dataString = data.toString();
-        Pattern pattern = Pattern.compile("contents=\"(.*?)\"");
-        Matcher matcher = pattern.matcher(dataString);
         Object data_;
-        if(matcher.find()) {
-            String contentString = matcher.group(1);
-            data_ = contentString;
+        if (data instanceof ByteString) {
+            String dataString = ((ByteString) data).toStringUtf8();
+            data_ = dataString;
         } else {
             data_ = data;
         }

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCQLTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCQLTest.java
@@ -292,8 +292,8 @@ public class YugabyteDBCQLTest extends YugabyteDBContainerTestBase {
     private String getBigInputString(int length) {
         StringBuilder sb = new StringBuilder();
         Random r = new Random();
-        for(int i = 0; i<length; i++) {
-            sb.append((char)(r.nextInt(26)+ 'A'));
+        for (int i = 0; i < length; i++) {
+            sb.append((char) (r.nextInt(26) + 'A'));
         }
         return sb.toString();
     }

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCQLTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCQLTest.java
@@ -20,6 +20,7 @@ import java.sql.SQLException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -203,6 +204,28 @@ public class YugabyteDBCQLTest extends YugabyteDBContainerTestBase {
         verifyRecordCount(recordsCount);
     }
 
+    @Test
+    public void testLargeStrings() throws Exception {
+        String createKeyspace = "CREATE KEYSPACE IF NOT EXISTS cdctest;";
+        session.execute(createKeyspace);
+
+        session.execute("create table if not exists cdctest.test_big_string(a varchar primary key);");
+
+        String dbStreamId = TestHelper.getNewDbStreamId("cdctest", "test_big_string", false, false,BeforeImageMode.CHANGE, true);
+
+        Configuration.Builder configBuilder = TestHelper.getConfigBuilderForCQL("cdctest","test_big_string", dbStreamId);
+        startEngine(configBuilder);
+
+        final long recordsCount = 1;
+
+        String bigInput = getBigInputString(5000);
+        awaitUntilConnectorIsReady();
+
+        session.execute("insert into cdctest.test_big_string(a) values ('" + bigInput + "');");
+        
+        verifyPrimaryKey(recordsCount, bigInput);
+    }
+
     private void verifyRecordCount(long recordsCount) {
         waitAndFailIfCannotConsume(new ArrayList<>(), recordsCount);
     }
@@ -265,5 +288,24 @@ public class YugabyteDBCQLTest extends YugabyteDBContainerTestBase {
 
         assertEquals(totalRecordsToConsume, totalConsumedRecords.get());
     }
+
+    private String getBigInputString(int length) {
+        StringBuilder sb = new StringBuilder();
+        Random r = new Random();
+        for(int i = 0; i<length; i++) {
+            sb.append((char)(r.nextInt(26)+ 'A'));
+        }
+        return sb.toString();
+    }
+
+    private void verifyPrimaryKey(long recordsCount, String input) {
+        List<SourceRecord> records = new ArrayList<>();
+        waitAndFailIfCannotConsume(records, recordsCount);
+
+        for (int i = 0; i < records.size(); ++i) {
+            assertValueField(records.get(i), "after/a/value", input);
+        }
+    }
+
 
 }


### PR DESCRIPTION
## Problem
There was a bug in the `convertString()` method of `YugabyteDBCQLValueConverter` because of which large input strings were getting truncated to the first 50 characters. This was due to the wrong `toString()` method being used for conversion of ByteString to String.

## Solution
This issue was resolved by using `toStringUtf8()` instead of `toString()` method to extract the string from the ByteString. This PR also adds a test to verify the correct behaviour.