### PR TITLE
[yugabyte/yugabyte-db#20717] Update yb-client version to use latest changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.kafka>3.6.1</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>
-        <version.ybclient>0.8.76-20240131.111415-1</version.ybclient>
+        <version.ybclient>0.8.78-20240213.065408-1</version.ybclient>
         <version.gson>2.8.9</version.gson>
 
         <!--


### PR DESCRIPTION
## Problem

In context of tablet splitting, we can arrive at a situation where the `YBClient` can host a `RemoteTablet` for a parent split tablet, the `RemoteTablet` in such cases does not have any active tservers. So when the method `getFirstTablet` will return us such `RemoteTablet` and `YBClient` will try to make the RPC call to it, the call would fail with a similar error (method and service names can vary depending on context):

```
org.yb.client.NonRecoverableException: Too many attempts: YRpc(method=GetTabletListToPollForCDC, service=yb.cdc.CDCService, tablet=null, attempt=1800, maxAttempts=1800, maxTimeoutMs=600000, elapsedTimeMs=6964)
```

## Solution

This diff updates the version of yb-client which has a new method `getRandomActiveTablet` which iterates over the list of `RemoteTablet` and only returns a random instance which has tservers linked to it.

This closes yugabyte/yugabyte-db#20717