### PR TITLE
Make MBean registration retry attempts configurable

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -594,11 +594,11 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
     protected static final long DEFAULT_CDC_POLL_INTERVAL_MS = 500;
     protected static final int DEFAULT_MAX_CONNECTOR_RETRIES = 5;
     protected static final long DEFAULT_CONNECTOR_RETRY_DELAY_MS = 60000;
-    protected static final long DEFAULT_MBEAN_REGISTRATION_RETRIES = 12;
-    protected static final long DEFAULT_MBEAN_REGISTRATION_RETRY_DELAY_MS = 5_000;
     protected static final boolean DEFAULT_LIMIT_ONE_POLL_PER_ITERATION = false;
     protected static final long DEFAULT_NEW_TABLE_POLL_INTERVAL_MS = 5 * 60 * 1000L;
     protected static final long DEFAULT_LOG_GET_CHANGES_INTERVAL_MS = 5 * 60 * 1000L;
+    public static final int DEFAULT_MBEAN_REGISTRATION_RETRIES = 12;
+    public static final long DEFAULT_MBEAN_REGISTRATION_RETRY_DELAY_MS = 5_000;
 
     @Override
     public JdbcConfiguration getJdbcConfig() {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -11,7 +11,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -51,10 +50,8 @@ import io.debezium.connector.yugabytedb.snapshot.InitialOnlySnapshotter;
 import io.debezium.connector.yugabytedb.snapshot.InitialSnapshotter;
 import io.debezium.connector.yugabytedb.snapshot.NeverSnapshotter;
 import io.debezium.connector.yugabytedb.spi.Snapshotter;
-import io.debezium.heartbeat.DatabaseHeartbeatImpl;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.JdbcConnection;
-import io.debezium.jdbc.JdbcValueConverters;
 import io.debezium.jdbc.JdbcConnection.ConnectionFactory;
 import io.debezium.jdbc.JdbcConnectionException;
 import io.debezium.relational.ColumnFilterMode;
@@ -597,6 +594,8 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
     protected static final long DEFAULT_CDC_POLL_INTERVAL_MS = 500;
     protected static final int DEFAULT_MAX_CONNECTOR_RETRIES = 5;
     protected static final long DEFAULT_CONNECTOR_RETRY_DELAY_MS = 60000;
+    protected static final long DEFAULT_MBEAN_REGISTRATION_RETRIES = 12;
+    protected static final long DEFAULT_MBEAN_REGISTRATION_RETRY_DELAY_MS = 5_000;
     protected static final boolean DEFAULT_LIMIT_ONE_POLL_PER_ITERATION = false;
     protected static final long DEFAULT_NEW_TABLE_POLL_INTERVAL_MS = 5 * 60 * 1000L;
     protected static final long DEFAULT_LOG_GET_CHANGES_INTERVAL_MS = 5 * 60 * 1000L;
@@ -711,6 +710,18 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
             .withImportance(Importance.LOW)
             .withDefault(DEFAULT_CONNECTOR_RETRY_DELAY_MS)
             .withDescription("The amount of time after which the connector will attempt to retry to get the changes from the server.");
+
+    public static final Field MBEAN_REGISTRATION_RETRIES = Field.create("mbean.registration.attempts")
+            .withDisplayName("Number of attempts for registering the metrics MBean")
+            .withType(Type.INT)
+            .withImportance(Importance.LOW)
+            .withDefault(DEFAULT_MBEAN_REGISTRATION_RETRIES);
+
+    public static final Field MBEAN_REGISTRATION_RETRY_DELAY_MS = Field.create("mbean.registration.retry.delay.ms")
+            .withDisplayName("Retry interval between successive attempts to register metrics MBean")
+            .withType(Type.LONG)
+            .withImportance(Importance.LOW)
+            .withDefault(DEFAULT_MBEAN_REGISTRATION_RETRY_DELAY_MS);
 
     public static final Field IGNORE_EXCEPTIONS = Field.create("ignore.exceptions")
             .withDisplayName("Flag to ignore exceptions which do not cause an issue while execution")
@@ -1407,6 +1418,14 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
         return this.isYSQL;
     }
 
