### PR TITLE
Log checkpoints for tablets after bootstrapping

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -304,53 +304,6 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
     }
 
     /**
-     * Get the checkpoint for given {@link YBTable} and tabletID
-     * @param ybTable
-     * @param tabletId
-     * @throws Exception if the RPC hits any error
-     */
-    protected GetCheckpointResponse getCheckpointWithRetry(YBTable ybTable, String tabletId)
-      throws Exception {
-      short retryCount = 0;
-      while (retryCount <= connectorConfig.maxConnectorRetries()) {
-        try {
-          GetCheckpointResponse resp =
-              this.syncClient.getCheckpoint(ybTable, connectorConfig.streamId(), tabletId);
-
-          return resp;
-        } catch (Exception e) {
-          ++retryCount;
-
-          if (retryCount > this.connectorConfig.maxConnectorRetries()) {
-            LOGGER.error("Too many errors while trying to get checkpoint for tablet {}, "
-                          + "all {} retries failed.", tabletId, this.connectorConfig.maxConnectorRetries());
-
-            throw e;
-          }
-
-          LOGGER.warn("Error while trying to get the checkpoint for tablet {}; will attempt " 
-                      + "retry {} of {} after {} milli-seconds. Exception message: {}",
-                      tabletId, retryCount, 
-                      connectorConfig.maxConnectorRetries(), 
-                      connectorConfig.connectorRetryDelayMs(), e.getMessage());
-          LOGGER.debug("Stacktrace: ", e);
-
-          try {
-            final Metronome retryMetronome =
-                Metronome.parker(Duration.ofMillis(connectorConfig.connectorRetryDelayMs()), Clock.SYSTEM);
-            retryMetronome.pause();
-          } catch (InterruptedException ie) {
-            LOGGER.warn("Connector retry sleep interrupted by exception: {}", ie);
-            Thread.currentThread().interrupt();
-          }
-        }
-      }
-
-      // In ideal scenarios, this code will never be hit.
-      return null;
-    }
-
-    /**
      * Decide if we need to take snapshot or do nothing if snapshot has completed previously
      */
     protected boolean isSnapshotRequired(GetCheckpointResponse getCheckpointResponse,
@@ -433,7 +386,8 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
         String tabletId = entry.getValue();
         YBPartition p = new YBPartition(tableId, tabletId, true /* colocated */);
 
-        GetCheckpointResponse resp = getCheckpointWithRetry(tableIdToTable.get(tableId), tabletId);
+        GetCheckpointResponse resp =
+            YBClientUtils.getCheckpointWithRetry(connectorConfig, syncClient, tableIdToTable.get(tableId), tabletId);
         LOGGER.info("Checkpoint before snapshotting tablet {}: Term {} Index {} SnapshotKey: {}",
                     tabletId, resp.getTerm(), resp.getIndex(), Arrays.toString(resp.getSnapshotKey()));
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -154,6 +154,11 @@ public class YugabyteDBStreamingChangeEventSource implements
         LOGGER.info("Bootstrapping the tablet {}", tabletId);
         syncClient.bootstrapTablet(table, connectorConfig.streamId(), tabletId, 0, 0, true, true);
         markNoSnapshotNeeded(syncClient, table, tabletId);
+
+        GetCheckpointResponse getCheckpointResponse =
+          YBClientUtils.getCheckpointWithRetry(connectorConfig, syncClient, table, tabletId);
+        Objects.requireNonNull(getCheckpointResponse);
+        LOGGER.info("Checkpoint after bootstrapping tablet {}: {}.{}", tabletId, getCheckpointResponse.getTerm(), getCheckpointResponse.getIndex());
     }
 
     protected void bootstrapTabletWithRetry(YBClient syncClient, List<Pair<String,String>> tabletPairList,


### PR DESCRIPTION
This PR adds a log statement which prints the checkpoints for a given tablet just after it has been bootstrapped.