### PR TITLE
[yugabyte/ygabyte-db#20052] Remove duplicate entries for colocated tables in the snapshot flow

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -410,7 +410,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
       }
 
       Map<TableId, String> filteredTableIdToUuid = determineTablesForSnapshot(tableIdToTable);
-      List<Pair<String, String>> tableToTabletForSnapshot = new ArrayList<>();
+      Set<Pair<String, String>> tableToTabletForSnapshot = new HashSet<>();
 
       Map<String, Boolean> schemaNeeded = new HashMap<>();
       Set<String> snapshotCompletedTablets = new HashSet<>();


### PR DESCRIPTION
### Problem
Current Behaviour:
Consider the case of colocated tables snapshot is to be taken on all tables. 

After snapshot bootstrap, if the connector restarts, `GetTabletListToPoll()` returns same `tablet_id` multiple times for a given colocated tableId. Due to this, after task division, same table-tablet pairs are added to a task config list multiple times . We filter out entries for snapshot using this task config list and store them in an ArrayList (`tableToTabletForSnapshot`). 

Finally, snapshot flow returns back successful status only when `snapshotCompletedTablets.size() == tableToTabletForSnapshot.size()`. This check never satisfies because `snapshotCompletedTablets` is a set, so it doesnt contain duplicate tablet entries and hence the connector is stuck in the snapshot flow.

Consider the below example:
1. Create 2 non-empty colocated tables - t1 & t2
2. Create a CDC stream in explicit mode
3. Deploy connector
4. Since snapshot.include.list was not passed, all tables will be considered for snapshot. Snapshot bootstrap on both tables. At this point, cdc_state table has 3 entries - <tablet1,stream1> , <tablet1, stream1.t1> , <tablet1, stream1.t2>.
5. Restart connector
6. GetTabletListToPoll (stream1, t1) returns 3 entries with same tablet i.e tablet1. Same happens for t2.
7. After task division, tableToTabletForSnapshot has the following entries: { {t1,tablet1}, {t1,tablet1}, {t1,tablet1}, {t2,tablet1},  {t2,tablet1}, {t2,tablet1} }
8. During snapshot consumpotion, since, tablets are not removed from shouldWaitForCallback set, they get added to tabletsWaitingForCallback set.
9. Connector gets stuck in snapshot flow, waiting for kafka's acknowledgement.

### Solution
Replace the ArrayList with a Set to only store unique table-tablet pairs after filtering. This will not change anything for non-colocated tables but will fix the addition of same entry multiple times for colocated tables.

**Note: This solution itself isnt sufficient to switch to streaming phase. This, along with fixes for [#20134](https://github.com/yugabyte/yugabyte-db/issues/20134) & [#20135](https://github.com/yugabyte/yugabyte-db/issues/20135) will ensure the connector switches to streaming phase.**

### Testing
Performed Manual testing:
- Ran `shouldSnapshotWithFailureAfterBootstrapSnapshotCall` test and manually verified the entries of `tableToTabletForSnapshot` before & after the fix.
- Manually ran a CDC pipeline with 2 non-empty colocated tables and verified the behaviour

### Linked Issue
[[CDCSDK] After snapshot bootstrap, GetTabletListToPoll returns same tablet_id multiple times for colocated tables on connector restart](https://yugabyte.atlassian.net/browse/DB-9017)