### PR TITLE
Shift tablet removal from shouldWaitForCallback set logic to snapshot consumption phase

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
@@ -135,16 +135,13 @@ public final class SourceInfo extends BaseSourceInfo {
      * Compares the lastRecordCheckpoint with {@code snapshotStartLsn} and {@code streamingStartLsn}.
      * If it is equal then it means that we haven't received any record for the given partition,
      * in case there's any difference, it technically siginifies that some record has updated the
-     * values. Also checks if commitTime is null. This covers cases when connector restarts
-     * after snapshot bootstrap is completed. In such cases, lastRecordCheckpoint for empty tablets
-     * would have been initialized with a non-null value.
+     * values.
      * @return true if the partition hasn't seen any record yet, false otherwise
      */
     public boolean noRecordSeen() {
         return (lastRecordCheckpoint == null)
             || lastRecordCheckpoint.equals(YugabyteDBOffsetContext.snapshotStartLsn())
-            || lastRecordCheckpoint.equals(YugabyteDBOffsetContext.streamingStartLsn())
-            || (commitTime == null);
+            || lastRecordCheckpoint.equals(YugabyteDBOffsetContext.streamingStartLsn());
     }
 
     public String sequence() {

--- a/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
@@ -135,13 +135,16 @@ public final class SourceInfo extends BaseSourceInfo {
      * Compares the lastRecordCheckpoint with {@code snapshotStartLsn} and {@code streamingStartLsn}.
      * If it is equal then it means that we haven't received any record for the given partition,
      * in case there's any difference, it technically siginifies that some record has updated the
-     * values.
+     * values. Also checks if commitTime is null. This covers cases when connector restarts
+     * after snapshot bootstrap is completed. In such cases, lastRecordCheckpoint for empty tablets
+     * would have been initialized with a non-null value.
      * @return true if the partition hasn't seen any record yet, false otherwise
      */
     public boolean noRecordSeen() {
         return (lastRecordCheckpoint == null)
             || lastRecordCheckpoint.equals(YugabyteDBOffsetContext.snapshotStartLsn())
-            || lastRecordCheckpoint.equals(YugabyteDBOffsetContext.streamingStartLsn());
+            || lastRecordCheckpoint.equals(YugabyteDBOffsetContext.streamingStartLsn())
+            || (commitTime == null);
     }
 
     public String sequence() {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -458,6 +458,8 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
 
       // Helper internal variable to log GetChanges request at regular intervals.
       long lastLoggedTimeForGetChanges = System.currentTimeMillis();
+      // Stores the READ records recevied in a single GetChanges call
+      long readRecordsReceived = 0;
 
       while (context.isRunning() && retryCount <= this.connectorConfig.maxConnectorRetries()) {
         try {
@@ -491,6 +493,8 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                   continue;
                 }
 
+                // Reset for the upcoming getChanges call
+                readRecordsReceived = 0;
                 CdcSdkCheckpoint explicitCdcSdkCheckpoint = null;
                 if (taskContext.shouldEnableExplicitCheckpointing()) {
                   explicitCdcSdkCheckpoint = tabletToExplicitCheckpoint.get(part.getId());
@@ -588,6 +592,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                         Objects.requireNonNull(tId);
                       }
 
+                      readRecordsReceived += 1;
                       // In case of snapshots, we do not want to ignore tableUUID while updating
                       // OpId value for a table-tablet pair.
                       previousOffset.updateRecordPosition(part, lsn, lastCompletelyProcessedLsn,
@@ -615,11 +620,10 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                                           resp.getWriteId(), resp.getSnapshotTime());
                 LOGGER.debug("Final OpId for tablet {} is {}", part.getId(), finalOpId);
 
-                // During the snapshot consumption phase (identified by cp i.e. from_op_id > 0),
-                // if the response doesn't have any record, it is safe to assume that we should
-                // not wait for the callback to come and that we can proceed further in processing
-                // this particular tablet.
-                if (cp.getIndex() > 0 && cp.getTerm() > 0 && previousOffset.getSourceInfo(part).noRecordSeen()) {
+                // During the snapshot consumption phase, if the response doesn't have any record,
+                // it is safe to assume that we should not wait for the callback to come and that we
+                // can proceed further in processing this particular tablet.
+                if (IsTabletInSnapshotConsumptionState(part, previousOffset) && readRecordsReceived == 0) {
                   LOGGER.info("Should not wait for callback on tablet {}", part.getId());
                   shouldWaitForCallback.remove(part.getId());
                 }
@@ -666,7 +670,8 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                   } else if (isSnapshotCompleteMarker(finalOpId)) {
                     // Add it to tablets waiting for callback only during snapshot consumption phase so that the
                     // connector doesn't end up calling GetChanges for the same again.
-                    if (cp.getIndex() > 0 && cp.getTerm() > 0 && shouldWaitForCallback.contains(part.getId())) {
+                    if (IsTabletInSnapshotConsumptionState(part, previousOffset) &&
+                            shouldWaitForCallback.contains(part.getId())) {
                       if (!tabletsWaitingForCallback.contains(part.getId())) {
                         LOGGER.info("Adding tablet {} of table {} ({}) to wait-list",
                                     part.getId(), table.getName(), part.getTableId());
@@ -851,6 +856,21 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
     private boolean isSnapshotCompleteMarker(OpId opId) {
         return Arrays.equals(opId.getKey(), "".getBytes()) && opId.getWrite_id() == 0
                 && opId.getTime() == 0;
+    }
+
+    /**
+     * Snapshot bootstrap call can be distinguished from Snapshot consumption call based
+     * on the from_op_id sent in the GetChanges request. During snapshot bootstrap, from_op_id
+     * is equal to {@code snapshotStartLsn} i.e term & index are invalid i.e. -1.-1. But during snapshot
+     * consumption, from_op_id's term & index are greater than 0.
+     * Check if the tablet is in the snapshot consumption state.
+     * @param partition the YBPartition to obtain the current tablet's ID in the form of TableId.TabletId
+     * @param previousOffset map storing the offset (from_op_id) for a partition
+     * @return true if the tablet's from_op_id is valid, false otherwise
+     */
+    private boolean IsTabletInSnapshotConsumptionState(YBPartition partition, YugabyteDBOffsetContext previousOffset) {
+        OpId fromOpId = previousOffset.snapshotLSN(partition);
+        return (fromOpId.getTerm() > 0) && (fromOpId.getIndex() > 0);
     }
 
     protected Stream<TableId> getDataCollectionsToBeSnapshotted(Set<TableId> allDataCollections) {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -622,7 +622,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                 // During the snapshot consumption phase, if the response doesn't have any record,
                 // it is safe to assume that we should not wait for the callback to come and that we
                 // can proceed further in processing this particular tablet.
-                if (!IsTabletInSnapshotBootstrapState(part, previousOffset) && readRecordsReceived == 0) {
+                if (!isTabletInPreSnapshotBootstrapState(part, previousOffset) && readRecordsReceived == 0) {
                   LOGGER.info("Should not wait for callback on tablet {}", part.getId());
                   shouldWaitForCallback.remove(part.getId());
                 }
@@ -669,7 +669,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                   } else if (isSnapshotCompleteMarker(finalOpId)) {
                     // Add it to tablets waiting for callback only during snapshot consumption phase so that the
                     // connector doesn't end up calling GetChanges for the same again.
-                    if (!IsTabletInSnapshotBootstrapState(part, previousOffset) &&
+                    if (!isTabletInPreSnapshotBootstrapState(part, previousOffset) &&
                             shouldWaitForCallback.contains(part.getId())) {
                       if (!tabletsWaitingForCallback.contains(part.getId())) {
                         LOGGER.info("Adding tablet {} of table {} ({}) to wait-list",
@@ -867,7 +867,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
      * @param previousOffset map storing the offset (from_op_id) for a partition
      * @return true if the tablet's from_op_id is valid, false otherwise
      */
-    private boolean IsTabletInSnapshotBootstrapState(YBPartition partition, YugabyteDBOffsetContext previousOffset) {
+    private boolean isTabletInPreSnapshotBootstrapState(YBPartition partition, YugabyteDBOffsetContext previousOffset) {
         OpId fromOpId = previousOffset.snapshotLSN(partition);
         return fromOpId.equals(YugabyteDBOffsetContext.snapshotStartLsn());
     }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -342,15 +342,15 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
      * Decide if we need to take snapshot or do nothing if snapshot has completed previously
      */
     protected boolean isSnapshotRequired(GetCheckpointResponse getCheckpointResponse,
-                                         String tableId, String tabletId,
+                                         YBPartition partition,
                                          Set<String> snapshotCompletedTablets,
                                          Set<String> snapshotCompletedPreviously) 
                                            throws Exception {
       if (hasSnapshotCompletedPreviously(getCheckpointResponse)) {
         LOGGER.info("Skipping snapshot for table {} tablet {} since tablet has streamed some data before",
-                  tableId, tabletId);
-        snapshotCompletedTablets.add(tabletId);
-        snapshotCompletedPreviously.add(tabletId);
+                  partition.getTableId(), partition.getTabletId());
+        snapshotCompletedTablets.add(partition.getId());
+        snapshotCompletedPreviously.add(partition.getId());
 
         return false;
       } else {
@@ -360,7 +360,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
           // A call to set the checkpoint is required first otherwise we will get an error 
           // from the server side saying:
           // INTERNAL_ERROR[code 21]: Stream ID {} is expired for Tablet ID {}
-          makeStreamActive(tableId, tabletId, false);
+          makeStreamActive(partition.getTableId(), partition.getTabletId(), false);
         }
 
         return true;
@@ -410,7 +410,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
       }
 
       Map<TableId, String> filteredTableIdToUuid = determineTablesForSnapshot(tableIdToTable);
-      List<Pair<String, String>> tableToTabletForSnapshot = new ArrayList<>();
+      Set<Pair<String, String>> tableToTabletForSnapshot = new HashSet<>();
 
       Map<String, Boolean> schemaNeeded = new HashMap<>();
       Set<String> snapshotCompletedTablets = new HashSet<>();
@@ -431,7 +431,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
           // We need to take the snapshot for this table.
           tableToTabletForSnapshot.add(entry);
 
-          if (isSnapshotRequired(resp, tableId, tabletId, snapshotCompletedTablets, snapshotCompletedPreviously)) {
+          if (isSnapshotRequired(resp, p, snapshotCompletedTablets, snapshotCompletedPreviously)) {
             startLsn = getSnapshotStartLsn(resp);
           }
         } else {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -342,15 +342,15 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
      * Decide if we need to take snapshot or do nothing if snapshot has completed previously
      */
     protected boolean isSnapshotRequired(GetCheckpointResponse getCheckpointResponse,
-                                         YBPartition partition,
+                                         String tableId, String tabletId,
                                          Set<String> snapshotCompletedTablets,
                                          Set<String> snapshotCompletedPreviously) 
                                            throws Exception {
       if (hasSnapshotCompletedPreviously(getCheckpointResponse)) {
         LOGGER.info("Skipping snapshot for table {} tablet {} since tablet has streamed some data before",
-                  partition.getTableId(), partition.getTabletId());
-        snapshotCompletedTablets.add(partition.getId());
-        snapshotCompletedPreviously.add(partition.getId());
+                  tableId, tabletId);
+        snapshotCompletedTablets.add(tabletId);
+        snapshotCompletedPreviously.add(tabletId);
 
         return false;
       } else {
@@ -360,7 +360,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
           // A call to set the checkpoint is required first otherwise we will get an error 
           // from the server side saying:
           // INTERNAL_ERROR[code 21]: Stream ID {} is expired for Tablet ID {}
-          makeStreamActive(partition.getTableId(), partition.getTabletId(), false);
+          makeStreamActive(tableId, tabletId, false);
         }
 
         return true;
@@ -410,7 +410,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
       }
 
       Map<TableId, String> filteredTableIdToUuid = determineTablesForSnapshot(tableIdToTable);
-      Set<Pair<String, String>> tableToTabletForSnapshot = new HashSet<>();
+      List<Pair<String, String>> tableToTabletForSnapshot = new ArrayList<>();
 
       Map<String, Boolean> schemaNeeded = new HashMap<>();
       Set<String> snapshotCompletedTablets = new HashSet<>();
@@ -431,7 +431,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
           // We need to take the snapshot for this table.
           tableToTabletForSnapshot.add(entry);
 
-          if (isSnapshotRequired(resp, p, snapshotCompletedTablets, snapshotCompletedPreviously)) {
+          if (isSnapshotRequired(resp, tableId, tabletId, snapshotCompletedTablets, snapshotCompletedPreviously)) {
             startLsn = getSnapshotStartLsn(resp);
           }
         } else {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -458,8 +458,6 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
 
       // Helper internal variable to log GetChanges request at regular intervals.
       long lastLoggedTimeForGetChanges = System.currentTimeMillis();
-      // Stores the READ records recevied in a single GetChanges call
-      long readRecordsReceived = 0;
 
       while (context.isRunning() && retryCount <= this.connectorConfig.maxConnectorRetries()) {
         try {
@@ -493,8 +491,9 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                   continue;
                 }
 
-                // Reset for the upcoming getChanges call
-                readRecordsReceived = 0;
+                // Stores the READ records received in a single GetChanges call
+                long readRecordsReceived = 0;
+
                 CdcSdkCheckpoint explicitCdcSdkCheckpoint = null;
                 if (taskContext.shouldEnableExplicitCheckpointing()) {
                   explicitCdcSdkCheckpoint = tabletToExplicitCheckpoint.get(part.getId());
@@ -590,9 +589,9 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                           tId = YugabyteDBSchema.parseWithKeyspace(message.getTable(), connectorConfig.databaseName());
                         }
                         Objects.requireNonNull(tId);
+                        readRecordsReceived += 1;
                       }
 
-                      readRecordsReceived += 1;
                       // In case of snapshots, we do not want to ignore tableUUID while updating
                       // OpId value for a table-tablet pair.
                       previousOffset.updateRecordPosition(part, lsn, lastCompletelyProcessedLsn,
@@ -623,7 +622,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                 // During the snapshot consumption phase, if the response doesn't have any record,
                 // it is safe to assume that we should not wait for the callback to come and that we
                 // can proceed further in processing this particular tablet.
-                if (IsTabletInSnapshotConsumptionState(part, previousOffset) && readRecordsReceived == 0) {
+                if (!IsTabletInSnapshotBootstrapState(part, previousOffset) && readRecordsReceived == 0) {
                   LOGGER.info("Should not wait for callback on tablet {}", part.getId());
                   shouldWaitForCallback.remove(part.getId());
                 }
@@ -670,7 +669,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                   } else if (isSnapshotCompleteMarker(finalOpId)) {
                     // Add it to tablets waiting for callback only during snapshot consumption phase so that the
                     // connector doesn't end up calling GetChanges for the same again.
-                    if (IsTabletInSnapshotConsumptionState(part, previousOffset) &&
+                    if (!IsTabletInSnapshotBootstrapState(part, previousOffset) &&
                             shouldWaitForCallback.contains(part.getId())) {
                       if (!tabletsWaitingForCallback.contains(part.getId())) {
                         LOGGER.info("Adding tablet {} of table {} ({}) to wait-list",
@@ -861,16 +860,16 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
     /**
      * Snapshot bootstrap call can be distinguished from Snapshot consumption call based
      * on the from_op_id sent in the GetChanges request. During snapshot bootstrap, from_op_id
-     * is equal to {@code snapshotStartLsn} i.e term & index are invalid i.e. -1.-1. But during snapshot
-     * consumption, from_op_id's term & index are greater than 0.
+     * is equal to {@code snapshotStartLsn} i.e term = -1, index = -1, snapshot_key = "", write_id = -1,
+     * snapshot_time = 0. But during snapshot consumption, term  > 0, index > 0, write_id = -1, snapshot_time > 0.
      * Check if the tablet is in the snapshot consumption state.
      * @param partition the YBPartition to obtain the current tablet's ID in the form of TableId.TabletId
      * @param previousOffset map storing the offset (from_op_id) for a partition
      * @return true if the tablet's from_op_id is valid, false otherwise
      */
-    private boolean IsTabletInSnapshotConsumptionState(YBPartition partition, YugabyteDBOffsetContext previousOffset) {
+    private boolean IsTabletInSnapshotBootstrapState(YBPartition partition, YugabyteDBOffsetContext previousOffset) {
         OpId fromOpId = previousOffset.snapshotLSN(partition);
-        return (fromOpId.getTerm() > 0) && (fromOpId.getIndex() > 0);
+        return fromOpId.equals(YugabyteDBOffsetContext.snapshotStartLsn());
     }
 
     protected Stream<TableId> getDataCollectionsToBeSnapshotted(Set<TableId> allDataCollections) {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -433,6 +433,8 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
 
           if (isSnapshotRequired(resp, tableId, tabletId, snapshotCompletedTablets, snapshotCompletedPreviously)) {
             startLsn = getSnapshotStartLsn(resp);
+            // Add only those tablets for which we are planning to take a snapshot.
+            shouldWaitForCallback.add(p.getId());
           }
         } else {
           // At this stage we know that the particular table is not a part of the
@@ -445,7 +447,6 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
 
         previousOffset.initSourceInfo(p, this.connectorConfig, startLsn);
         schemaNeeded.put(p.getId(), Boolean.TRUE);
-        shouldWaitForCallback.add(p.getId());
         LOGGER.debug("Previous offset for table {} tablet {} is {}", p.getTableId(),
                      p.getTabletId(), previousOffset.toString());
       }
@@ -680,6 +681,10 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                       LOGGER.info("Adding {} to the list of snapshot completed tablets", part.getId());
                       snapshotCompletedTablets.add(part.getId());
                       markSnapshotDoneOnServer(part, previousOffset);
+                      // Ideally, a tablet shouldnt be present in tabletsWaitingForCallback set if the flow reaches
+                      // this point. This is just a safety mechanism to ensure that snapshotCompletedTablets &
+                      // tabletsWaitingForCallback are always mutually exclusive.
+                      tabletsWaitingForCallback.removeIf(t -> t.equals(part.getId()));
                     }
                   }
                 } else if (!taskContext.shouldEnableExplicitCheckpointing() && isSnapshotCompleteMarker(finalOpId)) {

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -40,6 +40,8 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
     public void before() throws Exception {
         initializeConnectorTestFramework();
         TestHelper.dropAllSchemas();
+        YugabyteDBSnapshotChangeEventSource.FAIL_AFTER_SETTING_INITIAL_CHECKPOINT = false;
+        YugabyteDBSnapshotChangeEventSource.FAIL_AFTER_BOOTSTRAP_GET_CHANGES = false;
     }
 
     @AfterEach
@@ -49,6 +51,8 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         TestHelper.executeDDL("drop_tables_and_databases.ddl");
         TestHelper.dropAllSchemas();
         resetCommitCallbackDelay();
+        YugabyteDBSnapshotChangeEventSource.FAIL_AFTER_SETTING_INITIAL_CHECKPOINT = false;
+        YugabyteDBSnapshotChangeEventSource.FAIL_AFTER_BOOTSTRAP_GET_CHANGES = false;
     }
 
     @AfterAll


### PR DESCRIPTION
### Problem
Purpose of `shouldWaitForCallback` set:
If a tablet is part of this set, it means the connector should poll it for snapshot records and wait for kafka's callback. Therefore, empty tablets should not be a part of this set. 

Tablet removal Logic:
Currently, the logic to remove tablets from `shouldWaitForCallback` set is done after every getChanges call including the 1st Getchanges i.e. snapshot bootstrap call. We conclude there was no record seen in the GetChanges call based on the value of `lastRecordCheckpoint`. This variable is initialised based on the GetCheckpoint's response before we make any GetChanges call. 

GetCheckpoint returns opid > 0 --> set lastRecordCheckpoint to this valid Opid.
GetCheckpoint returns opid <= 0 --> set lastRecordCheckpoint to snapshotStartLsn i.e. opid = -1.-1 

- NoRecordSeen() checks if `lastRecordCheckpoint` is still equal to snapshotStartLsn. If NoRecordSeen() returns true, we remove the tablet from `shouldWaitForCallback` set.

- We update `lastRecordCheckpoint` only if we receive any READ records.

There are 2 issues with the current implementation of tablet remove logic:
1. Non-empty tablets getting removed
In the response of snapshot bootstrap call, we only receive a checkpoint and no records. At this point, since we didnt receive any records, the `lastRecordCheckpoint` is still set to `snapshotStartLsn` for all tablets (empty or non-empty). So, based on the current logic, we will remove all the tablets including non-empty tablets as well. This behavior is incorrect since we should only remove empty tablets. 

2. Empty tablets not getting removed
Consider this scenario: Connector has just finished snapshot bootstrap call on an empty tablet but havent yet sent the snapshot done key to the service. At this point, if the connector restarts, the `lastRecordCheckpoint` will be initialised with a value different than `snapshotStartLsn` since GetCheckpoint call on the empty tablet would returns opid > 0. So, in such cases, the noRecordSeen() would return false for empty tablets. Hence, we would not remove it from this set. 

### Solution

- Firstly, shift the tablet removal logic from the snapshot bootstrap call to the snapshot consumption phase i.e. 2nd GetChanges onwards since we receive records (if any) only during the snapshot consumption phase. Snapshot bootstrap call can be distinguished from Snapshot consumption call based on the from_op_id sent in the GetChanges request. During snapshot bootstrap, from_op_id is equal to `snapshotStartLsn` i.e term = -1, index = -1, snapshot_key = "", write_id = -1, snapshot_time = 0. But during snapshot consumption, term  > 0, index > 0, write_id = -1, snapshot_time > 0. Even empty tablets, after snapshot bootstrap is completed, have from_op_id > 0 because they do contain a DDL record.

- Secondly, we can distinguish between empty & non-empty tablets by simply keeping a count of READ records received during snapshot consumption phase. 


### Testing
Performed manual testing:

- Ran a test on single empty table split into 1 tablet. Restarted the connector after snapshot bootstrap and manually verified that tablet removal logic was executed during snapshot consumption phase and the empty tablet was removed.

- Ran a test on a single non-empty table split into 1 tablet. Manually verified that tablet removal logic was executed during snapshot consumption phase and no tablet was removed.

Note: Since this solution has changed the behaviour for tablet removal, some existing snapshot tests are failing because connector is not switching to streaming phase. This is primarily because tablets that are part of `shouldWaitForCallback` set are added to `tabletsWaitingForCallback` set. Tablet removal from `tabletsWaitingForCallback` set is also incorrect. This is a known [issue](https://github.com/yugabyte/yugabyte-db/issues/20135). 


### Linked Issues

- [[CDCSDK] Improve logic for adding tablets to snapshotCompletedTablets set](https://yugabyte.atlassian.net/browse/DB-9073)
- [[CDCSDK] After snapshot bootstrap, GetTabletListToPoll returns same tablet_id multiple times for colocated tables on connector restart](https://yugabyte.atlassian.net/browse/DB-9017)
