### PR TITLE
Added identification marker for last snapshot record of the last batch

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -508,7 +508,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                   // If the checkpoint in tabletToExplicitCheckpoint map corresponds to the last record's checkpoint
                   // of last snapshot batch, it means kafka has consumed the last record. So, we should
                   // not poll on this tablet anymore, instead mark snapshot done for this tablet.
-                  if(checkpoint != null && IsLastSnapshotRecordOfLastBatch(OpId.from(checkpoint))) {
+                  if (checkpoint != null && isLastSnapshotRecordOfLastBatch(OpId.from(checkpoint))) {
                     LOGGER.debug("Already received the last record's modified checkpoint in kafka's callback. " +
                             "Discontinuing polling on tablet {}", part.getId());
                     LOGGER.info("Adding {} to the list of snapshot completed tablets", part.getId());
@@ -552,7 +552,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
 
                 // Process the response
                 for (int idx = 0; idx < resp.getResp().getCdcSdkProtoRecordsList().size(); idx++) {
-                  CdcService.CDCSDKProtoRecordPB record = resp.getResp().getCdcSdkProtoRecordsList().get(idx);
+                  CdcService.CDCSDKProtoRecordPB record = resp.getResp().getCdcSdkProtoRecords(idx);
                   CdcService.RowMessage m = record.getRowMessage();
                   YbProtoReplicationMessage message =
                     new YbProtoReplicationMessage(m, this.yugabyteDbTypeRegistry);
@@ -615,9 +615,9 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                         }
                         Objects.requireNonNull(tId);
 
-                        // if the DML record is the last snapshot record of the last snapshot batch, set all the fields
+                        // If the DML record is the last snapshot record of the last snapshot batch, set all the fields
                         // of Opid to max values and snapshot key to LAST_SNAPSHOT_RECORD.
-                        if(isSnapshotCompleteMarker(finalOpId) &&
+                        if (isSnapshotCompleteMarker(finalOpId) &&
                                 (idx == (resp.getResp().getCdcSdkProtoRecordsList().size() - 1))) {
                           LOGGER.info("Modifying record checkpoint for last snapshot record of the last snapshot batch");
                           setIdentificationMarkerForLastSnapshotRecord(lsn);
@@ -788,7 +788,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
       }
 
       OpId opId = OpId.from(this.tabletToExplicitCheckpoint.get(partition.getId()));
-      if (IsLastSnapshotRecordOfLastBatch(opId)) {
+      if (isLastSnapshotRecordOfLastBatch(opId)) {
         LOGGER.info("Adding tablet {} to snapshot completed list", partition.getId());
         snapshotCompletedTablets.add(partition.getId());
         markSnapshotDoneOnServer(partition, offsetContext);
@@ -843,7 +843,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
     recordCheckpoint.setTime(Long.MAX_VALUE);
   }
 
-  private Boolean IsLastSnapshotRecordOfLastBatch(OpId opid) {
+  private Boolean isLastSnapshotRecordOfLastBatch(OpId opid) {
     String snapshotKey = ByteString.copyFrom(opid.getKey()).toStringUtf8();
     return (opid.getTerm() == Long.MAX_VALUE) &&
             (opid.getIndex() == Long.MAX_VALUE) &&

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -559,7 +559,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
 
                   String pgSchemaName = m.getPgschemaName();
 
-                  final OpId lsn = new OpId(record.getCdcSdkOpId().getTerm(),
+                  OpId lsn = new OpId(record.getCdcSdkOpId().getTerm(),
                                             record.getCdcSdkOpId().getIndex(),
                                             record.getCdcSdkOpId().getWriteIdKey().toByteArray(),
                                             record.getCdcSdkOpId().getWriteId(),
@@ -620,7 +620,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                         if (isSnapshotCompleteMarker(finalOpId) &&
                                 (idx == (resp.getResp().getCdcSdkProtoRecordsList().size() - 1))) {
                           LOGGER.info("Modifying record checkpoint for last snapshot record of the last snapshot batch");
-                          setIdentificationMarkerForLastSnapshotRecord(lsn);
+                          lsn = getIdentificationMarkerForLastSnapshotRecord();
                         }
                       }
 
@@ -832,15 +832,12 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
 
   /**
    * Last snapshot record of the last snapshot batch will have a unique marker that will be used for indentification.
-   * Set all the fields of the record's Checkpoint to max values and set snapshot key to 'LAST_SNAPSHOT_RECORD'
+   * Set all the fields of the record's Checkpoint to max values and set the snapshot key to 'LAST_SNAPSHOT_RECORD'
    * @param recordCheckpoint the record's checkpoint of the last snapshot record
    */
-  private void setIdentificationMarkerForLastSnapshotRecord(OpId recordCheckpoint) {
-    recordCheckpoint.setTerm(Long.MAX_VALUE);
-    recordCheckpoint.setIndex(Long.MAX_VALUE);
-    recordCheckpoint.setKey(LAST_SNAPSHOT_RECORD_KEY);
-    recordCheckpoint.setWriteId(Integer.MAX_VALUE);
-    recordCheckpoint.setTime(Long.MAX_VALUE);
+  private OpId getIdentificationMarkerForLastSnapshotRecord() {
+    byte[] lastSnapshotRecordKey = ByteString.copyFromUtf8(LAST_SNAPSHOT_RECORD_KEY).toByteArray();
+    return new OpId(Long.MAX_VALUE, Long.MAX_VALUE, lastSnapshotRecordKey, Integer.MAX_VALUE, Long.MAX_VALUE);
   }
 
   private Boolean isLastSnapshotRecordOfLastBatch(OpId opid) {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -13,6 +13,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.google.protobuf.ByteString;
 import io.debezium.connector.yugabytedb.connection.HashPartition;
 import io.debezium.connector.yugabytedb.util.YugabyteDBConnectorUtils;
 import io.debezium.pipeline.source.AbstractSnapshotChangeEventSource;
@@ -79,6 +80,8 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
     protected List<HashPartition> partitionRanges;
 
     private boolean snapshotComplete = false;
+
+    private final String LAST_SNAPSHOT_RECORD_KEY = "LAST_SNAPSHOT_RECORD";
 
     public YugabyteDBSnapshotChangeEventSource(YugabyteDBConnectorConfig connectorConfig,
                                                YugabyteDBTaskContext taskContext,
@@ -500,7 +503,21 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
 
                 CdcSdkCheckpoint explicitCdcSdkCheckpoint = null;
                 if (taskContext.shouldEnableExplicitCheckpointing()) {
-                  explicitCdcSdkCheckpoint = tabletToExplicitCheckpoint.get(part.getId());
+                  CdcSdkCheckpoint checkpoint = tabletToExplicitCheckpoint.get(part.getId());
+
+                  // If the checkpoint in tabletToExplicitCheckpoint map corresponds to the last record's checkpoint
+                  // of last snapshot batch, it means kafka has consumed the last record. So, we should
+                  // not poll on this tablet anymore, instead mark snapshot done for this tablet.
+                  if(IsLastSnapshotRecordOfLastBatch(OpId.from(checkpoint))) {
+                    LOGGER.debug("Already received the last record's modified checkpoint in kafka's callback. " +
+                            "Discontinuing polling on tablet {}", part.getId());
+                    LOGGER.info("Adding {} to the list of snapshot completed tablets", part.getId());
+                    snapshotCompletedTablets.add(part.getId());
+                    markSnapshotDoneOnServer(part, previousOffset);
+                    tabletsWaitingForCallback.removeIf(t -> t.equals(part.getId()));
+                    continue;
+                  }
+                  explicitCdcSdkCheckpoint = checkpoint;
                 }
 
                 OpId cp = previousOffset.snapshotLSN(part);
@@ -529,9 +546,13 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
 
                 tabletSafeTime.put(part.getId(), resp.getResp().getSafeHybridTime());
 
+                OpId finalOpId = new OpId(resp.getTerm(), resp.getIndex(), resp.getKey(),
+                        resp.getWriteId(), resp.getSnapshotTime());
+                LOGGER.debug("Final OpId for tablet {} is {}", part.getId(), finalOpId);
+
                 // Process the response
-                for (CdcService.CDCSDKProtoRecordPB record :
-                        resp.getResp().getCdcSdkProtoRecordsList()) {
+                for (int idx = 0; idx < resp.getResp().getCdcSdkProtoRecordsList().size(); idx++) {
+                  CdcService.CDCSDKProtoRecordPB record = resp.getResp().getCdcSdkProtoRecordsList().get(idx);
                   CdcService.RowMessage m = record.getRowMessage();
                   YbProtoReplicationMessage message =
                     new YbProtoReplicationMessage(m, this.yugabyteDbTypeRegistry);
@@ -593,6 +614,14 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                           tId = YugabyteDBSchema.parseWithKeyspace(message.getTable(), connectorConfig.databaseName());
                         }
                         Objects.requireNonNull(tId);
+
+                        // if the DML record is the last snapshot record of the last snapshot batch, set all the fields
+                        // of Opid to max values and snapshot key to LAST_SNAPSHOT_RECORD.
+                        if(isSnapshotCompleteMarker(finalOpId) &&
+                                (idx == (resp.getResp().getCdcSdkProtoRecordsList().size() - 1))) {
+                          LOGGER.info("Modifying record checkpoint for last snapshot record of the last snapshot batch");
+                          setIdentificationMarkerForLastSnapshotRecord(lsn);
+                        }
                       }
 
                       // In case of snapshots, we do not want to ignore tableUUID while updating
@@ -617,10 +646,6 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                     throw e;
                   }
                 }
-
-                OpId finalOpId = new OpId(resp.getTerm(), resp.getIndex(), resp.getKey(),
-                                          resp.getWriteId(), resp.getSnapshotTime());
-                LOGGER.debug("Final OpId for tablet {} is {}", part.getId(), finalOpId);
 
                 // If the response doesn't have any record, it is safe to assume that we should not wait
                 // for the callback to come and that we can proceed further in processing this particular tablet.
@@ -763,7 +788,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
       }
 
       OpId opId = OpId.from(this.tabletToExplicitCheckpoint.get(partition.getId()));
-      if (isSnapshotCompleteMarker(opId)) {
+      if (IsLastSnapshotRecordOfLastBatch(opId)) {
         LOGGER.info("Adding tablet {} to snapshot completed list", partition.getId());
         snapshotCompletedTablets.add(partition.getId());
         markSnapshotDoneOnServer(partition, offsetContext);
@@ -803,6 +828,28 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
       }
     }
 
+  }
+
+  /**
+   * Last snapshot record of the last snapshot batch will have a unique marker that will be used for indentification.
+   * Set all the fields of the record's Checkpoint to max values and set snapshot key to 'LAST_SNAPSHOT_RECORD'
+   * @param recordCheckpoint the record's checkpoint of the last snapshot record
+   */
+  private void setIdentificationMarkerForLastSnapshotRecord(OpId recordCheckpoint) {
+    recordCheckpoint.setTerm(Long.MAX_VALUE);
+    recordCheckpoint.setIndex(Long.MAX_VALUE);
+    recordCheckpoint.setKey(LAST_SNAPSHOT_RECORD_KEY);
+    recordCheckpoint.setWriteId(Integer.MAX_VALUE);
+    recordCheckpoint.setTime(Long.MAX_VALUE);
+  }
+
+  private Boolean IsLastSnapshotRecordOfLastBatch(OpId opid) {
+    String snapshotKey = ByteString.copyFrom(opid.getKey()).toStringUtf8();
+    return (opid.getTerm() == Long.MAX_VALUE) &&
+            (opid.getIndex() == Long.MAX_VALUE) &&
+            (opid.getWrite_id() == Integer.MAX_VALUE) &&
+            (opid.getTime() == Long.MAX_VALUE) &&
+            (snapshotKey.equals(LAST_SNAPSHOT_RECORD_KEY));
   }
 
     /**

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -508,7 +508,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                   // If the checkpoint in tabletToExplicitCheckpoint map corresponds to the last record's checkpoint
                   // of last snapshot batch, it means kafka has consumed the last record. So, we should
                   // not poll on this tablet anymore, instead mark snapshot done for this tablet.
-                  if(IsLastSnapshotRecordOfLastBatch(OpId.from(checkpoint))) {
+                  if(checkpoint != null && IsLastSnapshotRecordOfLastBatch(OpId.from(checkpoint))) {
                     LOGGER.debug("Already received the last record's modified checkpoint in kafka's callback. " +
                             "Discontinuing polling on tablet {}", part.getId());
                     LOGGER.info("Adding {} to the list of snapshot completed tablets", part.getId());

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -619,7 +619,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                         // of Opid to max values and snapshot key to LAST_SNAPSHOT_RECORD.
                         if (isSnapshotCompleteMarker(finalOpId) &&
                                 (idx == (resp.getResp().getCdcSdkProtoRecordsList().size() - 1))) {
-                          LOGGER.info("Modifying record checkpoint for last snapshot record of the last snapshot batch");
+                          LOGGER.debug("Modifying record checkpoint for last snapshot record of the last snapshot batch");
                           lsn = getIdentificationMarkerForLastSnapshotRecord();
                         }
                       }

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
@@ -66,26 +66,6 @@ public class OpId implements Comparable<OpId> {
         return Base64.getDecoder().decode(keyString);
     }
 
-    public void setTerm(long term) {
-        this.term = term;
-    }
-
-    public void setIndex(long index) {
-        this.index = index;
-    }
-
-    public void setWriteId(int writeId) {
-        this.write_id = writeId;
-    }
-
-    public void setKey(String key) {
-        this.key = ByteString.copyFromUtf8(key).toByteArray();
-    }
-
-    public void setTime(long time) {
-        this.time = time;
-    }
-
     public static OpId valueOf(String stringId) {
         if (stringId != null && !stringId.isEmpty()) {
             String[] arr = stringId.split(":");

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
@@ -3,6 +3,7 @@ package io.debezium.connector.yugabytedb.connection;
 import java.util.Arrays;
 import java.util.Base64;
 
+import com.google.protobuf.ByteString;
 import org.yb.cdc.CdcService.CDCSDKCheckpointPB;
 
 import com.google.common.base.Objects;
@@ -63,6 +64,26 @@ public class OpId implements Comparable<OpId> {
         }
 
         return Base64.getDecoder().decode(keyString);
+    }
+
+    public void setTerm(long term) {
+        this.term = term;
+    }
+
+    public void setIndex(long index) {
+        this.index = index;
+    }
+
+    public void setWriteId(int writeId) {
+        this.write_id = writeId;
+    }
+
+    public void setKey(String key) {
+        this.key = ByteString.copyFromUtf8(key).toByteArray();
+    }
+
+    public void setTime(long time) {
+        this.time = time;
     }
 
     public static OpId valueOf(String stringId) {

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -730,6 +730,154 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         YugabyteDBStreamingChangeEventSource.TEST_WAIT_BEFORE_GETTING_CHILDREN = false;
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void snapshotTwoColocatedNonEmptyAndNonColocatedEmptyThenStream(boolean colocation) throws Exception {
+        /* The objective of this test is to verify that we are able to consume all snapshot records on a
+            combination of empty & non-empty tables and successfully switch to streaming phase and consume
+            the streaming records for all the tables.
+         */
+
+        // Create tables.
+        createTables(colocation);
+
+        // 2 colocated non-empty tables + 1 colocated empty table + 1 non-colocated empty table
+        final int recordCountForTest1 = 1000;
+        final int recordCountForTest2 = 2000;
+        insertBulkRecords(recordCountForTest1, "public.test_1");
+        insertBulkRecords(recordCountForTest2, "public.test_2");
+
+        String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
+        Configuration.Builder configBuilder =
+                TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME, "public.test_1,public.test_2,public.test_3,public.test_no_colocated", dbStreamId);
+        configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE,
+                YugabyteDBConnectorConfig.SnapshotMode.INITIAL.getValue());
+
+        // Enable the failure flag to introduce an explicit failure.
+        YugabyteDBSnapshotChangeEventSource.FAIL_AFTER_BOOTSTRAP_GET_CHANGES = true;
+        startEngine(configBuilder);
+
+        // Since we have specified the failure flag, we should not get any snapshot and
+        // connector would fail after the first GetChanges call to all the tablets. Verify that
+        // we haven't received any record even after waiting for a minute.
+        TestHelper.waitFor(Duration.ofMinutes(1));
+        assertNoRecordsToConsume();
+
+        // Stop the connector.
+        stopConnector();
+
+        // Disable the failure flag so that execution can happen normally.
+        YugabyteDBSnapshotChangeEventSource.FAIL_AFTER_BOOTSTRAP_GET_CHANGES = false;
+        startEngine(configBuilder);
+
+        // Wait until connector is started.
+        awaitUntilConnectorIsReady();
+
+        List<SourceRecord> recordsForTest1 = new ArrayList<>();
+        List<SourceRecord> recordsForTest2 = new ArrayList<>();
+        List<SourceRecord> recordsForTest3 = new ArrayList<>();
+        List<SourceRecord> recordsForNonColocated = new ArrayList<>();
+
+        final int totalStreamingRecords = insertStreamingRecordsInAllTables();
+
+        List<SourceRecord> records = new ArrayList<>();
+
+        waitAndFailIfCannotConsume(records, recordCountForTest1 + recordCountForTest2 + totalStreamingRecords);
+
+        // Iterate over the records and add them to their respective topic
+        for (SourceRecord record : records) {
+            if (record.topic().equals(TestHelper.TEST_SERVER + ".public.test_1")) {
+                recordsForTest1.add(record);
+            } else if (record.topic().equals(TestHelper.TEST_SERVER + ".public.test_2")) {
+                recordsForTest2.add(record);
+            } else if (record.topic().equals(TestHelper.TEST_SERVER + ".public.test_3")) {
+                recordsForTest3.add(record);
+            } else if (record.topic().equals(TestHelper.TEST_SERVER + ".public.test_no_colocated")) {
+                recordsForNonColocated.add(record);
+            }
+        }
+
+        assertEquals(recordCountForTest1 + 101, recordsForTest1.size());
+        assertEquals(recordCountForTest2 + 201, recordsForTest2.size());
+        assertEquals(301, recordsForTest3.size());
+        assertEquals(401, recordsForNonColocated.size());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void snapshotTwoColocatedNonEmptyAndNonColocatedNonEmptyThenStream(boolean colocation) throws Exception {
+        /* The objective of this test is to verify that we are able to consume all snapshot records on a
+            combination of empty & non-empty tables and successfully switch to streaming phase and consume
+            the streaming records for all the tables.
+         */
+        // Create tables.
+        createTables(colocation);
+
+        // 2 colocated non-empty tables + 1 colocated empty table + 1 non-colocated non-empty table
+        final int recordCountForTest1 = 1000;
+        final int recordCountForTest2 = 2000;
+        final int recordCountInNonColocated = 2000;
+        insertBulkRecords(recordCountForTest1, "public.test_1");
+        insertBulkRecords(recordCountForTest2, "public.test_2");
+        insertBulkRecords(recordCountInNonColocated, "public.test_no_colocated");
+
+        String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
+        Configuration.Builder configBuilder =
+                TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME, "public.test_1,public.test_2,public.test_3,public.test_no_colocated", dbStreamId);
+        configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE,
+                YugabyteDBConnectorConfig.SnapshotMode.INITIAL.getValue());
+
+        // Enable the failure flag to introduce an explicit failure.
+        YugabyteDBSnapshotChangeEventSource.FAIL_AFTER_BOOTSTRAP_GET_CHANGES = true;
+        startEngine(configBuilder);
+
+        // Since we have specified the failure flag, we should not get any snapshot and
+        // connector would fail after the first GetChanges call to all the tablets. Verify that
+        // we haven't received any record even after waiting for a minute.
+        TestHelper.waitFor(Duration.ofMinutes(1));
+        assertNoRecordsToConsume();
+
+        // Stop the connector.
+        stopConnector();
+
+        // Disable the failure flag so that execution can happen normally.
+        YugabyteDBSnapshotChangeEventSource.FAIL_AFTER_BOOTSTRAP_GET_CHANGES = false;
+        startEngine(configBuilder);
+
+        // Wait until connector is started.
+        awaitUntilConnectorIsReady();
+
+        List<SourceRecord> recordsForTest1 = new ArrayList<>();
+        List<SourceRecord> recordsForTest2 = new ArrayList<>();
+        List<SourceRecord> recordsForTest3 = new ArrayList<>();
+        List<SourceRecord> recordsForNonColocated = new ArrayList<>();
+
+        final int totalStreamingRecords = insertStreamingRecordsInAllTables();
+
+        List<SourceRecord> records = new ArrayList<>();
+
+        waitAndFailIfCannotConsume(records, recordCountForTest1 + recordCountForTest2 + recordCountInNonColocated + totalStreamingRecords);
+
+
+        // Iterate over the records and add them to their respective topic
+        for (SourceRecord record : records) {
+            if (record.topic().equals(TestHelper.TEST_SERVER + ".public.test_1")) {
+                recordsForTest1.add(record);
+            } else if (record.topic().equals(TestHelper.TEST_SERVER + ".public.test_2")) {
+                recordsForTest2.add(record);
+            } else if (record.topic().equals(TestHelper.TEST_SERVER + ".public.test_3")) {
+                recordsForTest3.add(record);
+            } else if (record.topic().equals(TestHelper.TEST_SERVER + ".public.test_no_colocated")) {
+                recordsForNonColocated.add(record);
+            }
+        }
+
+        assertEquals(recordCountForTest1 + 101, recordsForTest1.size());
+        assertEquals(recordCountForTest2 + 201, recordsForTest2.size());
+        assertEquals(301, recordsForTest3.size());
+        assertEquals(recordCountInNonColocated + 401, recordsForNonColocated.size());
+    }
+
     /**
      * Helper function to create the required tables in the database DEFAULT_COLOCATED_DB_NAME
      */
@@ -777,5 +925,21 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
 
     private void verifyRecordCount(long recordsCount) {
         waitAndFailIfCannotConsume(new ArrayList<>(), recordsCount);
+    }
+
+    private int insertStreamingRecordsInAllTables() {
+        // Inserting 1001 records to test_1
+        TestHelper.executeInDatabase("INSERT INTO test_1 VALUES (generate_series(1000, 1100));", DEFAULT_COLOCATED_DB_NAME);
+
+        // Inserting 2001 records to test_1
+        TestHelper.executeInDatabase("INSERT INTO test_2 VALUES (generate_series(2000, 2200));", DEFAULT_COLOCATED_DB_NAME);
+
+        // Inserting 3001 records to test_3
+        TestHelper.executeInDatabase("INSERT INTO test_3 VALUES (generate_series(3000, 3300));", DEFAULT_COLOCATED_DB_NAME);
+
+        // Inserting 4001 records to test_no_colocated
+        TestHelper.executeInDatabase("INSERT INTO test_no_colocated VALUES (generate_series(4000, 4400));", DEFAULT_COLOCATED_DB_NAME);
+        final int totalRecordsInserted = 101 + 201 + 301 + 401;
+        return totalRecordsInserted;
     }
 }


### PR DESCRIPTION
### Problem

There are 2 types of checkpoints received in the GetChanges response: Record's checkpoint and Response checkpoint. The service, while sending the last batch of snapshot records, sends the snapshot complete marker (key = "", write_id = 0, snapshot_time = 0) only in the response checkpoint. No record checkpoint will ever contain the snapshot complete marker.

Logic for removing tablet from `tabletsWaitingForCallback` set:
Tablets that are part of `tabletsWaitingForCallback` set are only removed when we receive snapshot complete marker (key = "", write_id = 0, snapshot_time = 0) in kafka's callback.  But the problem is, from the connector, we only send the record's checkpoint to kafka. So, as discussed above, we would never receive snapshot complete marker in kafka's callback. Therefore, we would never remove the tablets from this set and the connector would be stuck in the snapshot phase. We need a different identification marker for the last snapshot record of the last batch so that we can remove tablets on receiving kafka's callack for the last record.


### Solution
Modify the record checkpoint of last snapshot record of the last batch. The last record's checkoint will be set to the following:

- term = Long.MAX
- index = Long.MAX
- write_id = Integer.MAX
- time = Long.MAX
- snapshot_key = "LAST_SNAPSHOT_RECORD

Use the same field values to validate and remove tablets from the `tabletsWaitingForCallback` set accordingly. 

We also need to ensure that this record checkpoint is never sent as the explicit checkpoint in a GetChanges call. So, if we have received this modified checkpoint from kafka, we should stop polling on such tablets since kafka has already consumed all the snapshot records. 


NOTE: This solution works only in conjunction with this [PR](https://github.com/yugabyte/debezium-connector-yugabytedb/pull/302) because based on this PR's logic, we add tablets to the  `tabletsWaitingForCallback` set.


### Testing

- Ran the existing snapshot tests  
- Added two new tests where we restart connector after snapshot bootstrap and verify that we receive all records (snapshot + streaming).