### PR TITLE
[yugabyte/yugabyte-db#20000] Upgrade Kafka API in dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <!-- Dependency Versions -->
         <version.postgresql.driver>42.5.1</version.postgresql.driver>
         <version.com.google.protobuf>3.21.7</version.com.google.protobuf>
-        <version.kafka>3.3.1</version.kafka>
+        <version.kafka>3.6.1</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>
         <version.ybclient>0.8.75-20231215.051722-1</version.ybclient>
@@ -602,7 +602,6 @@
                             <build>
                                 <contextDir>${project.basedir}</contextDir>
                                 <tags>
-                                    <tag>latest</tag>
                                     <tag>${project.version}</tag>
                                 </tags>
                             </build>


### PR DESCRIPTION
## Changes
This PR contains the following changes:
* Upgrade of Kafka API version from `3.3.1` to `3.6.1`
* Removing the `latest` tag from the snapshot builds so that the snapshot releases do not get tagged with `latest` automatically

This closes yugabyte/yugabyte-db#20000