### PR TITLE
Added test to repro data loss of last snapshot batch

### DIFF
--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotResumeTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotResumeTest.java
@@ -162,7 +162,6 @@ public class YugabyteDBSnapshotResumeTest extends YugabyteDBContainerTestBase {
 
 		// Wait for kafka to receive all the expected records before consuming records from kafka topic.
 		Awaitility.await()
-				.atLeast(Duration.ofSeconds(1))
 				.atMost(Duration.ofSeconds(180))
 				.until(() -> (getNonConsumedRecordCount() == totalRecordExpectedAfterPartialConsumption));
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotResumeTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotResumeTest.java
@@ -22,9 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Basic unit tests to ensure proper working of snapshot resuming functionality - the connector
@@ -135,19 +133,20 @@ public class YugabyteDBSnapshotResumeTest extends YugabyteDBContainerTestBase {
 	}
 
 	@ParameterizedTest
-    @ValueSource(booleans = {true, false})
-	public void VerifyNoDataLossIfConnectorRestartDuringLastBatchConsumption(boolean colocation) throws Exception {
-		/**
-		 * The objective of this test is to verify the connector starts in the snapshot phase and 
-		 * consumes the all the snapshot records before switching to streaming phase in the 
+	@ValueSource(booleans = {true, false})
+	public void verifyNoDataLossIfConnectorRestartDuringLastBatchConsumption (boolean colocation) throws Exception {
+		/*
+		 * The objective of this test is to verify the connector starts in the snapshot phase and
+		 * consumes the all the snapshot records before switching to streaming phase in the
 		 * following scenario: Connector restarts after it has received the last snapshot batch but
-		 * kafka hasnt fully consumed the last batch. 
+		 * kafka hasn't fully consumed the last batch.
 		 */
 		TestHelper.dropAllSchemas();
 		TestHelper.executeDDL("yugabyte_create_tables.ddl");
 		createTables(colocation);
 
 		final int recordsCount = 1000;
+		final int totalRecordExpectedAfterPartialConsumption = recordsCount - snapshotBatchSize / 2;
 
 		insertBulkRecords(recordsCount, "public.test_1");
 
@@ -156,17 +155,22 @@ public class YugabyteDBSnapshotResumeTest extends YugabyteDBContainerTestBase {
 		String dbStreamId = TestHelper.getNewDbStreamId("colocated_database", "test_1");
 		Configuration.Builder configBuilder = TestHelper.getConfigBuilder("colocated_database", "public.test_1", dbStreamId);
 		configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE, YugabyteDBConnectorConfig.SnapshotMode.INITIAL.getValue());
-		startEngineWithPartialConsumptionOfLastBatch(configBuilder, recordsCount);
+
+		// Explicitly avoid sending half of the last batch to kafka
+		startEngineWithPartialConsumptionOfLastBatch(configBuilder, totalRecordExpectedAfterPartialConsumption);
 		awaitUntilConnectorIsReady();
 
-		// Wait for the connector to complete all the GetChanges call and push all the records to 
-		// the in-memory queue during snapshot phase.
-		TestHelper.waitFor(Duration.ofMinutes(1));
-		// Consume 976 records (1 DDL + 950 + 25 from last batch)
-		int totalConsumedSoFar = consumeByTopic(976).recordsForTopic("test_server.public.test_1").size();
+		// Wait for kafka to receive all the expected records before consuming records from kafka topic.
+		Awaitility.await()
+				.atLeast(Duration.ofSeconds(1))
+				.atMost(Duration.ofSeconds(180))
+				.until(() -> (getNonConsumedRecordCount() == totalRecordExpectedAfterPartialConsumption));
+
+		// Consume 975 records (950 + 25 from last batch)
+		int totalConsumedSoFar = consumeByTopic(totalRecordExpectedAfterPartialConsumption).recordsForTopic("test_server.public.test_1").size();
 		assertNoRecordsToConsume();
 
-		// Kill the connector after some seconds and consume whatever data is available.
+		// Kill the connector
 		stopConnector();
 	
 		// The last set explicit checkpoint can be obtained from the static variable.
@@ -183,7 +187,7 @@ public class YugabyteDBSnapshotResumeTest extends YugabyteDBContainerTestBase {
 
 		assertEquals(lastExplicitCheckpoint.getTerm(), resp.getTerm());
 		assertEquals(lastExplicitCheckpoint.getIndex(), resp.getIndex());
-		assertTrue(Arrays.equals(lastExplicitCheckpoint.getKey(), resp.getSnapshotKey()));
+    assertArrayEquals(lastExplicitCheckpoint.getKey(), resp.getSnapshotKey());
 		
 		// Restart the connector
 		YugabyteDBSnapshotChangeEventSource.TRACK_EXPLICIT_CHECKPOINTS = false;
@@ -191,14 +195,13 @@ public class YugabyteDBSnapshotResumeTest extends YugabyteDBContainerTestBase {
 		awaitUntilConnectorIsReady();
 
 		List<SourceRecord> recordsAfterRestart = new ArrayList<>();
+
 		// We should receive the last 2 snapshot batch (500 records) again since we will be setting 
-		// from_op_id to the last explicit checkpoint (points to start of 2nd last record) sent to the server 
+		// from_op_id to the last explicit checkpoint (that points to start of the 2nd last batch) sent to the server
 		// during the snapshot phase.
 		waitAndFailIfCannotConsume(recordsAfterRestart, 2 * snapshotBatchSize);
-
 		LOGGER.info("Remaining consumed record count: {}", recordsAfterRestart.size());
 		assertNotEquals(totalConsumedSoFar, recordsAfterRestart.size());
-
 		assertEquals(2 * snapshotBatchSize, recordsAfterRestart.size());
 	}
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotResumeTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotResumeTest.java
@@ -132,7 +132,7 @@ public class YugabyteDBSnapshotResumeTest extends YugabyteDBContainerTestBase {
 		YugabyteDBSnapshotChangeEventSource.TRACK_EXPLICIT_CHECKPOINTS = false;
 	}
 
-	@ParameterizedTest
+  @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void verifyNoDataLossIfConnectorRestartDuringLastBatchConsumption (boolean colocation) throws Exception {
     /*

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -926,51 +926,6 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         YugabyteDBSnapshotChangeEventSource.FAIL_WHEN_MARKING_SNAPSHOT_DONE = false;
     }
 
-    /**
-     * Helper function to create the required tables in the database DEFAULT_COLOCATED_DB_NAME
-     */
-    private void createTables(boolean colocation) {
-        LOGGER.info("Creating tables with colocation: {}", colocation);
-        final String createTest1 = String.format("CREATE TABLE test_1 (id INT PRIMARY KEY," +
-                                                 "name TEXT DEFAULT 'Vaibhav Kushwaha') " +
-                                                  "WITH (COLOCATION = %b);", colocation);
-        final String createTest2 = String.format("CREATE TABLE test_2 (text_key TEXT PRIMARY " +
-                                                 "KEY) WITH (COLOCATION = %b);", colocation);
-        final String createTest3 =
-          String.format("CREATE TABLE test_3 (hours FLOAT PRIMARY KEY, " +
-                        "hours_in_text VARCHAR(40) DEFAULT 'some_default_hour_value') " +
-                        "WITH (COLOCATION = %b);", colocation);
-        final String createTestNoColocated = "CREATE TABLE test_no_colocated (id INT PRIMARY KEY," +
-                                             "name TEXT DEFAULT 'name_for_non_colocated') " +
-                                             "WITH (COLOCATION = false) SPLIT INTO 3 TABLETS;";
-
-        TestHelper.executeInDatabase(createTest1, DEFAULT_COLOCATED_DB_NAME);
-        TestHelper.executeInDatabase(createTest2, DEFAULT_COLOCATED_DB_NAME);
-        TestHelper.executeInDatabase(createTest3, DEFAULT_COLOCATED_DB_NAME);
-        TestHelper.executeInDatabase(createTestNoColocated, DEFAULT_COLOCATED_DB_NAME);
-    }
-
-    /**
-     * Helper function to drop all the tables being created as a part of this test.
-     */
-    private void dropAllTables() {
-        TestHelper.executeInDatabase("DROP TABLE IF EXISTS test_1;", DEFAULT_COLOCATED_DB_NAME);
-        TestHelper.executeInDatabase("DROP TABLE IF EXISTS test_2;", DEFAULT_COLOCATED_DB_NAME);
-        TestHelper.executeInDatabase("DROP TABLE IF EXISTS test_3;", DEFAULT_COLOCATED_DB_NAME);
-        TestHelper.executeInDatabase("DROP TABLE IF EXISTS test_no_colocated;", DEFAULT_COLOCATED_DB_NAME);
-        TestHelper.executeInDatabase("DROP TABLE IF EXISTS all_types;", DEFAULT_COLOCATED_DB_NAME);
-    }
-
-    private void insertBulkRecords(int numRecords, String fullTableName) {
-        String formatInsertString = "INSERT INTO " + fullTableName + " VALUES (%d);";
-        TestHelper.executeBulk(formatInsertString, numRecords, DEFAULT_COLOCATED_DB_NAME);
-    }
-
-    private void insertBulkRecordsInRange(int beginKey, int endKey, String fullTableName) {
-        String formatInsertString = "INSERT INTO " + fullTableName + " VALUES (%d);";
-        TestHelper.executeBulkWithRange(formatInsertString, beginKey, endKey, DEFAULT_COLOCATED_DB_NAME);
-    }
-
     private void verifyRecordCount(long recordsCount) {
         waitAndFailIfCannotConsume(new ArrayList<>(), recordsCount);
     }

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -48,7 +48,7 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
     @AfterEach
     public void after() throws Exception {
         stopConnector();
-        dropAllTables();
+        dropAllTablesInColocatedDB();
         TestHelper.executeDDL("drop_tables_and_databases.ddl");
         TestHelper.dropAllSchemas();
         resetCommitCallbackDelay();
@@ -66,9 +66,9 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
     @ValueSource(booleans = {true, false})
     public void testSnapshotRecordConsumption(boolean colocation) throws Exception {
         setCommitCallbackDelay(10000);
-        createTables(colocation);
+        createTablesInColocatedDB(colocation);
         final int recordsCount = 5000;
-        insertBulkRecords(recordsCount, "public.test_1");
+        insertBulkRecordsInColocatedDB(recordsCount, "public.test_1");
 
         LOGGER.info("Creating DB stream ID");
         String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
@@ -91,9 +91,9 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
     @ValueSource(booleans = {true, false})
     public void testSnapshotRecordCountInInitialOnlyMode(boolean colocation) throws Exception {
         setCommitCallbackDelay(10000);
-        createTables(colocation);
+        createTablesInColocatedDB(colocation);
         final int recordsCount = 4000;
-        insertBulkRecords(recordsCount, "public.test_1");
+        insertBulkRecordsInColocatedDB(recordsCount, "public.test_1");
 
         LOGGER.info("Creating DB stream ID");
         String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
@@ -112,12 +112,12 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void shouldOnlySnapshotTablesInList(boolean colocation) throws Exception {
-        createTables(colocation);
+        createTablesInColocatedDB(colocation);
 
         int recordCountT1 = 5000;
 
         // Insert records in the table test_1
-        insertBulkRecords(recordCountT1, "public.test_1");
+        insertBulkRecordsInColocatedDB(recordCountT1, "public.test_1");
 
         // Create table and insert records in all_types
         TestHelper.executeInDatabase(HelperStrings.CREATE_ALL_TYPES, DEFAULT_COLOCATED_DB_NAME);
@@ -151,12 +151,12 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void snapshotTableThenStreamData(boolean colocation) throws Exception {
-        createTables(colocation);
+        createTablesInColocatedDB(colocation);
 
         int recordCountT1 = 5000;
 
         // Insert records in the table test_1
-        insertBulkRecords(recordCountT1, "public.test_1");
+        insertBulkRecordsInColocatedDB(recordCountT1, "public.test_1");
 
         String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME, "public.test_1", dbStreamId);
@@ -186,12 +186,12 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void snapshotTableWithCompaction(boolean colocation) throws Exception {
-        createTables(colocation);
+        createTablesInColocatedDB(colocation);
 
         int recordCount = 5000;
 
         // Insert records in the table test_1
-        insertBulkRecords(recordCount, "public.test_1");
+        insertBulkRecordsInColocatedDB(recordCount, "public.test_1");
 
         String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME, "public.test_1", dbStreamId);
@@ -217,14 +217,14 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
     @ValueSource(booleans = {true, false})
     public void snapshotForMultipleTables(boolean colocation) throws Exception {
         // Create colocated tables
-        createTables(colocation);
+        createTablesInColocatedDB(colocation);
 
         final int recordsTest1 = 10;
         final int recordsTest2 = 20;
         final int recordsTest3 = 30;
-        insertBulkRecords(recordsTest1, "public.test_1");
-        insertBulkRecords(recordsTest2, "public.test_2");
-        insertBulkRecords(recordsTest3, "public.test_3");
+        insertBulkRecordsInColocatedDB(recordsTest1, "public.test_1");
+        insertBulkRecordsInColocatedDB(recordsTest2, "public.test_2");
+        insertBulkRecordsInColocatedDB(recordsTest3, "public.test_3");
 
         String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
         Configuration.Builder configBuilder =
@@ -260,16 +260,16 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
     @Test
     public void snapshotMixOfColocatedNonColocatedTables() throws Exception {
         // Create tables.
-        createTables(true /* enforce creation of the colocated tables only */);
+        createTablesInColocatedDB(true /* enforce creation of the colocated tables only */);
 
         final int recordCountForTest1 = 1000;
         final int recordCountForTest2 = 2000;
         final int recordCountForTest3 = 3000;
         final int recordCountInNonColocated = 4000;
-        insertBulkRecords(recordCountForTest1, "public.test_1");
-        insertBulkRecords(recordCountForTest2, "public.test_2");
-        insertBulkRecords(recordCountForTest3, "public.test_3");
-        insertBulkRecords(recordCountInNonColocated, "public.test_no_colocated");
+        insertBulkRecordsInColocatedDB(recordCountForTest1, "public.test_1");
+        insertBulkRecordsInColocatedDB(recordCountForTest2, "public.test_2");
+        insertBulkRecordsInColocatedDB(recordCountForTest3, "public.test_3");
+        insertBulkRecordsInColocatedDB(recordCountInNonColocated, "public.test_no_colocated");
 
         String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
         Configuration.Builder configBuilder =
@@ -310,15 +310,15 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
     @ValueSource(booleans = {true, false})
     public void snapshotColocatedNonColocatedThenStream(boolean initialOnly) throws Exception {
         // Create tables.
-        createTables(true /* enforce creation of the colocated tables only */);
+        createTablesInColocatedDB(true /* enforce creation of the colocated tables only */);
 
         final int recordCountForTest1 = 1000;
         final int recordCountForTest2 = 2000;
         final int recordCountForTest3 = 3000;
         final int recordCountInNonColocated = 4000;
-        insertBulkRecords(recordCountForTest1, "public.test_1");
-        insertBulkRecords(recordCountForTest2, "public.test_2");
-        insertBulkRecords(recordCountForTest3, "public.test_3");
+        insertBulkRecordsInColocatedDB(recordCountForTest1, "public.test_1");
+        insertBulkRecordsInColocatedDB(recordCountForTest2, "public.test_2");
+        insertBulkRecordsInColocatedDB(recordCountForTest3, "public.test_3");
 
         String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
         Configuration.Builder configBuilder =
@@ -342,7 +342,7 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         // Wait for some time so that the connector can transition to the streaming mode.
         TestHelper.waitFor(Duration.ofSeconds(60));
 
-        insertBulkRecords(recordCountInNonColocated, "public.test_no_colocated");
+        insertBulkRecordsInColocatedDB(recordCountInNonColocated, "public.test_no_colocated");
 
         // Inserting 1001 records to test_1
         TestHelper.executeInDatabase("INSERT INTO test_1 VALUES (generate_series(1000, 2000));", DEFAULT_COLOCATED_DB_NAME);
@@ -387,12 +387,12 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         throws Exception {
         // This test verifies that if there is a failure after snapshot is bootstrapped,
         // then snapshot is taken normally once the connector restarts.
-        createTables(colocation);
+        createTablesInColocatedDB(colocation);
 
         // Insert records to be snapshotted.
         final int recordsCount = 10;
-        insertBulkRecords(recordsCount, "public.test_1");
-        insertBulkRecords(recordsCount, "public.test_2");
+        insertBulkRecordsInColocatedDB(recordsCount, "public.test_1");
+        insertBulkRecordsInColocatedDB(recordsCount, "public.test_2");
 
         String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder(
@@ -444,12 +444,12 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         throws Exception {
         // This test verifies that if there is a failure after the call to set the checkpoint,
         // then snapshot is taken normally once the connector restarts.
-        createTables(colocation);
+        createTablesInColocatedDB(colocation);
 
         // Insert records to be snapshotted.
         final int recordsCount = 10;
-        insertBulkRecords(recordsCount, "public.test_1");
-        insertBulkRecords(recordsCount, "public.test_2");
+        insertBulkRecordsInColocatedDB(recordsCount, "public.test_1");
+        insertBulkRecordsInColocatedDB(recordsCount, "public.test_2");
 
         String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder(
@@ -511,10 +511,10 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
               no records to consume
          */ 
 
-        createTables(false);
+        createTablesInColocatedDB(false);
 
         final int recordsCount = 50;
-        insertBulkRecords(recordsCount, "public.test_1");
+        insertBulkRecordsInColocatedDB(recordsCount, "public.test_1");
 
         String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
         Configuration.Builder configBuilder =
@@ -574,10 +574,10 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
            7. Verify that we get the change records here.
          */ 
 
-        createTables(colocation);
+        createTablesInColocatedDB(colocation);
 
         final int recordsCount = 50;
-        insertBulkRecords(recordsCount, "public.test_1");
+        insertBulkRecordsInColocatedDB(recordsCount, "public.test_1");
 
         String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
         Configuration.Builder configBuilder =
@@ -592,8 +592,8 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         assertEquals(recordsCount, records.size());
 
         // Insert records in other tables, this shouldn't cause an issue.
-        insertBulkRecords(1000, "public.test_2");
-        insertBulkRecords(500, "public.test_3");
+        insertBulkRecordsInColocatedDB(1000, "public.test_2");
+        insertBulkRecordsInColocatedDB(500, "public.test_3");
 
         // Verify that there are no records to consume anymore.
         assertNoRecordsToConsume();
@@ -612,7 +612,7 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
 
         // Insert a few records --> total records inserted here would be 10, [50, 60)
         final int insertRecords = 10;
-        insertBulkRecordsInRange(recordsCount, recordsCount + insertRecords, "public.test_1");
+        insertBulkRecordsInRangeInColocatedDB(recordsCount, recordsCount + insertRecords, "public.test_1");
 
         // Change snapshot.mode to initial and start connector.
         configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE, "never");
@@ -745,13 +745,13 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
          */
 
         // Create tables.
-        createTables(colocation);
+        createTablesInColocatedDB(colocation);
 
         // 2 colocated non-empty tables + 1 colocated empty table + 1 non-colocated empty table
         final int recordCountForTest1 = 1000;
         final int recordCountForTest2 = 2000;
-        insertBulkRecords(recordCountForTest1, "public.test_1");
-        insertBulkRecords(recordCountForTest2, "public.test_2");
+        insertBulkRecordsInColocatedDB(recordCountForTest1, "public.test_1");
+        insertBulkRecordsInColocatedDB(recordCountForTest2, "public.test_2");
 
         String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
         Configuration.Builder configBuilder =
@@ -817,15 +817,15 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
             the streaming records for all the tables.
          */
         // Create tables.
-        createTables(colocation);
+        createTablesInColocatedDB(colocation);
 
         // 2 colocated non-empty tables + 1 colocated empty table + 1 non-colocated non-empty table
         final int recordCountForTest1 = 1000;
         final int recordCountForTest2 = 2000;
         final int recordCountInNonColocated = 2000;
-        insertBulkRecords(recordCountForTest1, "public.test_1");
-        insertBulkRecords(recordCountForTest2, "public.test_2");
-        insertBulkRecords(recordCountInNonColocated, "public.test_no_colocated");
+        insertBulkRecordsInColocatedDB(recordCountForTest1, "public.test_1");
+        insertBulkRecordsInColocatedDB(recordCountForTest2, "public.test_2");
+        insertBulkRecordsInColocatedDB(recordCountInNonColocated, "public.test_no_colocated");
 
         String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
         Configuration.Builder configBuilder =
@@ -887,12 +887,12 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void verifyConnectorFailsIfMarkSnapshotDoneFails(boolean colocation) throws Exception {
-        createTables(colocation);
+        createTablesInColocatedDB(colocation);
 
         int recordCountT1 = 5000;
 
         // Insert records in the table test_1
-        insertBulkRecords(recordCountT1, "public.test_1");
+        insertBulkRecordsInColocatedDB(recordCountT1, "public.test_1");
 
         String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME, "public.test_1", dbStreamId);

--- a/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
@@ -200,10 +200,20 @@ public class TestBaseClass extends AbstractConnectorTest {
     });
   }
 
+  /**
+   * Returns the available records in the queue linesConsumed
+   * @return the available (non-consumed) records in the queue linesConsumed
+   */
   public int getNonConsumedRecordCount() {
     return linesConsumed.size();
   }
 
+  /**
+   * Start an embeddedEngine but only consume records passed in totalRecordsToConsume.
+   * @param configBuilder configurations for the engine
+   * @param totalRecordsToConsume the total number of records to be added to linesConsumed i.e. the Kafka queue
+   * @param callback completion callback
+   */
   public void startEngineWithPartialConsumptionOfLastBatch(Configuration.Builder configBuilder, int totalRecordsToConsume, DebeziumEngine.CompletionCallback callback) {
     configBuilder
       .with(EmbeddedEngine.ENGINE_NAME, "test-connector")

--- a/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
@@ -244,7 +244,7 @@ public class TestBaseClass extends AbstractConnectorTest {
                .notifying((records, committer) -> {
                  for (SourceRecord record: records) {
                   // Partially consume the last batch
-                  if(linesConsumed.size() >= totalRecordsToConsume) {
+                  if (linesConsumed.size() >= totalRecordsToConsume) {
                     break;
                   }
                   linesConsumed.add(record);  

--- a/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
@@ -381,7 +381,7 @@ public class TestBaseClass extends AbstractConnectorTest {
     waitAndFailIfCannotConsume(records, recordsCount, 300 * 1000 /* 5 minutes */);
   }
 
-  protected void insertBulkRecords(int numRecords, String fullTableName) {
+  protected void insertBulkRecordsInColocatedDB(int numRecords, String fullTableName) {
     String formatInsertString = "INSERT INTO " + fullTableName + " VALUES (%d);";
     TestHelper.executeBulk(formatInsertString, numRecords, DEFAULT_COLOCATED_DB_NAME);
   }
@@ -389,7 +389,7 @@ public class TestBaseClass extends AbstractConnectorTest {
   /**
    * Helper function to create the required tables in the database DEFAULT_COLOCATED_DB_NAME
    */
-  protected void createTables(boolean colocation) {
+  protected void createTablesInColocatedDB(boolean colocation) {
     LOGGER.info("Creating tables with colocation: {}", colocation);
     final String createTest1 = String.format("CREATE TABLE test_1 (id INT PRIMARY KEY," +
                                               "name TEXT DEFAULT 'Vaibhav Kushwaha') " +
@@ -413,7 +413,7 @@ public class TestBaseClass extends AbstractConnectorTest {
   /**
    * Helper function to drop all the tables being created as a part of this test.
    */
-  protected void dropAllTables() {
+  protected void dropAllTablesInColocatedDB() {
     TestHelper.executeInDatabase("DROP TABLE IF EXISTS test_1;", DEFAULT_COLOCATED_DB_NAME);
     TestHelper.executeInDatabase("DROP TABLE IF EXISTS test_2;", DEFAULT_COLOCATED_DB_NAME);
     TestHelper.executeInDatabase("DROP TABLE IF EXISTS test_3;", DEFAULT_COLOCATED_DB_NAME);
@@ -421,10 +421,11 @@ public class TestBaseClass extends AbstractConnectorTest {
     TestHelper.executeInDatabase("DROP TABLE IF EXISTS all_types;", DEFAULT_COLOCATED_DB_NAME);
   }
 
-  protected void insertBulkRecordsInRange(int beginKey, int endKey, String fullTableName) {
+  protected void insertBulkRecordsInRangeInColocatedDB(int beginKey, int endKey, String fullTableName) {
     String formatInsertString = "INSERT INTO " + fullTableName + " VALUES (%d);";
     TestHelper.executeBulkWithRange(formatInsertString, beginKey, endKey, DEFAULT_COLOCATED_DB_NAME);
   }
+
   protected class SourceRecords {
     private final List<SourceRecord> records = new ArrayList<>();
     private final Map<String, List<SourceRecord>> recordsByTopic = new HashMap<>();

--- a/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
@@ -200,7 +200,11 @@ public class TestBaseClass extends AbstractConnectorTest {
     });
   }
 
-  public void startEngineWithPartialConsumptionOfLastBatch(Configuration.Builder configBuilder, int snapshotRecords, DebeziumEngine.CompletionCallback callback) {
+  public int getNonConsumedRecordCount() {
+    return linesConsumed.size();
+  }
+
+  public void startEngineWithPartialConsumptionOfLastBatch(Configuration.Builder configBuilder, int totalRecordsToConsume, DebeziumEngine.CompletionCallback callback) {
     configBuilder
       .with(EmbeddedEngine.ENGINE_NAME, "test-connector")
       .with(EmbeddedEngine.OFFSET_STORAGE, MemoryOffsetBackingStore.class.getName())
@@ -240,7 +244,7 @@ public class TestBaseClass extends AbstractConnectorTest {
                .notifying((records, committer) -> {
                  for (SourceRecord record: records) {
                   // Partially consume the last batch
-                  if(linesConsumed.size() > (snapshotRecords - 25)) { 
+                  if(linesConsumed.size() >= totalRecordsToConsume) {
                     break;
                   }
                   linesConsumed.add(record);  


### PR DESCRIPTION
### Problem
Consider this scenario:
Connector, in the snapshot phase, received the last batch of snapshot records. Since all the tablets were removed from the `shouldWaitForCallback` set right after the snapshot bootstrap call, connector will straight away send `snapshotDoneKey` even without waiting for Kafka to send callback for the last batch of snapshot records. Now if kafka had partially consumed the last batch of records and the connector restarted, the remaining records would be lost because connector when reading the cdc_state would conclude that snapshot has been completed on that particular tablet.  

### Solution
This is fixed by #306 

### Testing
Added new test `VerifyNoDataLossIfConnectorRestartDuringLastBatchConsumption` to reproduce the scenario. 

- Ran the test without fix in #306 and it fails when comparing the snapshot key before restarting the connector 

snapshot key of explicit checkpoint - some non-empty string
snapshot key in GetCheckpoint response - null (because snapshot was marked done on the server)

- Ran the test with the fix in #306 and both the snapshot keys are equal.

### Linked Issue
yugabyte/yugabyte-db#20272