### PR TITLE
[yugabyte/yugabyte-db#20636] Fetch for tablets from service in snapshot phase as well

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.kafka>3.6.1</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>
-        <version.ybclient>0.8.75-20231215.051722-1</version.ybclient>
+        <version.ybclient>0.8.75-SNAPSHOT</version.ybclient>
         <version.gson>2.8.9</version.gson>
 
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.kafka>3.6.1</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>
-        <version.ybclient>0.8.75-SNAPSHOT</version.ybclient>
+        <version.ybclient>0.8.76-20240131.111415-1</version.ybclient>
         <version.gson>2.8.9</version.gson>
 
         <!--

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -398,9 +398,32 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
       }
     }
 
-    protected void populateTabletPairList(List<Pair<String, String>> res) {
-      for (HashPartition hp : partitionRanges) {
-        res.add(new ImmutablePair<>(hp.getTableId(), hp.getTabletId()));
+    /**
+     * Use the {@link GetTabletListToPollForCDCResponse} and the populated {@code partitionRanges}
+     * to verify if the tablets in the response should be a part of this task. The logic only
+     * adds the tablets in the response which are contained in the parent partition ranges. Note
+     * that this method also assumes that the object {@code partitionRanges} is already populated.
+     *
+     * @param tableId the tableUUID for which the {@link GetTabletListToPollForCDCResponse} is passed
+     * @param response of type {@link GetTabletListToPollForCDCResponse}
+     * @param res a list of {@link Pair} to be populated where each pair is {@code <tableId, tabletId>}
+     */
+    protected void populateTabletPairList(String tableId,
+                                          GetTabletListToPollForCDCResponse response,
+                                          List<Pair<String, String>> res) {
+      // Verify that the partitionRanges are already populated.
+      Objects.requireNonNull(partitionRanges);
+      assert !partitionRanges.isEmpty();
+
+      // Iterate over the stored partitions and add valid tablets for streaming.
+      for (CdcService.TabletCheckpointPair pair : response.getTabletCheckpointPairList()) {
+        HashPartition hp = HashPartition.from(pair, tableId);
+
+        for (HashPartition parent : partitionRanges) {
+          if (parent.containsPartition(hp)) {
+            res.add(new ImmutablePair<>(hp.getTableId(), hp.getTabletId()));
+          }
+        }
       }
     }
 
@@ -411,13 +434,16 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
       LOGGER.info("Starting the snapshot process now");
       
       // Get the list of tablets
-      List<Pair<String, String>> tableToTabletIds = HashPartition.getTableToTabletPairs(partitionRanges);
+      List<Pair<String, String>> tableToTabletIds = new ArrayList<>();
 
-      Set<String> tableUUIDs = tableToTabletIds.stream()
-                                  .map(pair -> pair.getLeft())
-                                  .collect(Collectors.toSet());
+      Set<String> tableUUIDs = partitionRanges.stream().map(HashPartition::getTableId).collect(Collectors.toSet());
       for (String tableUUID : tableUUIDs) {
-        tableIdToTable.put(tableUUID, this.syncClient.openTableByUUID(tableUUID));
+        YBTable ybTable = syncClient.openTableByUUID(tableUUID);
+        tableIdToTable.put(tableUUID, ybTable);
+
+        GetTabletListToPollForCDCResponse resp =
+            YBClientUtils.getTabletListToPollForCDCWithRetry(ybTable, tableUUID, connectorConfig);
+        populateTabletPairList(tableUUID, resp, tableToTabletIds);
       }
 
       Map<TableId, String> filteredTableIdToUuid = determineTablesForSnapshot(tableIdToTable);

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
  */
-public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
+public class YugabyteDBSnapshotTest extends YugabytedTestBase {
     @BeforeAll
     public static void beforeClass() throws Exception {
         initializeYBContainer();


### PR DESCRIPTION
## Problem

The connector flow today is such that:
1. Connector obtains the tablets from service
2. `HashPartitions` are created and the partition keys are passed down to the tasks
3. Tasks receive an immutable list of tablets and start processing that
4. In snapshot phase, connector directly rely on the passed list from the top level connector and take snapshot but in streaming phase it validates the tablet list again by asking the current tablets from service.
5. Now suppose if a tablet is split and connector is in streaming phase, connector will handle the split gracefully.
6. At this stage, if a task is restarted the flow will start from the snapshot phase itself and connector will try to get the checkpoint of tablets in the task to confirm whether to take snapshot. But the tablet list available here is stale and it will error out while getting the checkpoint since the tablet would have been deleted by this time.

## Solution

This diff implements a solution to the problem by making a call to `GetTabletListToPollForCDC` in the snapshot phase as well which then ensures that we are only receiving a valid set of tablets to poll.

### Testing

Tested manually using the following steps:
1. Start connector with snapshot mode initial with a single tablet
2. Split a tablet once it reaches streaming phase
3. Insert more data
4. Restart the task
5. Upon restart:
    i. **Without fix:** The task will fail while trying to get the checkpoint of deleted parent tablet
    ii. **With fix:** Connector proceeds to the streaming phase without any error

This fixes yugabyte/yugabyte-db#20636