### PR TITLE
Run GitHub actions only when PR created from upstream repository

### DIFF
--- a/.github/workflows/create-pr-workflow.yml
+++ b/.github/workflows/create-pr-workflow.yml
@@ -1,0 +1,24 @@
+name: Compilation check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Compile code
+        run: mvn clean verify -Dquick

--- a/.github/workflows/sanity-workflow-preview.yml
+++ b/.github/workflows/sanity-workflow-preview.yml
@@ -9,32 +9,34 @@ on:
       - main
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Login to Quay.io
-        uses: docker/login-action@v2
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_BOT_USERNAME }}
-          password: ${{ secrets.QUAY_BOT_TOKEN }}
-      - name: Pull docker image
-        env:
-          YB_DOCKER_IMAGE: ${{ secrets.YB_DOCKER_IMAGE_PREVIEW }}
-        run: docker pull $YB_DOCKER_IMAGE
-      - name: Sanity Test that code compiles and tests pass.
-        env:
-          YB_DOCKER_IMAGE: ${{ secrets.YB_DOCKER_IMAGE_PREVIEW }}
-        run: mvn clean test -Dtest=!YugabyteDBColocatedTablesTest#shouldWorkWithMixOfColocatedAndNonColocatedTables
-      - name: Flaky test YugabyteDBColocatedTablesTest#shouldWorkWithMixOfColocatedAndNonColocatedTables
-        env:
-          YB_DOCKER_IMAGE: ${{ secrets.YB_DOCKER_IMAGE_PREVIEW }}
-        run: mvn clean test -Dtest=YugabyteDBColocatedTablesTest#shouldWorkWithMixOfColocatedAndNonColocatedTables
+  runs_if:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    build:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v3
+        - name: Cache local Maven repository
+          uses: actions/cache@v3
+          with:
+            path: ~/.m2/repository
+            key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+            restore-keys: |
+              ${{ runner.os }}-maven-
+        - name: Login to Quay.io
+          uses: docker/login-action@v2
+          with:
+            registry: quay.io
+            username: ${{ secrets.QUAY_BOT_USERNAME }}
+            password: ${{ secrets.QUAY_BOT_TOKEN }}
+        - name: Pull docker image
+          env:
+            YB_DOCKER_IMAGE: ${{ secrets.YB_DOCKER_IMAGE_PREVIEW }}
+          run: docker pull $YB_DOCKER_IMAGE
+        - name: Sanity Test that code compiles and tests pass.
+          env:
+            YB_DOCKER_IMAGE: ${{ secrets.YB_DOCKER_IMAGE_PREVIEW }}
+          run: mvn clean test -Dtest=!YugabyteDBColocatedTablesTest#shouldWorkWithMixOfColocatedAndNonColocatedTables
+        - name: Flaky test YugabyteDBColocatedTablesTest#shouldWorkWithMixOfColocatedAndNonColocatedTables
+          env:
+            YB_DOCKER_IMAGE: ${{ secrets.YB_DOCKER_IMAGE_PREVIEW }}
+          run: mvn clean test -Dtest=YugabyteDBColocatedTablesTest#shouldWorkWithMixOfColocatedAndNonColocatedTables

--- a/.github/workflows/sanity-workflow.yml
+++ b/.github/workflows/sanity-workflow.yml
@@ -11,32 +11,34 @@ on:
       - 1.7
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Login to Quay.io
-        uses: docker/login-action@v2
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_BOT_USERNAME }}
-          password: ${{ secrets.QUAY_BOT_TOKEN }}
-      - name: Pull docker image
-        env:
-          YB_DOCKER_IMAGE: ${{ secrets.YB_DOCKER_IMAGE }}
-        run: docker pull $YB_DOCKER_IMAGE
-      - name: Sanity Test that code compiles and tests pass.
-        env:
-          YB_DOCKER_IMAGE: ${{ secrets.YB_DOCKER_IMAGE }}
-        run: mvn clean test -Dtest=!YugabyteDBColocatedTablesTest#shouldWorkWithMixOfColocatedAndNonColocatedTables
-      - name: Flaky test YugabyteDBColocatedTablesTest#shouldWorkWithMixOfColocatedAndNonColocatedTables
-        env:
-          YB_DOCKER_IMAGE: ${{ secrets.YB_DOCKER_IMAGE }}
-        run: mvn clean test -Dtest=YugabyteDBColocatedTablesTest#shouldWorkWithMixOfColocatedAndNonColocatedTables
+  run_if:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    build:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v3
+        - name: Cache local Maven repository
+          uses: actions/cache@v3
+          with:
+            path: ~/.m2/repository
+            key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+            restore-keys: |
+              ${{ runner.os }}-maven-
+        - name: Login to Quay.io
+          uses: docker/login-action@v2
+          with:
+            registry: quay.io
+            username: ${{ secrets.QUAY_BOT_USERNAME }}
+            password: ${{ secrets.QUAY_BOT_TOKEN }}
+        - name: Pull docker image
+          env:
+            YB_DOCKER_IMAGE: ${{ secrets.YB_DOCKER_IMAGE }}
+          run: docker pull $YB_DOCKER_IMAGE
+        - name: Sanity Test that code compiles and tests pass.
+          env:
+            YB_DOCKER_IMAGE: ${{ secrets.YB_DOCKER_IMAGE }}
+          run: mvn clean test -Dtest=!YugabyteDBColocatedTablesTest#shouldWorkWithMixOfColocatedAndNonColocatedTables
+        - name: Flaky test YugabyteDBColocatedTablesTest#shouldWorkWithMixOfColocatedAndNonColocatedTables
+          env:
+            YB_DOCKER_IMAGE: ${{ secrets.YB_DOCKER_IMAGE }}
+          run: mvn clean test -Dtest=YugabyteDBColocatedTablesTest#shouldWorkWithMixOfColocatedAndNonColocatedTables


### PR DESCRIPTION
This PR modifies the GH actions condition to only run the workflows for tests if the PR is created from the upstream repository only.

Additionally, this adds a workflow which will check for compilation if the PR will be created from any repository.