### PR TITLE
[yugabyte/yugabyte-db#20177] Support to run the connector tests with consistent snapshot streams

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.kafka>3.3.1</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>
-        <version.ybclient>0.8.75-SNAPSHOT</version.ybclient>
+        <version.ybclient>0.8.75-20231215.051722-1</version.ybclient>
         <version.gson>2.8.9</version.gson>
 
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.kafka>3.3.1</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>
-        <version.ybclient>0.8.73-20231201.070308-1</version.ybclient>
+        <version.ybclient>0.8.74-SNAPSHOT</version.ybclient>
         <version.gson>2.8.9</version.gson>
 
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.kafka>3.3.1</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>
-        <version.ybclient>0.8.74-SNAPSHOT</version.ybclient>
+        <version.ybclient>0.8.75-SNAPSHOT</version.ybclient>
         <version.gson>2.8.9</version.gson>
 
         <!--

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -466,11 +466,6 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
       // Helper internal variable to log GetChanges request at regular intervals.
       long lastLoggedTimeForGetChanges = System.currentTimeMillis();
 
-      // This flag is only meant for testing purposes only.
-      if (FAIL_AFTER_BOOTSTRAP_GET_CHANGES) {
-        throw new RuntimeException("[TEST ONLY] Throwing error explicitly after bootstrap snapshot GetChanges call");
-      }
-
       while (context.isRunning() && retryCount <= this.connectorConfig.maxConnectorRetries()) {
         try {
             while (context.isRunning() && (previousOffset.getStreamingStoppingLsn() == null)) {
@@ -701,6 +696,11 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
             // Reset the retry count here indicating that if the flow has reached here then
             // everything succeeded without any exceptions
             retryCount = 0;
+
+            // This flag is only meant for testing purposes only.
+            if (FAIL_AFTER_BOOTSTRAP_GET_CHANGES) {
+              throw new RuntimeException("[TEST ONLY] Throwing error explicitly after bootstrap snapshot GetChanges call");
+            }
           }
         } catch (Exception e) {
           ++retryCount;

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -466,6 +466,11 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
       // Helper internal variable to log GetChanges request at regular intervals.
       long lastLoggedTimeForGetChanges = System.currentTimeMillis();
 
+      // This flag is only meant for testing purposes only.
+      if (FAIL_AFTER_BOOTSTRAP_GET_CHANGES) {
+        throw new RuntimeException("[TEST ONLY] Throwing error explicitly after bootstrap snapshot GetChanges call");
+      }
+
       while (context.isRunning() && retryCount <= this.connectorConfig.maxConnectorRetries()) {
         try {
             while (context.isRunning() && (previousOffset.getStreamingStoppingLsn() == null)) {
@@ -696,11 +701,6 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
             // Reset the retry count here indicating that if the flow has reached here then
             // everything succeeded without any exceptions
             retryCount = 0;
-
-            // This flag is only meant for testing purposes only.
-            if (FAIL_AFTER_BOOTSTRAP_GET_CHANGES) {
-              throw new RuntimeException("[TEST ONLY] Throwing error explicitly after bootstrap snapshot GetChanges call");
-            }
           }
         } catch (Exception e) {
           ++retryCount;

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBBeforeImageTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBBeforeImageTest.java
@@ -15,6 +15,8 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.yb.client.CDCStreamInfo;
 
 import io.debezium.config.Configuration;
@@ -28,7 +30,7 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
 
   @BeforeAll
   public static void beforeClass() throws SQLException {
-      initializeYBContainer();
+      initializeYBContainer("TEST_yb_enable_cdc_consistent_snapshot_streams=true", null);
       TestHelper.dropAllSchemas();
   }
 
@@ -48,12 +50,14 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
       shutdownYBContainer();
   }
 
-  @Test
-  public void isBeforeGettingPublished() throws Exception {
+  @ParameterizedTest
+  @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+  public void isBeforeGettingPublished(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
       TestHelper.initDB("yugabyte_create_tables.ddl");
 
       String dbStreamId = TestHelper.getNewDbStreamId(
-          "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.FULL);
+          "yugabyte", "t1", true /* withBeforeImage */, true,
+          BeforeImageMode.FULL, consistentSnapshot, useSnapshot);
       Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
       startEngine(configBuilder);
 
@@ -78,12 +82,14 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
       assertAfterImage(updateRecord, 1, "VKVK", "Kushwaha", 56.78);
   }
 
-  @Test
-  public void consecutiveSingleShardTransactions() throws Exception {
+  @ParameterizedTest
+  @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+  public void consecutiveSingleShardTransactions(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
       TestHelper.initDB("yugabyte_create_tables.ddl");
 
       String dbStreamId = TestHelper.getNewDbStreamId(
-          "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.FULL);
+          "yugabyte", "t1", true /* withBeforeImage */, true,
+          BeforeImageMode.FULL, consistentSnapshot, useSnapshot);
       Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
       startEngine(configBuilder);
 
@@ -114,11 +120,14 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
       assertAfterImage(updateRecord2, 1, "V", "K", 0.05);
   }
 
-  @Test
-  public void consecutiveSingleShardTransactionsForChange() throws Exception {
+  @ParameterizedTest
+  @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+  public void consecutiveSingleShardTransactionsForChange(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
       TestHelper.initDB("yugabyte_create_tables.ddl");
 
-      String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.CHANGE);
+      String dbStreamId = TestHelper.getNewDbStreamId(
+          "yugabyte", "t1", true /* withBeforeImage */, true,
+          BeforeImageMode.CHANGE, consistentSnapshot, useSnapshot);
       Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
       startEngine(configBuilder);
 
@@ -150,12 +159,14 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
       assertValueField(deleteRecord, "after", null);
   }
 
-  @Test
-  public void consecutiveSingleShardTransactionsForChangeOldNew() throws Exception {
+  @ParameterizedTest
+  @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+  public void consecutiveSingleShardTransactionsForChangeOldNew(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
       TestHelper.initDB("yugabyte_create_tables.ddl");
 
       String dbStreamId = TestHelper.getNewDbStreamId(
-          "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.CHANGE_OLD_NEW);
+          "yugabyte", "t1", true /* withBeforeImage */, true, 
+          BeforeImageMode.CHANGE_OLD_NEW, consistentSnapshot, useSnapshot);
       Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
       startEngine(configBuilder);
 
@@ -188,12 +199,14 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
       assertValueField(deleteRecord, "after", null);
   }
 
-  @Test
-  public void consecutiveSingleShardTransactionsForDefault() throws Exception {
+  @ParameterizedTest
+  @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+  public void consecutiveSingleShardTransactionsForDefault(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
       TestHelper.initDB("yugabyte_create_tables.ddl");
 
       String dbStreamId = TestHelper.getNewDbStreamId(
-          "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.DEFAULT);
+          "yugabyte", "t1", true /* withBeforeImage */, true,
+          BeforeImageMode.DEFAULT, consistentSnapshot, useSnapshot);
       Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
       startEngine(configBuilder);
 
@@ -224,12 +237,14 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
       assertValueField(deleteRecord, "after", null);
   }
 
-  @Test
-  public void consecutiveSingleShardTransactionsForNothing() throws Exception {
+  @ParameterizedTest
+  @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+  public void consecutiveSingleShardTransactionsForNothing(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
       TestHelper.initDB("yugabyte_create_tables.ddl");
 
       String dbStreamId = TestHelper.getNewDbStreamId(
-          "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.NOTHING);
+          "yugabyte", "t1", true /* withBeforeImage */, true,
+          BeforeImageMode.NOTHING, consistentSnapshot, useSnapshot);
       Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
       startEngine(configBuilder);
 
@@ -260,12 +275,14 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
       assertValueField(deleteRecord, "after", null);
   }
 
-  @Test
-  public void multiShardTransactions() throws Exception {
+  @ParameterizedTest
+  @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+  public void multiShardTransactions(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
     TestHelper.initDB("yugabyte_create_tables.ddl");
 
     String dbStreamId = TestHelper.getNewDbStreamId(
-        "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.FULL);
+        "yugabyte", "t1", true /* withBeforeImage */, true,
+        BeforeImageMode.FULL, consistentSnapshot, useSnapshot);
     Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
     startEngine(configBuilder);
 
@@ -319,12 +336,14 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
     assertTombstone(records.get(7));
   }
 
-  @Test
-  public void updateWithNullValues() throws Exception {
+  @ParameterizedTest
+  @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+  public void updateWithNullValues(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
     TestHelper.initDB("yugabyte_create_tables.ddl");
 
     String dbStreamId = TestHelper.getNewDbStreamId(
-        "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.FULL);
+        "yugabyte", "t1", true /* withBeforeImage */, true,
+        BeforeImageMode.FULL, consistentSnapshot, useSnapshot);
     Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
     startEngine(configBuilder);
 
@@ -349,15 +368,17 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
     assertAfterImage(updateRecord, 1, "Vaibhav", null, null);
   }
 
-  @Test
-  public void modifyPrimaryKey() throws Exception {
+  @ParameterizedTest
+  @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+  public void modifyPrimaryKey(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
     // NOTE: The modification of primary key will not lead to any different behaviour, it will
     // simply give us two records, DELETE + INSERT.
 
     TestHelper.initDB("yugabyte_create_tables.ddl");
 
     String dbStreamId = TestHelper.getNewDbStreamId(
-        "yugabyte", "t1", true /* withBeforeImage */, true, BeforeImageMode.FULL);
+        "yugabyte", "t1", true /* withBeforeImage */, true,
+        BeforeImageMode.FULL, consistentSnapshot, useSnapshot);
     Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
     startEngine(configBuilder);
 
@@ -395,8 +416,9 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
     assertAfterImage(record4, 404, "Vaibhav", "some_last_name", 98.765);
   }
 
-  @Test
-  public void operationsOnTableWithDefaultValues() throws Exception {
+  @ParameterizedTest
+  @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+  public void operationsOnTableWithDefaultValues(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
     TestHelper.initDB("yugabyte_create_tables.ddl");
 
     // Create a table with default values.
@@ -405,7 +427,8 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
                        + " hours DOUBLE PRECISION DEFAULT 12.345);");
 
     String dbStreamId = TestHelper.getNewDbStreamId(
-        "yugabyte", "table_with_defaults", true /* withBeforeImage */, true, BeforeImageMode.FULL);
+        "yugabyte", "table_with_defaults", true /* withBeforeImage */, true,
+        BeforeImageMode.FULL, consistentSnapshot, useSnapshot);
     Configuration.Builder configBuilder =
         TestHelper.getConfigBuilder("public.table_with_defaults", dbStreamId);
     startEngine(configBuilder);

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBBeforeImageTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBBeforeImageTest.java
@@ -30,7 +30,7 @@ public class YugabyteDBBeforeImageTest extends YugabyteDBContainerTestBase {
 
   @BeforeAll
   public static void beforeClass() throws SQLException {
-      initializeYBContainer("TEST_yb_enable_cdc_consistent_snapshot_streams=true", null);
+      initializeYBContainer();
       TestHelper.dropAllSchemas();
   }
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCQLTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCQLTest.java
@@ -36,7 +36,7 @@ public class YugabyteDBCQLTest extends YugabyteDBContainerTestBase {
 
     @BeforeAll
     public static void beforeClass() throws SQLException {
-        initializeYBContainer("TEST_yb_enable_cdc_consistent_snapshot_streams=true", null);
+        initializeYBContainer();
     }
 
     @BeforeEach

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBColocatedTablesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBColocatedTablesTest.java
@@ -32,7 +32,7 @@ public class YugabyteDBColocatedTablesTest extends YugabyteDBContainerTestBase {
 
   @BeforeAll
   public static void beforeClass() throws Exception {
-    initializeYBContainer("TEST_yb_enable_cdc_consistent_snapshot_streams=true", null);
+    initializeYBContainer();
     TestHelper.dropAllSchemas();
     TestHelper.executeDDL("yugabyte_create_tables.ddl");
   }

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCompleteTypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCompleteTypesTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class YugabyteDBCompleteTypesTest extends YugabyteDBContainerTestBase {
     @BeforeAll
     public static void beforeClass() throws SQLException {
-        initializeYBContainer("TEST_yb_enable_cdc_consistent_snapshot_streams=true", null);
+        initializeYBContainer();
         TestHelper.dropAllSchemas();
     }
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCompleteTypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCompleteTypesTest.java
@@ -67,8 +67,8 @@ public class YugabyteDBCompleteTypesTest extends YugabyteDBContainerTestBase {
         }
     }
 
-  @ParameterizedTest
-  @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+    @ParameterizedTest
+    @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
     public void verifyAllWorkingDataTypesInSingleTable(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
         TestHelper.dropAllSchemas();
         TestHelper.executeDDL("yugabyte_create_tables.ddl");

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCompleteTypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCompleteTypesTest.java
@@ -18,6 +18,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import io.debezium.DebeziumException;
 import io.debezium.config.Configuration;
 import io.debezium.util.Strings;
+
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -25,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class YugabyteDBCompleteTypesTest extends YugabyteDBContainerTestBase {
     @BeforeAll
     public static void beforeClass() throws SQLException {
-        initializeYBContainer();
+        initializeYBContainer("TEST_yb_enable_cdc_consistent_snapshot_streams=true", null);
         TestHelper.dropAllSchemas();
     }
 
@@ -65,13 +67,14 @@ public class YugabyteDBCompleteTypesTest extends YugabyteDBContainerTestBase {
         }
     }
 
-    @Test
-    public void verifyAllWorkingDataTypesInSingleTable() throws Exception {
+  @ParameterizedTest
+  @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+    public void verifyAllWorkingDataTypesInSingleTable(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
         TestHelper.dropAllSchemas();
         TestHelper.executeDDL("yugabyte_create_tables.ddl");
         Thread.sleep(1000);
 
-        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "all_types");
+        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "all_types", consistentSnapshot, useSnapshot);
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.all_types", dbStreamId);
         startEngine(configBuilder);
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConfigTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConfigTest.java
@@ -23,7 +23,7 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
 
     @BeforeAll
     public static void beforeClass() throws SQLException {
-        initializeYBContainer("TEST_yb_enable_cdc_consistent_snapshot_streams=true", null);
+        initializeYBContainer();
         TestHelper.dropAllSchemas();
     }
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConfigTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConfigTest.java
@@ -4,6 +4,8 @@ import java.sql.SQLException;
 import java.util.concurrent.CompletableFuture;
 
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import io.debezium.DebeziumException;
 import io.debezium.config.Configuration;
@@ -21,7 +23,7 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
 
     @BeforeAll
     public static void beforeClass() throws SQLException {
-        initializeYBContainer();
+        initializeYBContainer("TEST_yb_enable_cdc_consistent_snapshot_streams=true", null);
         TestHelper.dropAllSchemas();
     }
 
@@ -66,13 +68,14 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
     }
 
     // This verifies that the connector should not be running if a wrong table.include.list is provided
-    @Test
-    public void shouldThrowExceptionWithWrongIncludeList() throws Exception {
+    @ParameterizedTest
+    @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+    public void shouldThrowExceptionWithWrongIncludeList(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
         TestHelper.dropAllSchemas();
 
         TestHelper.executeDDL("yugabyte_create_tables.ddl");
 
-        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "all_types");
+        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "all_types", consistentSnapshot, useSnapshot);
 
         // Create another table which will not be a part of the DB stream ID
         TestHelper.execute("CREATE TABLE not_part_of_stream (id INT PRIMARY KEY);");
@@ -92,13 +95,14 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
 
     // This test verifies that the connector configuration works properly even if there are tables of the same name
     // in another database
-    @Test
-    public void shouldWorkWithSameNameTablePresentInAnotherDatabase() throws Exception {
+    @ParameterizedTest
+    @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+    public void shouldWorkWithSameNameTablePresentInAnotherDatabase(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
         TestHelper.dropAllSchemas();
 
         TestHelper.executeDDL("yugabyte_create_tables.ddl");
 
-        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
+        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", consistentSnapshot, useSnapshot);
 
         // Create a same table in another database
         // This is to ensure that when the yb-client returns all the tables, then the YugabyteDBConnector
@@ -143,14 +147,15 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
         assertConnectorNotRunning();
     }
 
-    @Test
-    public void shouldNotWorkWithWrongDatabaseName() throws Exception {
+    @ParameterizedTest
+    @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+    public void shouldNotWorkWithWrongDatabaseName(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
         TestHelper.dropAllSchemas();
 
         TestHelper.executeDDL("yugabyte_create_tables.ddl");
 
         // Create a dbStreamId on the default namespace but provide a different namespace to the configuration
-        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
+        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", consistentSnapshot, useSnapshot);
 
         String wrongNamespaceName = "wrong_namespace";
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder(wrongNamespaceName, "public.t1", dbStreamId);
@@ -164,14 +169,15 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
         assertConnectorNotRunning();
     }
 
-    @Test
-    public void shouldNotAuthenticateWithWrongUsername() throws Exception {
+    @ParameterizedTest
+    @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+    public void shouldNotAuthenticateWithWrongUsername(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
         TestHelper.dropAllSchemas();
 
         TestHelper.executeDDL("yugabyte_create_tables.ddl");
 
         // Create a dbStreamId on the default namespace
-        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
+        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", consistentSnapshot, useSnapshot);
 
         Configuration.Builder configBuilderWithWrongUser = TestHelper.getConfigBuilder("public.t1", dbStreamId);
         configBuilderWithWrongUser.with(YugabyteDBConnectorConfig.USER, "wrong_username");
@@ -184,14 +190,15 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
         assertConnectorNotRunning();
     }
 
-    @Test
-    public void shouldNotAuthenticateWithWrongPassword() throws Exception {
+    @ParameterizedTest
+    @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+    public void shouldNotAuthenticateWithWrongPassword(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
         TestHelper.dropAllSchemas();
 
         TestHelper.executeDDL("yugabyte_create_tables.ddl");
 
         // Create a dbStreamId on the default namespace
-        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
+        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", consistentSnapshot, useSnapshot);
 
         Configuration.Builder configBuilderWithWrongPassword = TestHelper.getConfigBuilder("public.t1", dbStreamId);
         configBuilderWithWrongPassword.with(YugabyteDBConnectorConfig.PASSWORD, "wrong_password");
@@ -204,14 +211,15 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
         assertConnectorNotRunning();
     }
 
-    @Test
-    public void shouldThrowProperErrorMessageWithEmptyTableList() throws Exception {
+    @ParameterizedTest
+    @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+    public void shouldThrowProperErrorMessageWithEmptyTableList(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
         TestHelper.dropAllSchemas();
 
         TestHelper.executeDDL("yugabyte_create_tables.ddl");
 
         // Create a dbStreamId on the default namespace
-        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
+        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", consistentSnapshot, useSnapshot);
 
         Configuration.Builder configBuilderWithWrongPassword = TestHelper.getConfigBuilder("", dbStreamId);
         startEngine(configBuilderWithWrongPassword, (success, message, error) -> {
@@ -223,14 +231,15 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
         assertConnectorNotRunning();
     }
 
-    @Test
-    public void shouldThrowExceptionIfTheProvidedTableDoesNotExist() throws Exception {
+    @ParameterizedTest
+    @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+    public void shouldThrowExceptionIfTheProvidedTableDoesNotExist(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
         TestHelper.dropAllSchemas();
 
         TestHelper.executeDDL("yugabyte_create_tables.ddl");
 
         // Create a dbStreamId on the default namespace
-        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
+        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", consistentSnapshot, useSnapshot);
 
         Configuration.Builder configBuilderWithWrongPassword = TestHelper.getConfigBuilder("public.non_existent_table", dbStreamId);
         startEngine(configBuilderWithWrongPassword, (success, message, error) -> {
@@ -261,12 +270,13 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
         assertConnectorNotRunning();
     }
 
-    @Test
-    public void throwProperErrorMessageIfStreamIdIsNotAssociatedWithAnyTable() throws Exception {
+    @ParameterizedTest
+    @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+    public void throwProperErrorMessageIfStreamIdIsNotAssociatedWithAnyTable(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
         TestHelper.dropAllSchemas();
 
         TestHelper.execute("CREATE TABLE dummy_table (id INT);");
-        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "dummy_table");
+        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "dummy_table", consistentSnapshot, useSnapshot);
 
         Configuration.Builder configBuilderWithHollowStreamId = 
             TestHelper.getConfigBuilder("public.dummy_table", dbStreamId);
@@ -280,13 +290,15 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
         assertConnectorNotRunning();
     }
 
-    @Test
-    public void throwExceptionIfExplicitCheckpointingNotConfiguredWithConsistency() throws Exception {
+    @ParameterizedTest
+    @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+    public void throwExceptionIfExplicitCheckpointingNotConfiguredWithConsistency(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
         TestHelper.dropAllSchemas();
 
         // Create a stream ID with IMPLICIT checkpointing and then deploy it in a consistent streaming setup.
         TestHelper.execute("CREATE TABLE dummy_table (id INT PRIMARY KEY);");
-        final String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "dummy_table", false, false);
+        final String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "dummy_table", false,
+                false, consistentSnapshot, useSnapshot);
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.dummy_table", dbStreamId);
         configBuilder.with(YugabyteDBConnectorConfig.TRANSACTION_ORDERING, true);
 
@@ -299,13 +311,14 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
         assertConnectorNotRunning();
     }
 
-    @Test
-    public void throwExceptionWithIncorrectTaskCountWithTransactionOrdering() throws Exception {
+    @ParameterizedTest
+    @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+    public void throwExceptionWithIncorrectTaskCountWithTransactionOrdering(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
         TestHelper.dropAllSchemas();
 
         // Create a stream ID with IMPLICIT checkpointing and then deploy it in a consistent streaming setup.
         TestHelper.execute("CREATE TABLE dummy_table (id INT PRIMARY KEY);");
-        final String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "dummy_table");
+        final String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "dummy_table", consistentSnapshot, useSnapshot);
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.dummy_table", dbStreamId);
         configBuilder.with(YugabyteDBConnectorConfig.TRANSACTION_ORDERING, true);
         configBuilder.with("tasks.max", 2);

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
@@ -134,9 +134,7 @@ public class YugabyteDBDatatypesTest extends YugabyteDBContainerTestBase {
 
     @BeforeAll
     public static void beforeClass() throws SQLException {
-        initializeYBContainer(
-                "enable_tablet_split_of_cdcsdk_streamed_tables=true,TEST_yb_enable_cdc_consistent_snapshot_streams=true",
-                null);
+        initializeYBContainer("enable_tablet_split_of_cdcsdk_streamed_tables=true", null);
         TestHelper.dropAllSchemas();
     }
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBEnumValuesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBEnumValuesTest.java
@@ -28,7 +28,7 @@ public class YugabyteDBEnumValuesTest extends YugabyteDBContainerTestBase {
     
     @BeforeAll
     public static void beforeClass() throws SQLException {
-        initializeYBContainer("TEST_yb_enable_cdc_consistent_snapshot_streams=true", null);
+        initializeYBContainer();
         TestHelper.dropAllSchemas();
     }
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBEnumValuesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBEnumValuesTest.java
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
@@ -26,7 +28,7 @@ public class YugabyteDBEnumValuesTest extends YugabyteDBContainerTestBase {
     
     @BeforeAll
     public static void beforeClass() throws SQLException {
-        initializeYBContainer();
+        initializeYBContainer("TEST_yb_enable_cdc_consistent_snapshot_streams=true", null);
         TestHelper.dropAllSchemas();
     }
 
@@ -48,9 +50,10 @@ public class YugabyteDBEnumValuesTest extends YugabyteDBContainerTestBase {
         shutdownYBContainer();
     }
 
-    @Test
-    public void testEnumValue() throws Exception {
-        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "test_enum");
+    @ParameterizedTest
+    @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+    public void testEnumValue(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
+        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "test_enum", consistentSnapshot, useSnapshot);
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.test_enum", dbStreamId);
         startEngine(configBuilder);
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBExplicitCheckpointingTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBExplicitCheckpointingTest.java
@@ -46,9 +46,7 @@ public class YugabyteDBExplicitCheckpointingTest extends YugabyteDBContainerTest
 
     @BeforeAll
     public static void beforeAll() throws SQLException {
-        initializeYBContainer(
-            "TEST_yb_enable_cdc_consistent_snapshot_streams=true",
-            "cdc_state_checkpoint_update_interval_ms=0");
+        initializeYBContainer(null, "cdc_state_checkpoint_update_interval_ms=0");
         TestHelper.dropAllSchemas();
     }
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBPartitionTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBPartitionTest.java
@@ -25,7 +25,7 @@ public class YugabyteDBPartitionTest extends YugabyteDBContainerTestBase {
 
   @BeforeAll
   public static void beforeClass() throws SQLException {
-      initializeYBContainer("TEST_yb_enable_cdc_consistent_snapshot_streams=true", null);
+      initializeYBContainer();
       TestHelper.dropAllSchemas();
   }
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSchemaEvolutionTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSchemaEvolutionTest.java
@@ -29,8 +29,7 @@ public class YugabyteDBSchemaEvolutionTest extends YugabyteDBContainerTestBase {
   @BeforeAll
   public static void beforeClass() throws SQLException {
       String tserverFlags = "cdc_max_stream_intent_records=200";
-      String masterFlags = "TEST_yb_enable_cdc_consistent_snapshot_streams=true";
-      initializeYBContainer(masterFlags, tserverFlags);
+      initializeYBContainer(null, tserverFlags);
       TestHelper.dropAllSchemas();
   }
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotResumeTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotResumeTest.java
@@ -60,9 +60,9 @@ public class YugabyteDBSnapshotResumeTest extends YugabyteDBContainerTestBase {
 		shutdownYBContainer();
 	}
 
-	@ParameterizedTest
-	@MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForSnapshot")
-	public void verifySnapshotIsResumedFromKey(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
+    @ParameterizedTest
+    @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForSnapshot")
+    public void verifySnapshotIsResumedFromKey(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
 		TestHelper.dropAllSchemas();
 		TestHelper.executeDDL("yugabyte_create_tables.ddl");
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotResumeTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotResumeTest.java
@@ -38,9 +38,7 @@ public class YugabyteDBSnapshotResumeTest extends YugabyteDBContainerTestBase {
 	private static final int snapshotBatchSize = 50;
 	@BeforeAll
 	public static void beforeClass() throws SQLException {
-		initializeYBContainer(
-			"TEST_yb_enable_cdc_consistent_snapshot_streams=true",
-			"cdc_snapshot_batch_size=" + snapshotBatchSize);
+		initializeYBContainer(null, "cdc_snapshot_batch_size=" + snapshotBatchSize);
 		TestHelper.dropAllSchemas();
 	}
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotResumeTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotResumeTest.java
@@ -57,9 +57,9 @@ public class YugabyteDBSnapshotResumeTest extends YugabyteDBContainerTestBase {
 		shutdownYBContainer();
 	}
 
-    @ParameterizedTest
-    @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForSnapshot")
-    public void verifySnapshotIsResumedFromKey(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
+  @ParameterizedTest
+  @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForSnapshot")
+  public void verifySnapshotIsResumedFromKey(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
 		TestHelper.dropAllSchemas();
 		TestHelper.executeDDL("yugabyte_create_tables.ddl");
 
@@ -135,8 +135,8 @@ public class YugabyteDBSnapshotResumeTest extends YugabyteDBContainerTestBase {
 	}
 
   @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  public void verifyNoDataLossIfConnectorRestartDuringLastBatchConsumption (boolean colocation) throws Exception {
+  @MethodSource("io.debezium.connector.yugabytedb.YugabyteDBSnapshotTest#streamTypeProviderForSnapshotWithColocation")
+  public void verifyNoDataLossIfConnectorRestartDuringLastBatchConsumption (boolean consistentSnapshot, boolean useSnapshot, boolean colocation) throws Exception {
     /*
      * The objective of this test is to verify the connector starts in the snapshot phase and
      * consumes the all the snapshot records before switching to streaming phase in the
@@ -154,7 +154,7 @@ public class YugabyteDBSnapshotResumeTest extends YugabyteDBContainerTestBase {
 
     YugabyteDBSnapshotChangeEventSource.TRACK_EXPLICIT_CHECKPOINTS = true;
 
-    String dbStreamId = TestHelper.getNewDbStreamId("colocated_database", "test_1");
+    String dbStreamId = TestHelper.getNewDbStreamId("colocated_database", "test_1", consistentSnapshot, useSnapshot);
     Configuration.Builder configBuilder = TestHelper.getConfigBuilder("colocated_database", "public.test_1", dbStreamId);
     configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE, YugabyteDBConnectorConfig.SnapshotMode.INITIAL.getValue());
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -744,6 +744,9 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         YugabyteDBStreamingChangeEventSource.TEST_WAIT_BEFORE_GETTING_CHILDREN = false;
     }
 
+    // This test should not be run with consistent snapshot stream since it verifies
+    // the behaviour on failure after snapshot bootstrap call. For consistent
+    // snapshot streams, the very first getChanges call starts the snapshot consumption
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void snapshotTwoColocatedNonEmptyAndNonColocatedEmptyThenStream(boolean colocation) throws Exception {
@@ -817,6 +820,68 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         assertEquals(401, recordsForNonColocated.size());
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void snapshotTwoColocatedNonEmptyAndNonColocatedEmptyThenStreamWithConsistentSnapshot(boolean colocation) throws Exception {
+        /* The objective of this test is to verify that we are able to consume all snapshot records on a
+            combination of empty & non-empty tables and successfully switch to streaming phase and consume
+            the streaming records for all the tables.
+         */
+
+        // Create tables.
+        createTables(colocation);
+
+        // 2 colocated non-empty tables + 1 colocated empty table + 1 non-colocated empty table
+        final int recordCountForTest1 = 1000;
+        final int recordCountForTest2 = 2000;
+        insertBulkRecords(recordCountForTest1, "public.test_1");
+        insertBulkRecords(recordCountForTest2, "public.test_2");
+
+        String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1", true, true);
+        Configuration.Builder configBuilder =
+                TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME, "public.test_1,public.test_2,public.test_3,public.test_no_colocated", dbStreamId);
+        configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE,
+                YugabyteDBConnectorConfig.SnapshotMode.INITIAL.getValue());
+
+        startEngine(configBuilder);
+
+        // Wait until connector is started.
+        awaitUntilConnectorIsReady();
+
+        List<SourceRecord> recordsForTest1 = new ArrayList<>();
+        List<SourceRecord> recordsForTest2 = new ArrayList<>();
+        List<SourceRecord> recordsForTest3 = new ArrayList<>();
+        List<SourceRecord> recordsForNonColocated = new ArrayList<>();
+
+        final int totalStreamingRecords = insertStreamingRecordsInAllTables();
+
+        List<SourceRecord> records = new ArrayList<>();
+
+        waitAndFailIfCannotConsume(records, recordCountForTest1 + recordCountForTest2 + totalStreamingRecords);
+
+        // Iterate over the records and add them to their respective topic
+        for (SourceRecord record : records) {
+            if (record.topic().equals(TestHelper.TEST_SERVER + ".public.test_1")) {
+                recordsForTest1.add(record);
+            } else if (record.topic().equals(TestHelper.TEST_SERVER + ".public.test_2")) {
+                recordsForTest2.add(record);
+            } else if (record.topic().equals(TestHelper.TEST_SERVER + ".public.test_3")) {
+                recordsForTest3.add(record);
+            } else if (record.topic().equals(TestHelper.TEST_SERVER + ".public.test_no_colocated")) {
+                recordsForNonColocated.add(record);
+            }
+        }
+
+        assertEquals(recordCountForTest1 + 101, recordsForTest1.size());
+        assertEquals(recordCountForTest2 + 201, recordsForTest2.size());
+        assertEquals(301, recordsForTest3.size());
+        assertEquals(401, recordsForNonColocated.size());
+    }
+
+
+    // This test should not be run with consistent snapshot stream since it verifies
+    // the behaviour on failure after snapshot bootstrap call. For consistent
+    // snapshot streams, the very first getChanges call starts the snapshot consumption
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void snapshotTwoColocatedNonEmptyAndNonColocatedNonEmptyThenStream(boolean colocation) throws Exception {
@@ -894,7 +959,67 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void verifyConnectorFailsIfMarkSnapshotDoneFails(boolean colocation) throws Exception {
+    public void snapshotTwoColocatedNonEmptyAndNonColocatedNonEmptyThenStreamWithConsistentSnapshot(boolean colocation) throws Exception {
+        /* The objective of this test is to verify that we are able to consume all snapshot records on a
+            combination of empty & non-empty tables and successfully switch to streaming phase and consume
+            the streaming records for all the tables.
+         */
+        // Create tables.
+        createTables(colocation);
+
+        // 2 colocated non-empty tables + 1 colocated empty table + 1 non-colocated non-empty table
+        final int recordCountForTest1 = 1000;
+        final int recordCountForTest2 = 2000;
+        final int recordCountInNonColocated = 2000;
+        insertBulkRecords(recordCountForTest1, "public.test_1");
+        insertBulkRecords(recordCountForTest2, "public.test_2");
+        insertBulkRecords(recordCountInNonColocated, "public.test_no_colocated");
+
+        String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1", true, true);
+        Configuration.Builder configBuilder =
+                TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME, "public.test_1,public.test_2,public.test_3,public.test_no_colocated", dbStreamId);
+        configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE,
+                YugabyteDBConnectorConfig.SnapshotMode.INITIAL.getValue());
+
+        startEngine(configBuilder);
+        // Wait until connector is started.
+        awaitUntilConnectorIsReady();
+
+        List<SourceRecord> recordsForTest1 = new ArrayList<>();
+        List<SourceRecord> recordsForTest2 = new ArrayList<>();
+        List<SourceRecord> recordsForTest3 = new ArrayList<>();
+        List<SourceRecord> recordsForNonColocated = new ArrayList<>();
+
+        final int totalStreamingRecords = insertStreamingRecordsInAllTables();
+
+        List<SourceRecord> records = new ArrayList<>();
+
+        waitAndFailIfCannotConsume(records, recordCountForTest1 + recordCountForTest2 + recordCountInNonColocated + totalStreamingRecords);
+
+
+        // Iterate over the records and add them to their respective topic
+        for (SourceRecord record : records) {
+            if (record.topic().equals(TestHelper.TEST_SERVER + ".public.test_1")) {
+                recordsForTest1.add(record);
+            } else if (record.topic().equals(TestHelper.TEST_SERVER + ".public.test_2")) {
+                recordsForTest2.add(record);
+            } else if (record.topic().equals(TestHelper.TEST_SERVER + ".public.test_3")) {
+                recordsForTest3.add(record);
+            } else if (record.topic().equals(TestHelper.TEST_SERVER + ".public.test_no_colocated")) {
+                recordsForNonColocated.add(record);
+            }
+        }
+
+        assertEquals(recordCountForTest1 + 101, recordsForTest1.size());
+        assertEquals(recordCountForTest2 + 201, recordsForTest2.size());
+        assertEquals(301, recordsForTest3.size());
+        assertEquals(recordCountInNonColocated + 401, recordsForNonColocated.size());
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("streamTypeProviderForSnapshotWithColocation")
+    public void verifyConnectorFailsIfMarkSnapshotDoneFails(boolean consistentSnapshot, boolean useSnapshot, boolean colocation) throws Exception {
         createTables(colocation);
 
         int recordCountT1 = 5000;
@@ -902,7 +1027,7 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         // Insert records in the table test_1
         insertBulkRecords(recordCountT1, "public.test_1");
 
-        String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
+        String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1", consistentSnapshot, useSnapshot);
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME, "public.test_1", dbStreamId);
         configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE, "initial")
             .with(YugabyteDBConnectorConfig.MAX_CONNECTOR_RETRIES, "1");
@@ -990,7 +1115,7 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
                 Arguments.of(true, true, true), // USE_SNAPSHOT stream with colocation
                 Arguments.of(true, true, false));  // USE_SNAPSHOT stream without colocation
     }
-    
+
     private int insertStreamingRecordsInAllTables() {
         // Inserting 1001 records to test_1
         TestHelper.executeInDatabase("INSERT INTO test_1 VALUES (generate_series(1000, 1100));", DEFAULT_COLOCATED_DB_NAME);

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -378,9 +378,12 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         }
     }
 
+    // This test should not be run with consistent snapshot stream since it verifies
+    // the behaviour on failure after snapshot bootstrap call. For consistent
+    // snapshot streams, the very first getChanges call starts the snapshot consumption
 	@ParameterizedTest
-	@MethodSource("streamTypeProviderForSnapshotWithColocation")
-    public void shouldSnapshotWithFailureAfterBootstrapSnapshotCall(boolean consistentSnapshot, boolean useSnapshot, boolean colocation)
+	@ValueSource(booleans = {true, false})
+    public void shouldSnapshotWithFailureAfterBootstrapSnapshotCall(boolean colocation)
         throws Exception {
         // This test verifies that if there is a failure after snapshot is bootstrapped,
         // then snapshot is taken normally once the connector restarts.
@@ -391,7 +394,7 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         insertBulkRecords(recordsCount, "public.test_1");
         insertBulkRecords(recordsCount, "public.test_2");
 
-        String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1", consistentSnapshot, useSnapshot);
+        String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder(
             DEFAULT_COLOCATED_DB_NAME, "public.test_1,public.test_2", dbStreamId);
         configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE, "initial");

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -59,8 +59,8 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         shutdownYBContainer();
     }
 
-	@ParameterizedTest
-	@MethodSource("streamTypeProviderForSnapshotWithColocation")
+    @ParameterizedTest
+    @MethodSource("streamTypeProviderForSnapshotWithColocation")
     public void testSnapshotRecordConsumption(boolean consistentSnapshot, boolean useSnapshot, boolean colocation) throws Exception {
         setCommitCallbackDelay(10000);
         createTables(colocation);
@@ -84,8 +84,8 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
           }).get();
     }
 
-	@ParameterizedTest
-	@MethodSource("streamTypeProviderForSnapshotWithColocation")
+    @ParameterizedTest
+    @MethodSource("streamTypeProviderForSnapshotWithColocation")
     public void testSnapshotRecordCountInInitialOnlyMode(boolean consistentSnapshot, boolean useSnapshot, boolean colocation) throws Exception {
         setCommitCallbackDelay(10000);
         createTables(colocation);
@@ -106,8 +106,8 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         verifyRecordCount(recordsCount);
     }
 
-	@ParameterizedTest
-	@MethodSource("streamTypeProviderForSnapshotWithColocation")
+    @ParameterizedTest
+    @MethodSource("streamTypeProviderForSnapshotWithColocation")
     public void shouldOnlySnapshotTablesInList(boolean consistentSnapshot, boolean useSnapshot, boolean colocation) throws Exception {
         createTables(colocation);
         int recordCountT1 = 5000;
@@ -144,8 +144,8 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         assertFalse(records.topics().contains("test_server.public.all_types"));
     }
 
-	@ParameterizedTest
-	@MethodSource("streamTypeProviderForSnapshotWithColocation")
+    @ParameterizedTest
+    @MethodSource("streamTypeProviderForSnapshotWithColocation")
     public void snapshotTableThenStreamData(boolean consistentSnapshot, boolean useSnapshot, boolean colocation) throws Exception {
         createTables(colocation);
 
@@ -179,8 +179,8 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
     }
 
     // GitHub issue: https://github.com/yugabyte/debezium-connector-yugabytedb/issues/143
-	@ParameterizedTest
-	@MethodSource("streamTypeProviderForSnapshotWithColocation")
+    @ParameterizedTest
+    @MethodSource("streamTypeProviderForSnapshotWithColocation")
     public void snapshotTableWithCompaction(boolean consistentSnapshot, boolean useSnapshot, boolean colocation) throws Exception {
         createTables(colocation);
 
@@ -209,8 +209,8 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         waitAndFailIfCannotConsume(records, recordCount + 10 /* updates */);
     }
 
-	@ParameterizedTest
-	@MethodSource("streamTypeProviderForSnapshotWithColocation")
+    @ParameterizedTest
+    @MethodSource("streamTypeProviderForSnapshotWithColocation")
     public void snapshotForMultipleTables(boolean consistentSnapshot, boolean useSnapshot, boolean colocation) throws Exception {
         // Create colocated tables
         createTables(colocation);
@@ -253,8 +253,8 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         assertEquals(recordsTest3, recordsForTest3.size());
     }
 
-	@ParameterizedTest
-	@MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForSnapshot")
+    @ParameterizedTest
+    @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForSnapshot")
     public void snapshotMixOfColocatedNonColocatedTables(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
         // Create tables.
         createTables(true /* enforce creation of the colocated tables only */);
@@ -303,8 +303,8 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         assertEquals(recordCountInNonColocated, recordsForNonColocated.size());
     }
 
-	@ParameterizedTest
-	@MethodSource("streamTypeProviderForSnapshotWithColocation")
+    @ParameterizedTest
+    @MethodSource("streamTypeProviderForSnapshotWithColocation")
     public void snapshotColocatedNonColocatedThenStream(boolean consistentSnapshot, boolean useSnapshot, boolean initialOnly) throws Exception {
         // Create tables.
         createTables(true /* enforce creation of the colocated tables only */);
@@ -381,8 +381,8 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
     // This test should not be run with consistent snapshot stream since it verifies
     // the behaviour on failure after snapshot bootstrap call. For consistent
     // snapshot streams, the very first getChanges call starts the snapshot consumption
-	@ParameterizedTest
-	@ValueSource(booleans = {true, false})
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
     public void shouldSnapshotWithFailureAfterBootstrapSnapshotCall(boolean colocation)
         throws Exception {
         // This test verifies that if there is a failure after snapshot is bootstrapped,
@@ -438,8 +438,8 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         assertEquals(recordsCount, recordsForTest2.size());
     }
 
-	@ParameterizedTest
-	@MethodSource("streamTypeProviderForSnapshotWithColocation")
+    @ParameterizedTest
+    @MethodSource("streamTypeProviderForSnapshotWithColocation")
     public void shouldSnapshotWithFailureAfterSettingInitialCheckpoint(boolean consistentSnapshot, boolean useSnapshot, boolean colocation)
         throws Exception {
         // This test verifies that if there is a failure after the call to set the checkpoint,
@@ -495,8 +495,8 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         assertEquals(recordsCount, recordsForTest2.size());
     }
 
-	@ParameterizedTest
-	@MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForSnapshot")
+    @ParameterizedTest
+    @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForSnapshot")
     public void shouldNotSnapshotAgainIfSnapshotCompletedOnce(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
         /* This test aims to verify that if snapshot is taken on certain streamID + tabletId
            combination once then we should not be taking it again. To verify the same, we will
@@ -556,8 +556,8 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         }
     }
 
-	@ParameterizedTest
-	@MethodSource("streamTypeProviderForSnapshotWithColocation")
+    @ParameterizedTest
+    @MethodSource("streamTypeProviderForSnapshotWithColocation")
     public void shouldContinueStreamingInNeverAfterSnapshotCompleteInInitialOnly(boolean consistentSnapshot, boolean useSnapshot, boolean colocation)
         throws Exception {
         /* This test aims to verify that if snapshot is taken on certain streamID + tabletId
@@ -637,8 +637,8 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         }
     }
 
-	@ParameterizedTest
-	@MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForSnapshot")
+    @ParameterizedTest
+    @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForSnapshot")
     public void snapshotShouldNotBeAffectedByDroppingUnrelatedTables(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
         /* The objective of the test is to verify that when an unrelated table is dropped, it
            should not cause any harm to the existing flow. At the same time, if tablet split

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTabletSplitTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTabletSplitTest.java
@@ -35,7 +35,7 @@ public class YugabyteDBTabletSplitTest extends YugabyteDBContainerTestBase {
 
   @BeforeAll
   public static void beforeClass() throws SQLException {
-      initializeYBContainer("TEST_yb_enable_cdc_consistent_snapshot_streams=true", null);
+      initializeYBContainer();
       masterAddresses = getMasterAddress();
 
       TestHelper.dropAllSchemas();

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTabletSplitTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTabletSplitTest.java
@@ -14,6 +14,8 @@ import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.Struct;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.yb.client.GetTabletListToPollForCDCResponse;
 import org.yb.client.YBClient;
 import org.yb.client.YBTable;
@@ -33,7 +35,7 @@ public class YugabyteDBTabletSplitTest extends YugabyteDBContainerTestBase {
 
   @BeforeAll
   public static void beforeClass() throws SQLException {
-      initializeYBContainer();
+      initializeYBContainer("TEST_yb_enable_cdc_consistent_snapshot_streams=true", null);
       masterAddresses = getMasterAddress();
 
       TestHelper.dropAllSchemas();
@@ -56,12 +58,13 @@ public class YugabyteDBTabletSplitTest extends YugabyteDBContainerTestBase {
   }
 
   @Order(1)
-  @Test
-  public void shouldConsumeDataAfterTabletSplit() throws Exception {
+  @ParameterizedTest
+  @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+  public void shouldConsumeDataAfterTabletSplit(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
     TestHelper.dropAllSchemas();
     TestHelper.execute("CREATE TABLE t1 (id INT PRIMARY KEY, name TEXT) SPLIT INTO 1 TABLETS;");
 
-    String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
+    String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", consistentSnapshot, useSnapshot);
     Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
 
     startEngine(configBuilder, (success, message, error) -> {
@@ -124,8 +127,9 @@ public class YugabyteDBTabletSplitTest extends YugabyteDBContainerTestBase {
   }
 
   @Order(2)
-  @Test
-  public void reproduceSplitWhileTransactionIsNotFinishedWithAutomaticSplitting() throws Exception {
+  @ParameterizedTest
+  @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+  public void reproduceSplitWhileTransactionIsNotFinishedWithAutomaticSplitting(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
     // Stop, if ybContainer already running.
     if (ybContainer.isRunning()) {
       ybContainer.stop();
@@ -173,7 +177,7 @@ public class YugabyteDBTabletSplitTest extends YugabyteDBContainerTestBase {
                        + "1234567890123456789012345678901234567890123456789012345')"
                        + " SPLIT INTO 1 TABLETS;");
 
-    String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
+    String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", consistentSnapshot, useSnapshot);
     Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
 
     startEngine(configBuilder, (success, message, error) -> {

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionMetadataTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionMetadataTest.java
@@ -83,9 +83,9 @@ public class YugabyteDBTransactionMetadataTest extends YugabyteDBContainerTestBa
 		assertEndTransaction(metadataRecords.get(1), transactionId, 5, begin.getString("partition_id"));
 	}
 
-	@ParameterizedTest
-	@MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
-	public void assertMultipleTransactions(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
+    @ParameterizedTest
+    @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+    public void assertMultipleTransactions(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
 		String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_DB_NAME, "t1", consistentSnapshot, useSnapshot);
 		Configuration.Builder configBuilder = getConfigBuilderForMetadata(dbStreamId, "public.t1");
 
@@ -123,9 +123,9 @@ public class YugabyteDBTransactionMetadataTest extends YugabyteDBContainerTestBa
 		assertEquals(begin1.getString("partition_id"), begin2.getString("partition_id"));
 	}
 
-	@ParameterizedTest
-	@MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
-	public void verifyTransactionalDataAcrossMultipleTablets(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
+    @ParameterizedTest
+    @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+    public void verifyTransactionalDataAcrossMultipleTablets(boolean consistentSnapshot, boolean useSnapshot) throws Exception {
 		// This will lead to 2 tablets of range [lowest, 1000] and (1000, highest]
 		final String createTable =
 			"CREATE TABLE test_table (id INT, PRIMARY KEY(id ASC)) SPLIT AT VALUES ((1000));";

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionMetadataTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBTransactionMetadataTest.java
@@ -30,7 +30,7 @@ public class YugabyteDBTransactionMetadataTest extends YugabyteDBContainerTestBa
 
 	@BeforeAll
 	public static void beforeClass() throws SQLException {
-		initializeYBContainer("TEST_yb_enable_cdc_consistent_snapshot_streams=true", null);
+		initializeYBContainer();
 		TestHelper.dropAllSchemas();
 	}
 

--- a/src/test/java/io/debezium/connector/yugabytedb/common/YugabyteDBContainerTestBase.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/YugabyteDBContainerTestBase.java
@@ -28,7 +28,7 @@ public class YugabyteDBContainerTestBase extends TestBaseClass {
                                         : tserverFlags + ",cdc_state_checkpoint_update_interval_ms=0");
 
         if (masterFlags == null || masterFlags.isEmpty()) {
-            masterFlags = "--master_flags=rpc_bind_addresses=0.0.0.0";
+            masterFlags = "--master_flags=rpc_bind_addresses=0.0.0.0,TEST_yb_enable_cdc_consistent_snapshot_streams=true";
         } else {
             masterFlags = "--master_flags=rpc_bind_addresses=0.0.0.0," + masterFlags;
         }

--- a/src/test/java/io/debezium/connector/yugabytedb/common/YugabyteDBContainerTestBase.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/YugabyteDBContainerTestBase.java
@@ -30,7 +30,7 @@ public class YugabyteDBContainerTestBase extends TestBaseClass {
         if (masterFlags == null || masterFlags.isEmpty()) {
             masterFlags = "--master_flags=rpc_bind_addresses=0.0.0.0,TEST_yb_enable_cdc_consistent_snapshot_streams=true";
         } else {
-            masterFlags = "--master_flags=rpc_bind_addresses=0.0.0.0," + masterFlags;
+            masterFlags = "--master_flags=rpc_bind_addresses=0.0.0.0,TEST_yb_enable_cdc_consistent_snapshot_streams=true," + masterFlags;
         }
 
         logger.info("tserver flags: {}", finalTserverFlags);


### PR DESCRIPTION
Recently consistent snapshot streams have been introduced on the server side. All the connector tests currently run with the older streams. This PR provides support to run all the connector tests using older config model (`stream.id` and `table.include.list`) with the newly introduced consistent snapshot streams along with the older streams.