+    public int mbeanRegistrationRetries() {
+        return getConfig().getInteger(MBEAN_REGISTRATION_RETRIES);
+    }
+
+    public long mbeanRegistrationRetryDelayMs() {
+        return getConfig().getLong(MBEAN_REGISTRATION_RETRY_DELAY_MS);
+    }
+
     /*
      * protected Duration xminFetchInterval() {
      * return Duration.ofMillis(getConfig().getLong(PostgresConnectorConfig.XMIN_FETCH_INTERVAL));
@@ -1457,7 +1476,9 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
                     AUTO_ADD_NEW_TABLES,
                     NEW_TABLE_POLL_INTERVAL_MS,
                     LOG_GET_CHANGES,
-                    LOG_GET_CHANGES_INTERVAL_MS)
+                    LOG_GET_CHANGES_INTERVAL_MS,
+              MBEAN_REGISTRATION_RETRIES,
+                    MBEAN_REGISTRATION_RETRY_DELAY_MS)
             .events(
                     INCLUDE_UNKNOWN_DATATYPES)
             .connector(

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -711,7 +711,7 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
             .withDefault(DEFAULT_CONNECTOR_RETRY_DELAY_MS)
             .withDescription("The amount of time after which the connector will attempt to retry to get the changes from the server.");
 
-    public static final Field MBEAN_REGISTRATION_RETRIES = Field.create("mbean.registration.attempts")
+    public static final Field MBEAN_REGISTRATION_RETRIES = Field.create("mbean.registration.retries")
             .withDisplayName("Number of attempts for registering the metrics MBean")
             .withType(Type.INT)
             .withImportance(Importance.LOW)

--- a/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBMetrics.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBMetrics.java
@@ -38,8 +38,9 @@ public class YugabyteDBMetrics {
   private static final Logger LOGGER = LoggerFactory.getLogger(YugabyteDBMetrics.class);
 
   // Total 1 minute attempting to retry metrics registration in case of errors
-  private int registrationRetries = 12;
-  private Duration registrationRetryDelay = Duration.ofSeconds(5);
+  private int registrationRetries = YugabyteDBConnectorConfig.DEFAULT_MBEAN_REGISTRATION_RETRIES;
+  private Duration registrationRetryDelay =
+    Duration.ofMillis(YugabyteDBConnectorConfig.DEFAULT_MBEAN_REGISTRATION_RETRY_DELAY_MS);
 
   private final ObjectName name;
   private volatile boolean registered = false;

--- a/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBMetrics.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBMetrics.java
@@ -18,12 +18,12 @@ import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
+import io.debezium.connector.yugabytedb.YugabyteDBConnectorConfig;
 import org.apache.kafka.common.utils.Sanitizer;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.debezium.config.CommonConnectorConfig;
 import io.debezium.connector.common.CdcSourceTaskContext;
 import io.debezium.util.Clock;
 import io.debezium.util.Collect;
@@ -38,8 +38,8 @@ public class YugabyteDBMetrics {
   private static final Logger LOGGER = LoggerFactory.getLogger(YugabyteDBMetrics.class);
 
   // Total 1 minute attempting to retry metrics registration in case of errors
-  private static final int REGISTRATION_RETRIES = 12;
-  private static final Duration REGISTRATION_RETRY_DELAY = Duration.ofSeconds(5);
+  private int registrationRetries = 12;
+  private Duration registrationRetryDelay = Duration.ofSeconds(5);
 
   private final ObjectName name;
   private volatile boolean registered = false;
@@ -52,10 +52,14 @@ public class YugabyteDBMetrics {
     this.name = metricName(taskContext.getConnectorType(), tags);
   }
 
-  protected YugabyteDBMetrics(CommonConnectorConfig connectorConfig, String contextName,
+  protected YugabyteDBMetrics(YugabyteDBConnectorConfig connectorConfig, String contextName,
                               boolean multiPartitionMode) {
     String connectorType = connectorConfig.getContextName();
     String connectorName = connectorConfig.getLogicalName();
+
+    registrationRetries = connectorConfig.mbeanRegistrationRetries();
+    registrationRetryDelay = Duration.ofMillis(connectorConfig.mbeanRegistrationRetryDelayMs());
+
     if (multiPartitionMode) {
       this.name = metricName(connectorType, Collect.linkMapOf(
               "server", connectorName,
@@ -69,18 +73,21 @@ public class YugabyteDBMetrics {
   /**
    * Constructor to initialize the metric related settings while picking up the task Id from the
    * taskContext
-   * @param taskContext the CdcSourceTaskContext to pick the task Id from
+   * @param taskId
    * @param connectorConfig the connector configuration
    * @param contextName name of the context
    * @param multiPartitionMode whether the connector is supposed to work with multi partition per
    * task mode
    */
   protected YugabyteDBMetrics(String taskId,
-                              CommonConnectorConfig connectorConfig,
+                              YugabyteDBConnectorConfig connectorConfig,
                               String contextName,
                               boolean multiPartitionMode) {
     String connectorType = connectorConfig.getContextName();
     String connectorName = connectorConfig.getLogicalName();
+
+    registrationRetries = connectorConfig.mbeanRegistrationRetries();
+    registrationRetryDelay = Duration.ofMillis(connectorConfig.mbeanRegistrationRetryDelayMs());
     
     if (multiPartitionMode) {
       LOGGER.info("Configuring a metric with connector type {} server {}, task ID {} and context {}",
@@ -108,16 +115,16 @@ public class YugabyteDBMetrics {
       // During connector restarts it is possible that Kafka Connect does not manage
       // the lifecycle perfectly. In that case it is possible the old metric MBean is still present.
       // There will be multiple attempts executed to register new MBean.
-      for (int attempt = 1; attempt <= REGISTRATION_RETRIES; attempt++) {
+      for (int attempt = 1; attempt <= registrationRetries; attempt++) {
         try {
           mBeanServer.registerMBean(this, name);
           break;
         } catch (InstanceAlreadyExistsException e) {
-          if (attempt < REGISTRATION_RETRIES) {
+          if (attempt < registrationRetries) {
             LOGGER.warn(
               "Unable to register metrics as an old set with the same name exists, retrying in {} (attempt {} out of {})",
-              REGISTRATION_RETRY_DELAY, attempt, REGISTRATION_RETRIES);
-              final Metronome metronome = Metronome.sleeper(REGISTRATION_RETRY_DELAY, Clock.system());
+              registrationRetryDelay, attempt, registrationRetries);
+              final Metronome metronome = Metronome.sleeper(registrationRetryDelay, Clock.system());
               metronome.pause();
           }
           else {


### PR DESCRIPTION
This PR adds two configuration properties to make the process of MBean registration configurable:
* `mbean.registration.retries` - the number of attempts to retry upon a failure (default: 12)
* `mbean.registration.retry.delay.ms` - the number of milliseconds to wait before attempting a retry to register the MBean (default: 5000)