### PR TITLE
[yugabyte/yugabyte-db#20414] Fix loss of precision while interpreting as double

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -789,17 +789,6 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
                     "Whether or not to delete the logical replication stream when the connector finishes orderly" +
                             "By default the replication is kept so that on restart progress can resume from the last recorded location");
 
-    // Changing the default decimal.handling.mode to double
-//    @Override
-//    public JdbcValueConverters.DecimalMode getDecimalMode() {
-//        if (super.getDecimalMode() == JdbcValueConverters.DecimalMode.PRECISE) {
-//            LOGGER.info("decimal.handling.mode PRECISE is not supported, defaulting to double");
-//            return JdbcValueConverters.DecimalMode.DOUBLE;
-//        }
-//
-//        return super.getDecimalMode();
-//    }
-
     public enum AutoCreateMode implements EnumeratedValue {
         /**
          * No Publication will be created, it's expected the user

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -790,15 +790,15 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
                             "By default the replication is kept so that on restart progress can resume from the last recorded location");
 
     // Changing the default decimal.handling.mode to double
-    @Override
-    public JdbcValueConverters.DecimalMode getDecimalMode() {
-        if (super.getDecimalMode() == JdbcValueConverters.DecimalMode.PRECISE) {
-            LOGGER.debug("decimal.handling.mode PRECISE is not supported, defaulting to double");
-            return JdbcValueConverters.DecimalMode.DOUBLE;
-        }
-
-        return super.getDecimalMode();
-    }
+//    @Override
+//    public JdbcValueConverters.DecimalMode getDecimalMode() {
+//        if (super.getDecimalMode() == JdbcValueConverters.DecimalMode.PRECISE) {
+//            LOGGER.info("decimal.handling.mode PRECISE is not supported, defaulting to double");
+//            return JdbcValueConverters.DecimalMode.DOUBLE;
+//        }
+//
+//        return super.getDecimalMode();
+//    }
 
     public enum AutoCreateMode implements EnumeratedValue {
         /**

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCompleteTypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCompleteTypesTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import io.debezium.jdbc.TemporalPrecisionMode;
+import io.debezium.relational.RelationalDatabaseConnectorConfig.DecimalHandlingMode;
 import io.debezium.util.HexConverter;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
 import io.debezium.connector.yugabytedb.common.YugabytedTestBase;
@@ -24,7 +25,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class YugabyteDBCompleteTypesTest extends YugabyteDBContainerTestBase {
+public class YugabyteDBCompleteTypesTest extends YugabytedTestBase {
     @BeforeAll
     public static void beforeClass() throws SQLException {
         initializeYBContainer();
@@ -166,6 +167,50 @@ public class YugabyteDBCompleteTypesTest extends YugabyteDBContainerTestBase {
         } else if (precisionMode == TemporalPrecisionMode.CONNECT) {
             // Note that in 'connect' mode, we have a loss of precision.
             assertValueField(record, "after/ts/value", 1637841600123L);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"precise", "double", "string"})
+    public void shouldWorkWithAllDecimalTypes(String decimalMode) throws Exception {
+        TestHelper.dropAllSchemas();
+        TestHelper.executeDDL("yugabyte_create_tables.ddl");
+        Thread.sleep(1000);
+
+        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "numeric_type");
+        Configuration.Builder configBuilder =
+          TestHelper.getConfigBuilder("public.numeric_type", dbStreamId);
+        configBuilder.with("decimal.handling.mode", decimalMode);
+        startEngine(configBuilder);
+
+        awaitUntilConnectorIsReady();
+
+        final long recordsCount = 1;
+
+        // This insert statement will insert a row containing all types
+        TestHelper.execute("INSERT INTO numeric_type VALUES (1, 987654321.12345678);");
+
+        List<SourceRecord> records = new ArrayList<>();
+
+        CompletableFuture.runAsync(() -> consumeRecords(records, recordsCount))
+          .exceptionally(throwable -> {
+              throw new RuntimeException(throwable);
+          }).get();
+
+        assertEquals(1, records.size());
+
+        // Get the only record from the list.
+        SourceRecord record_0 = records.get(0);
+//        SourceRecord record_1 = records.get(1);
+
+        DecimalHandlingMode decimalHandlingMode =
+          DecimalHandlingMode.parse(decimalMode);
+        if (decimalHandlingMode == DecimalHandlingMode.PRECISE) {
+            assertValueField(record_0, "after/col_val/value", 987654321.12345678);
+        } else if (decimalHandlingMode == DecimalHandlingMode.DOUBLE) {
+            assertValueField(record_0, "after/col_val/value", 9.876543211234568E8);
+        } else if (decimalHandlingMode == DecimalHandlingMode.STRING) {
+            assertValueField(record_0, "after/col_val/value", "987654321.12345678");
         }
     }
 }

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCompleteTypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCompleteTypesTest.java
@@ -201,7 +201,6 @@ public class YugabyteDBCompleteTypesTest extends YugabytedTestBase {
 
         // Get the only record from the list.
         SourceRecord record_0 = records.get(0);
-//        SourceRecord record_1 = records.get(1);
 
         DecimalHandlingMode decimalHandlingMode =
           DecimalHandlingMode.parse(decimalMode);

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCompleteTypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCompleteTypesTest.java
@@ -1,5 +1,6 @@
 package io.debezium.connector.yugabytedb;
 
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -186,8 +187,7 @@ public class YugabyteDBCompleteTypesTest extends YugabytedTestBase {
         awaitUntilConnectorIsReady();
 
         final long recordsCount = 1;
-
-        // This insert statement will insert a row containing all types
+        
         TestHelper.execute("INSERT INTO numeric_type VALUES (1, 987654321.12345678);");
 
         List<SourceRecord> records = new ArrayList<>();
@@ -210,6 +210,53 @@ public class YugabyteDBCompleteTypesTest extends YugabytedTestBase {
             assertValueField(record_0, "after/col_val/value", 9.876543211234568E8);
         } else if (decimalHandlingMode == DecimalHandlingMode.STRING) {
             assertValueField(record_0, "after/col_val/value", "987654321.12345678");
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"precise", "double", "string"})
+    public void shouldHaveLossOfPrecisionWithDecimalModeWithLargeValue(String decimalMode) throws Exception {
+        TestHelper.dropAllSchemas();
+        TestHelper.executeDDL("yugabyte_create_tables.ddl");
+        Thread.sleep(1000);
+
+        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "numeric_type");
+        Configuration.Builder configBuilder =
+          TestHelper.getConfigBuilder("public.numeric_type", dbStreamId);
+        configBuilder.with("decimal.handling.mode", decimalMode);
+        startEngine(configBuilder);
+
+        awaitUntilConnectorIsReady();
+
+        final long recordsCount = 1;
+
+        // Insert a value having a large value.
+        BigDecimal val = new BigDecimal("100000000000000000000000000000000000000000000000000000000000000000000000000000.123456789123456789");
+        TestHelper.execute("INSERT INTO numeric_type (id, col_val_2) VALUES (1, " + val + ");");
+
+        List<SourceRecord> records = new ArrayList<>();
+
+        CompletableFuture.runAsync(() -> consumeRecords(records, recordsCount))
+          .exceptionally(throwable -> {
+              throw new RuntimeException(throwable);
+          }).get();
+
+        assertEquals(1, records.size());
+
+        // Get the only record from the list.
+        SourceRecord record_0 = records.get(0);
+        LOGGER.info("schema: {}", record_0.valueSchema().toString());
+        LOGGER.info(record_0.value().toString());
+
+        DecimalHandlingMode decimalHandlingMode =
+          DecimalHandlingMode.parse(decimalMode);
+        if (decimalHandlingMode == DecimalHandlingMode.PRECISE) {
+            assertValueField(record_0, "after/col_val_2/value", 100000000000000000000000000000000000000000000000000000000000000000000000000000.123456789123456789);
+        } else if (decimalHandlingMode == DecimalHandlingMode.DOUBLE) {
+            // This is a loss of precision as compared to the originally inserted value.
+            assertValueField(record_0, "after/col_val_2/value", 1.0E77);
+        } else if (decimalHandlingMode == DecimalHandlingMode.STRING) {
+            assertValueField(record_0, "after/col_val_2/value", "100000000000000000000000000000000000000000000000000000000000000000000000000000.123456789123456789");
         }
     }
 }

--- a/src/test/resources/drop_tables_and_databases.ddl
+++ b/src/test/resources/drop_tables_and_databases.ddl
@@ -5,6 +5,7 @@ DROP TABLE IF EXISTS t3;
 DROP TABLE IF EXISTS t1_range;
 
 DROP TABLE IF EXISTS all_types;
+DROP TABLE IF EXISTS numeric_types;
 DROP TABLE IF EXISTS test_enum;
 DROP TYPE IF EXISTS enum_type;
 DROP DATABASE IF EXISTS secondary_database;

--- a/src/test/resources/yugabyte_create_tables.ddl
+++ b/src/test/resources/yugabyte_create_tables.ddl
@@ -9,7 +9,7 @@ cidrval cidr, dt date, dp double precision, inetval inet, intervalval interval, 
 si smallint, i4r int4range, i8r int8range, nr numrange, tsr tsrange, tstzr tstzrange, dr daterange, txt text, tm time, tmtz timetz, ts timestamp, tstz timestamptz,
 uuidval uuid) WITH (COLOCATION = false);
 
-CREATE TABLE numeric_type (id INT PRIMARY KEY, col_val NUMERIC(17,8));
+CREATE TABLE numeric_type (id INT PRIMARY KEY, col_val NUMERIC(17, 8), col_val_2 numeric(102, 23));
 
 DROP DATABASE IF EXISTS secondary_database;
 CREATE DATABASE secondary_database;

--- a/src/test/resources/yugabyte_create_tables.ddl
+++ b/src/test/resources/yugabyte_create_tables.ddl
@@ -9,6 +9,8 @@ cidrval cidr, dt date, dp double precision, inetval inet, intervalval interval, 
 si smallint, i4r int4range, i8r int8range, nr numrange, tsr tsrange, tstzr tstzrange, dr daterange, txt text, tm time, tmtz timetz, ts timestamp, tstz timestamptz,
 uuidval uuid) WITH (COLOCATION = false);
 
+CREATE TABLE numeric_type (id INT PRIMARY KEY, col_val NUMERIC(17,8));
+
 DROP DATABASE IF EXISTS secondary_database;
 CREATE DATABASE secondary_database;
 


### PR DESCRIPTION
## Problem

The connector was interpreting all the decimal values as `double` even if the mode was set to `precise` - this would have resulted in a loss of precision when streamed.

## Solution

This PR disables the default form being set to `double` when the `decimal.handling.mode` is set to `precise`.