### PR TITLE
[yugabyte/yugabyte-db#20410] Add annotation `MinimumYBVersion` for tests

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/connection/YBVersion.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/YBVersion.java
@@ -1,0 +1,104 @@
+package io.debezium.connector.yugabytedb.connection;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Class to denote YugabyteDB version.
+ *
+ * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
+ */
+public class YBVersion implements Comparable<YBVersion> {
+  public Integer major;
+  public Integer minor;
+  public Integer patch = 0;
+  public Integer revision = 0;
+
+  public YBVersion(int major, int minor, int patch, int revision) {
+    this.major = major;
+    this.minor = minor;
+    this.patch = patch;
+    this.revision = revision;
+  }
+
+  public YBVersion(String versionString) {
+    assert !versionString.isEmpty();
+    String[] version = versionString.split("\\.");
+
+    this.major = Integer.parseInt(version[0]);
+    this.minor = Integer.parseInt(version[1]);
+
+    if (version.length >= 3) {
+      this.patch = Integer.parseInt(version[2]);
+    }
+
+    if (version.length == 4) {
+      this.revision = Integer.parseInt(version[3]);
+    }
+  }
+
+  @Override
+  public int compareTo(YBVersion o) {
+    if (!this.major.equals(o.major)) {
+      return this.major.compareTo(o.major);
+    } else if (!this.minor.equals(o.minor)) {
+      return this.minor.compareTo(o.minor);
+    } else if (!this.patch.equals(o.patch)) {
+      return this.patch.compareTo(o.patch);
+    } else if (!this.revision.equals(o.revision)) {
+      return this.revision.compareTo(o.revision);
+    }
+
+    // Both the versions are equal.
+    return 0;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s.%s.%s.%s", major, minor, patch, revision);
+  }
+
+  public static YBVersion getCurrentYBVersionEnv() {
+    String imageName = System.getenv("YB_DOCKER_IMAGE");
+
+    if (imageName.isEmpty()) {
+      return new YBVersion("2.18.2.0");
+    }
+
+    String regexPattern = "yugabyte:(.*?)-b*";
+    Pattern pattern = Pattern.compile(regexPattern);
+    Matcher matcher = pattern.matcher(imageName);
+
+    if (matcher.find()) {
+      return new YBVersion(matcher.group(1));
+    }
+
+    return new YBVersion("2.18.2.0");
+  }
+
+  public static YBVersion getCurrentYBVersion(Connection conn) {
+    try (Statement st = conn.createStatement()) {
+      ResultSet rs = st.executeQuery("select version();");
+
+      if (rs.next()) {
+        String fullVersionString = rs.getString("version");
+
+        String regexPattern = "YB-(.*?)-b*";
+        Pattern pattern = Pattern.compile(regexPattern);
+        Matcher matcher = pattern.matcher(fullVersionString);
+
+        if (matcher.find()) {
+          return new YBVersion(matcher.group(1));
+        }
+      }
+
+      return new YBVersion("2.18.2.0");
+    } catch (SQLException sqle) {
+      throw new RuntimeException("Exception while trying to get current YB version", sqle);
+    }
+  }
+}

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCQLTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCQLTest.java
@@ -6,6 +6,7 @@ import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.Row;
 import io.debezium.config.Configuration;
 import io.debezium.connector.yugabytedb.HelperBeforeImageModes.BeforeImageMode;
+import io.debezium.connector.yugabytedb.annotations.MinimumYBVersion;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
 import io.debezium.connector.yugabytedb.common.YugabytedTestBase;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -31,6 +32,12 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
+/**
+ * Tests to verify the streaming of changes from YCQL tables.
+ *
+ * @author Sumukh Phalgaonkar (sumukh.phalgaonkar@yugabyte.com)
+ */
+@MinimumYBVersion(value = "2.20", reason = "Feature was introduced in the given version only")
 public class YugabyteDBCQLTest extends YugabyteDBContainerTestBase {
     CqlSession session;
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
@@ -6,6 +6,7 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
+import io.debezium.connector.yugabytedb.annotations.MinimumYBVersion;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
 import io.debezium.connector.yugabytedb.common.YugabytedTestBase;
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBExplicitCheckpointingTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBExplicitCheckpointingTest.java
@@ -1,6 +1,7 @@
 package io.debezium.connector.yugabytedb;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.yugabytedb.annotations.MinimumYBVersion;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
 
 import io.debezium.connector.yugabytedb.common.YugabytedTestBase;
@@ -38,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
  */
+@MinimumYBVersion("2.18.2")
 public class YugabyteDBExplicitCheckpointingTest extends YugabyteDBContainerTestBase {
     private static final Logger LOGGER = LoggerFactory.getLogger(YugabyteDBExplicitCheckpointingTest.class);
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBPublicationReplicationTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBPublicationReplicationTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+import io.debezium.connector.yugabytedb.annotations.MinimumYBVersion;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
 import io.debezium.connector.yugabytedb.common.YugabytedTestBase;
 import io.debezium.connector.yugabytedb.connection.YugabyteDBConnection;
@@ -37,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * 
  * @author Sumukh Phalgaonkar (sumukh.phalgaonkar@yugabyte.com)
  */
+@MinimumYBVersion(value = "2.21", reason = "Feature was introduced in the given version only")
 public class YugabyteDBPublicationReplicationTest extends YugabyteDBContainerTestBase {
 
     public static String insertStatementFormatfort2 = "INSERT INTO t2 values (%d);";

--- a/src/test/java/io/debezium/connector/yugabytedb/annotations/MinimumYBVersion.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/annotations/MinimumYBVersion.java
@@ -1,0 +1,23 @@
+package io.debezium.connector.yugabytedb.annotations;
+
+import io.debezium.connector.yugabytedb.annotations.conditions.RunWithMinimumYBVersion;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to specify what is the minimum YB version a test should run against. <br><br>
+ *
+ * <strong>Usage:</strong><br>
+ * {@code @MinimumYBVersion("2.21")}
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(RunWithMinimumYBVersion.class)
+public @interface MinimumYBVersion {
+  String value() default "2.18.2.0";
+  String reason() default "";
+}

--- a/src/test/java/io/debezium/connector/yugabytedb/annotations/conditions/RunWithMinimumYBVersion.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/annotations/conditions/RunWithMinimumYBVersion.java
@@ -1,0 +1,37 @@
+package io.debezium.connector.yugabytedb.annotations.conditions;
+
+import io.debezium.connector.yugabytedb.annotations.MinimumYBVersion;
+import io.debezium.connector.yugabytedb.connection.YBVersion;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.lang.reflect.AnnotatedElement;
+import java.util.Optional;
+
+/**
+ * This class is to define the condition with which certain test will be executed if the
+ * annotation {@code @MinimumYBVersion} is present.
+ *
+ * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
+ */
+public class RunWithMinimumYBVersion implements ExecutionCondition {
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+    final Optional<AnnotatedElement> element = context.getElement();
+    if (element.isPresent()) {
+      YBVersion testYBVersion = new YBVersion(element.get().getAnnotation(MinimumYBVersion.class).value());
+
+      if (YBVersion.getCurrentYBVersionEnv().compareTo(testYBVersion) >= 0) {
+        return ConditionEvaluationResult.enabled("Test enabled");
+      } else {
+        return ConditionEvaluationResult.disabled("Test disabled as minimum YB version required to run this test is " + testYBVersion);
+      }
+    }
+
+    // The possibility of hitting this code block is not even there. If this is encountered, you've
+    // unleashed the devil now - run as fast as you can.
+    return ConditionEvaluationResult.disabled("No test element found");
+  }
+
+}

--- a/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/common/TestBaseClass.java
@@ -3,7 +3,9 @@ package io.debezium.connector.yugabytedb.common;
 import io.debezium.config.Configuration;
 import io.debezium.connector.yugabytedb.TestHelper;
 import io.debezium.connector.yugabytedb.YugabyteDBConnector;
+import io.debezium.connector.yugabytedb.annotations.conditions.RunWithMinimumYBVersion;
 import io.debezium.connector.yugabytedb.connection.OpId;
+import io.debezium.connector.yugabytedb.connection.YugabyteDBConnection;
 import io.debezium.connector.yugabytedb.container.YugabyteCustomContainer;
 import io.debezium.connector.yugabytedb.rules.YugabyteDBLogTestName;
 import io.debezium.embedded.AbstractConnectorTest;
@@ -18,17 +20,24 @@ import org.apache.kafka.connect.storage.MemoryOffsetBackingStore;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
 import org.eclipse.jetty.util.BlockingArrayQueue;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.YugabyteYSQLContainer;
 
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/io/debezium/connector/yugabytedb/consistent/MergerTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/consistent/MergerTest.java
@@ -1,5 +1,6 @@
 package io.debezium.connector.yugabytedb.consistent;
 
+import io.debezium.connector.yugabytedb.annotations.MinimumYBVersion;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -12,6 +13,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@MinimumYBVersion("2.18.2")
 class MergerTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(MergerTest.class);
     private final String DUMMY_TABLE_ID = "dummy_table_id";

--- a/src/test/java/io/debezium/connector/yugabytedb/consistent/MessageTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/consistent/MessageTest.java
@@ -1,6 +1,7 @@
 package io.debezium.connector.yugabytedb.consistent;
 
 import com.google.protobuf.ByteString;
+import io.debezium.connector.yugabytedb.annotations.MinimumYBVersion;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.yb.cdc.CdcService;
@@ -19,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * @author Rajat Venkatesh, Vaibhav Kushwaha
  */
+@MinimumYBVersion("2.18.2")
 public class MessageTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(MessageTest.class);
     private final String DUMMY_TABLE_ID = "dummy_table_id";

--- a/src/test/java/io/debezium/connector/yugabytedb/consistent/YugabyteDBConsistencyWithColocatedTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/consistent/YugabyteDBConsistencyWithColocatedTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 
+import io.debezium.connector.yugabytedb.annotations.MinimumYBVersion;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.awaitility.Awaitility;
@@ -30,6 +31,7 @@ import io.debezium.connector.yugabytedb.YugabyteDBConnectorConfig;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
 import io.debezium.connector.yugabytedb.connection.YugabyteDBConnection;
 
+@MinimumYBVersion("2.18.2")
 public class YugabyteDBConsistencyWithColocatedTest extends YugabyteDBContainerTestBase {
     @BeforeAll
     public static void beforeClass() throws SQLException {

--- a/src/test/java/io/debezium/connector/yugabytedb/consistent/YugabyteDBStreamConsistencyTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/consistent/YugabyteDBStreamConsistencyTest.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 import io.debezium.connector.yugabytedb.TestHelper;
 import io.debezium.connector.yugabytedb.YugabyteDBConnector;
 import io.debezium.connector.yugabytedb.YugabyteDBConnectorConfig;
+import io.debezium.connector.yugabytedb.annotations.MinimumYBVersion;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
 import io.debezium.connector.yugabytedb.common.YugabytedTestBase;
 import io.debezium.connector.yugabytedb.connection.YugabyteDBConnection;
@@ -39,6 +40,7 @@ import io.debezium.config.Configuration;
  * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
  */
 
+@MinimumYBVersion("2.18.2")
 public class YugabyteDBStreamConsistencyTest extends YugabyteDBContainerTestBase {
     private final static Logger LOGGER = LoggerFactory.getLogger(YugabyteDBStreamConsistencyTest.class);
     


### PR DESCRIPTION
## Problem

Currently, the test infra has a lot of tests and they are all compatible with the latest `master` branch at yugabyte/yugabyte-db but some of these tests are only compatible with the latest branch as the features are not available in previous versions.

Naturally, when these tests will be run against a previous YB version, they will fail, thus polluting the test results with failures.

## Solution

This PR introduces an annotation `@MinimumYBVersion` which adds the ability to a test to be run only when the service version is equal to or greater than the specified version for test, if the service version is less, the test will be skipped/disabled.

### Changes
1. Added class `YBVersion` to denote YugabyteDB version for service
2. Added annotation `MinimumYBVersion` and it's condition evaluation in the class `RunWithMinimumYBVersion`

**Note:**
The added annotation fetches the current YB version from the environment variable `YB_DOCKER_IMAGE` so it is mandatory for this environment variable to be set while running the tests, otherwise the current version will be defaulted to `2.21.0.0`

Additionally, this closes yugabyte/yugabyte-db#20410