### PR TITLE
[yugabyte/yugabyte-db#20243] Fix regression in streaming colocated tables

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
@@ -373,10 +373,7 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
                     List<HashPartition> partitions = new ArrayList<>();
                     LOGGER.info("TabletCheckpointPair list size for table {}: {}", tableId, resp.getTabletCheckpointPairListSize());
                     for (TabletCheckpointPair pair : resp.getTabletCheckpointPairList()) {
-                        HashPartition tempPartition =
-                            new HashPartition(tableId, pair.getTabletLocations().getTabletId().toStringUtf8(),
-                              pair.getTabletLocations().getPartition().getPartitionKeyStart().toByteArray(),
-                              pair.getTabletLocations().getPartition().getPartitionKeyEnd().toByteArray());
+                        HashPartition tempPartition = HashPartition.from(pair, tableId);
 
                         partitions.add(tempPartition);
                         this.hashRanges.add(tempPartition);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
@@ -67,7 +67,7 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
 
                 GetTabletListToPollForCDCResponse resp =
                         YBClientUtils.getTabletListToPollForCDCWithRetry(table, tId, connectorConfig);
-                populateTableToTabletPairsForTask(resp, tabletPairList);
+                populateTableToTabletPairsForTask(tId, resp, tabletPairList);
                 tabletListResponse.put(tId, resp);
             }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/HashPartition.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/HashPartition.java
@@ -239,10 +239,10 @@ public class HashPartition implements Comparable<HashPartition>, Serializable {
    * @param tabletCheckpointPair a {@link org.yb.cdc.CdcService.TabletCheckpointPair}  from the {@link org.yb.client.GetTabletListToPollForCDCResponse}
    * @return {@link HashPartition}
    */
-  public static HashPartition from(CdcService.TabletCheckpointPair tabletCheckpointPair) {
+  public static HashPartition from(CdcService.TabletCheckpointPair tabletCheckpointPair, String tableId) {
     // TODO: The tableId returned in case of colocated tables is not the correct table ID here.
     //  We only get the parent colocated ID in the response, this behaviour needs to be fixed on service.
-    return new HashPartition(tabletCheckpointPair.getTabletLocations().getTableId().toStringUtf8(),
+    return new HashPartition(tableId,
       tabletCheckpointPair.getTabletLocations().getTabletId().toStringUtf8(),
       tabletCheckpointPair.getTabletLocations().getPartition().getPartitionKeyStart().toByteArray(),
       tabletCheckpointPair.getTabletLocations().getPartition().getPartitionKeyEnd().toByteArray());
@@ -258,11 +258,11 @@ public class HashPartition implements Comparable<HashPartition>, Serializable {
    * @param response of type {@link GetTabletListToPollForCDCResponse}
    * @return a list of {@link HashPartition}
    */
-  public static List<HashPartition> from(GetTabletListToPollForCDCResponse response) {
+  public static List<HashPartition> getListFrom(GetTabletListToPollForCDCResponse response, String tableId) {
     List<HashPartition> result = new ArrayList<>();
 
     for (CdcService.TabletCheckpointPair tcp : response.getTabletCheckpointPairList()) {
-      result.add(from(tcp));
+      result.add(from(tcp, tableId));
     }
 
     return result;

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/HashPartition.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/HashPartition.java
@@ -240,6 +240,8 @@ public class HashPartition implements Comparable<HashPartition>, Serializable {
    * @return {@link HashPartition}
    */
   public static HashPartition from(CdcService.TabletCheckpointPair tabletCheckpointPair) {
+    // TODO: The tableId returned in case of colocated tables is not the correct table ID here.
+    //  We only get the parent colocated ID in the response, this behaviour needs to be fixed on service.
     return new HashPartition(tabletCheckpointPair.getTabletLocations().getTableId().toStringUtf8(),
       tabletCheckpointPair.getTabletLocations().getTabletId().toStringUtf8(),
       tabletCheckpointPair.getTabletLocations().getPartition().getPartitionKeyStart().toByteArray(),


### PR DESCRIPTION
## Problem

After the connector changes for tablet split in this [commit](https://github.com/yugabyte/debezium-connector-yugabytedb/commit/78ab3261f2033be6753b58fbda81625d8fde7800), the connector tests on colocated tables have started failing. The test failures can be seen in `YugabyteDBColocatedTablesTest` and `YugabyteDBSnapshotTest` classes. This was identified as a regression for colocated tables.

## Solution

We were relying on the `TabletLocationsPB` object to give us the table ID, however, in case of colocated tables, we only get the colocated parent id which is same for all the colocated tables and is not useful to us. This PR solves the problem by leveraging the table ID from the `YBTable` object and using the same to create the `HashPartition`

This closes yugabyte/yugabyte-db#20243