### PR TITLE
Use container IP address to connect to YugabyteDB

### DIFF
--- a/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
@@ -80,6 +80,8 @@ public final class TestHelper {
     // If this variable is changed, do not forget to change the name in postgres_create_tables.ddl
     private static final String SECONDARY_DATABASE = "secondary_database";
 
+    public static final String CONTAINER_HOSTNAME = "yugabyte-0";
+
     // Set the localhost value as the defaults for now
     private static String CONTAINER_YSQL_HOST = "127.0.0.1";
     private static String CONTAINER_YCQL_HOST = "127.0.0.1";
@@ -453,7 +455,7 @@ public final class TestHelper {
         container.withUsername("yugabyte");
         container.withDatabaseName("yugabyte");
         container.withExposedPorts(7100, 9100, 5433, 9042);
-        container.withCreateContainerCmdModifier(cmd -> cmd.withHostName("127.0.0.1").getHostConfig().withPortBindings(new ArrayList<PortBinding>() {
+        container.withCreateContainerCmdModifier(cmd -> cmd.withHostName(CONTAINER_HOSTNAME).getHostConfig().withPortBindings(new ArrayList<PortBinding>() {
             {
                 add(new PortBinding(Ports.Binding.bindPort(7100), new ExposedPort(7100)));
                 add(new PortBinding(Ports.Binding.bindPort(9100), new ExposedPort(9100)));

--- a/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
@@ -36,7 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.YugabyteYSQLContainer;
-import org.testcontainers.containers.wait.strategy.WaitStrategy;
 import org.testcontainers.utility.DockerImageName;
 import org.yb.client.AsyncYBClient;
 import org.yb.client.ListTablesResponse;

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
@@ -4,25 +4,20 @@ import java.sql.SQLException;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
 import io.debezium.connector.yugabytedb.common.YugabytedTestBase;
 
-import io.debezium.connector.yugabytedb.connection.HashPartition;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.yb.cdc.CdcService;
 import org.yb.client.*;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.yugabytedb.transforms.YBExtractNewRecordState;
 import io.debezium.transforms.ExtractNewRecordStateConfigDefinition;
-import org.yb.master.MasterClientOuterClass;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/io/debezium/connector/yugabytedb/common/YugabyteDBContainerTestBase.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/YugabyteDBContainerTestBase.java
@@ -1,10 +1,8 @@
 package io.debezium.connector.yugabytedb.common;
 
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStreamReader;
 import java.time.Duration;
-import java.util.Arrays;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.exception.NotFoundException;


### PR DESCRIPTION
## Problem

With the commit https://github.com/yugabyte/yugabyte-db/commit/cade0a8688fea889f1595bfa0a15d61124849f0d we cannot use the IP `0.0.0.0` to start the `yugabyted` process as it will start a process on `127.0.0.1` of the Docker container and thus we will not be able to connect it from outside the container i.e. the test framework.

This blocks the execution of all the tests since the YugabyteDB container itself will not be starting up with this.

## Solution

This PR implements a solution by leveraging the container IP address, so any RPC calls will be made to the container IP address.