### PR TITLE
[yugabyte/yugabyte-db#20431] Publish last snapshot record again if callback not received

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -599,6 +599,7 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
     protected static final long DEFAULT_LOG_GET_CHANGES_INTERVAL_MS = 5 * 60 * 1000L;
     public static final int DEFAULT_MBEAN_REGISTRATION_RETRIES = 12;
     public static final long DEFAULT_MBEAN_REGISTRATION_RETRY_DELAY_MS = 5_000;
+    public static final long DEFAULT_LAST_CALLBACK_TIMEOUT_MS = 3 * 60 * 1000;
 
     @Override
     public JdbcConfiguration getJdbcConfig() {
@@ -1076,6 +1077,14 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
                     "'key' Consistency grouping is at primary key level, " +
                     "'global' Consistency grouping is at global level across all transactions");
 
+    public static final Field LAST_CALLBACK_TIMEOUT_MS = Field.create("last.callback.timeout.ms")
+           .withDisplayName("Last callback timeout")
+           .withImportance(Importance.LOW)
+           .withValidation(Field::isNonNegativeLong)
+           .withDefault(DEFAULT_LAST_CALLBACK_TIMEOUT_MS)
+           .withDescription("Time to wait for commit callback before attempting " +
+                            "a failure handling assuming that we have not received any callback");
+
     /**
      * A comma-separated list of regular expressions that match the prefix of logical decoding messages to be excluded
      * from monitoring. Must not be used with {@link #LOGICAL_DECODING_MESSAGE_PREFIX_INCLUDE_LIST}
@@ -1424,6 +1433,10 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
 
     public long mbeanRegistrationRetryDelayMs() {
         return getConfig().getLong(MBEAN_REGISTRATION_RETRY_DELAY_MS);
+    }
+
+    public long lastCallbackTimeoutMs() {
+        return getConfig().getLong(LAST_CALLBACK_TIMEOUT_MS);
     }
 
     /*

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -494,6 +494,12 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                   if (!snapshotCompletedTablets.contains(part.getId()) && hasCallbackTimeoutExceeded(part)) {
                     LOGGER.info("Publishing last snapshot record for partition {} again", part.getId());
                     publishLastSnapshotRecord(part, previousOffset);
+
+                    // Also update the last GetChanges time to ensure that we do not end up publishing
+                    // the last record continuously without exhausting the delay. In other words, it
+                    // can be understood that the publishing the last snapshot record was the result
+                    // of a GetChanges call, thus we are updating the map for time.
+                    lastGetChangesTime.put(part.getId(), System.currentTimeMillis());
                   }
 
                   continue;

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -491,7 +491,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
 
                   // If the timeout has exceeded from the last GetChanges call and we haven't received
                   // any callback on the last snapshot record yet, publish last snapshot record again.
-                  if (!snapshotCompletedTablets.contains(part.getId()) && isCallbackTimeoutExceeded(part)) {
+                  if (!snapshotCompletedTablets.contains(part.getId()) && hasCallbackTimeoutExceeded(part)) {
                     LOGGER.info("Publishing last snapshot record for partition {} again", part.getId());
                     publishLastSnapshotRecord(part, previousOffset);
                   }
@@ -996,7 +996,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
      * @return true if the given partition has exceeded the timeout duration since the last GetChanges
      * call, false otherwise
      */
-    protected boolean isCallbackTimeoutExceeded(YBPartition partition) {
+    protected boolean hasCallbackTimeoutExceeded(YBPartition partition) {
       return (System.currentTimeMillis() - lastGetChangesTime.get(partition.getId())
                 >= connectorConfig.lastCallbackTimeoutMs());
     }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -483,13 +483,16 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                   continue;
                 }
 
-                // If the tablets are waiting for callback for the last snapshot record, check if
+                // If the tablets are waiting for callback for the last snapshot record, check whether the snapshot has
+                // completed, if not then check if the last GetChanges call has elapsed a delay indicating that we
+                // should publish the last snapshot record again.
                 if (tabletsWaitingForCallback.contains(part.getId()) && taskContext.shouldEnableExplicitCheckpointing()) {
                   doSnapshotCompletionCheck(part, snapshotCompletedTablets, tabletsWaitingForCallback, previousOffset);
 
                   // If the timeout has exceeded from the last GetChanges call and we haven't received
                   // any callback on the last snapshot record yet, publish last snapshot record again.
                   if (!snapshotCompletedTablets.contains(part.getId()) && isCallbackTimeoutExceeded(part)) {
+                    LOGGER.info("Publishing last snapshot record for partition {} again", part.getId());
                     publishLastSnapshotRecord(part, previousOffset);
                   }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
@@ -3,6 +3,7 @@ package io.debezium.connector.yugabytedb.connection;
 import java.util.Arrays;
 import java.util.Base64;
 
+import io.debezium.connector.yugabytedb.YugabyteDBOffsetContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yb.cdc.CdcService.CDCSDKCheckpointPB;
@@ -156,6 +157,10 @@ public class OpId implements Comparable<OpId> {
     }
 
     public static OpId snapshotCheckpoint(CdcSdkCheckpoint checkpoint) {
+        if (checkpoint == null) {
+            return YugabyteDBOffsetContext.snapshotStartLsn();
+        }
+
         return new OpId(checkpoint.getTerm(), checkpoint.getIndex(), checkpoint.getKey(),
                         -1 /* to indicate snapshot */, checkpoint.getTime());
     }

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
@@ -155,6 +155,11 @@ public class OpId implements Comparable<OpId> {
                         -1 /* write_id */ , response.getSnapshotTime());
     }
 
+    public static OpId snapshotCheckpoint(CdcSdkCheckpoint checkpoint) {
+        return new OpId(checkpoint.getTerm(), checkpoint.getIndex(), checkpoint.getKey(),
+                        -1 /* to indicate snapshot */, checkpoint.getTime());
+    }
+
     public CdcSdkCheckpoint toCdcSdkCheckpoint() {
         return new CdcSdkCheckpoint(this.term, this.index, this.key, this.write_id, this.time);
     }

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/OpId.java
@@ -3,7 +3,6 @@ package io.debezium.connector.yugabytedb.connection;
 import java.util.Arrays;
 import java.util.Base64;
 
-import io.debezium.connector.yugabytedb.YugabyteDBOffsetContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yb.cdc.CdcService.CDCSDKCheckpointPB;
@@ -156,11 +155,14 @@ public class OpId implements Comparable<OpId> {
                         -1 /* write_id */ , response.getSnapshotTime());
     }
 
+    /**
+     *
+     * @param checkpoint
+     * @return an {@link OpId} which should be used as from_op_id while calling GetChanges for
+     * snapshot
+     */
     public static OpId snapshotCheckpoint(CdcSdkCheckpoint checkpoint) {
-        if (checkpoint == null) {
-            return YugabyteDBOffsetContext.snapshotStartLsn();
-        }
-
+        java.util.Objects.requireNonNull(checkpoint);
         return new OpId(checkpoint.getTerm(), checkpoint.getIndex(), checkpoint.getKey(),
                         -1 /* to indicate snapshot */, checkpoint.getTime());
     }

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/pgproto/YbProtoReplicationMessage.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/pgproto/YbProtoReplicationMessage.java
@@ -106,6 +106,10 @@ public class YbProtoReplicationMessage implements ReplicationMessage {
         return !(rawMessage.getNewTypeinfoList() == null || rawMessage.getNewTypeinfoList().isEmpty());
     }
 
+    public String getPgSchemaName() {
+        return rawMessage.getPgschemaName();
+    }
+
     private List<ReplicationMessage.Column> transform(List<Common.DatumMessagePB> messageList,
                                                       List<CdcService.TypeInfo> typeInfoList) {
         return IntStream.range(0, messageList.size())

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -35,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.*;
 public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
     @BeforeAll
     public static void beforeClass() throws Exception {
-        setTserverFlags("cdc_snapshot_batch_size=50");
         initializeYBContainer();
         TestHelper.dropAllSchemas();
         TestHelper.executeDDL("yugabyte_create_tables.ddl");
@@ -90,10 +89,6 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
           .exceptionally(throwable -> {
               throw new RuntimeException(throwable);
           }).get();
-
-        int minutesToWait = 10;
-        LOGGER.info("Waiting for {} minutes to observe logs", minutesToWait);
-        TestHelper.waitFor(Duration.ofMinutes(10));
     }
 
     @ParameterizedTest

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -103,7 +103,6 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         createTablesInColocatedDB(colocation);
         final int recordsCount = 4000;
         insertBulkRecordsInColocatedDB(recordsCount, "public.test_1");
-        YugabyteDBSnapshotChangeEventSource.TEST_STOP_UPDATING_EXPLICIT_CHECKPOINTS = true;
 
         LOGGER.info("Creating DB stream ID");
         String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1", consistentSnapshot, useSnapshot);
@@ -1030,10 +1029,10 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
 
     static Stream<Arguments> streamTypeProviderForSnapshotWithColocation() {
         return Stream.of(
-//                Arguments.of(false, false, true), // Older stream with colocation
-                Arguments.of(false, false, false)); // Older stream without colocation
-//                Arguments.of(true, true, true), // USE_SNAPSHOT stream with colocation
-//                Arguments.of(true, true, false));  // USE_SNAPSHOT stream without colocation
+                Arguments.of(false, false, true), // Older stream with colocation
+                Arguments.of(false, false, false), // Older stream without colocation
+                Arguments.of(true, true, true), // USE_SNAPSHOT stream with colocation
+                Arguments.of(true, true, false));  // USE_SNAPSHOT stream without colocation
     }
 
     static Stream<Arguments> argumentProviderForEmptyNonEmptyNonColocatedTables() {


### PR DESCRIPTION
## Problem

1. Kafka topic is created with multiple partitions (2 in this example), let’s call them `partition_0` and `partition_1`
2. Connector takes snapshot
3. When the connector receives the last record of the last snapshot batch, it modifies its offset to `Long.MAX_VALUE` so that when Kafka executes a callback on this, we know that Kafka has received the last record of the snapshot process and we can transition to streaming.
4. But here’s the catch, suppose we have the second last record of the snapshot batch which has the offset `offset_second_last_record` and the last record’s modified offset is `offset_last_record`
5. Now even when the connector reads it in the correct order i.e. `second_last` and then `last`, since there are two partitions, there seems to be some kind of situation where the `second_last` record is published later in the topic and that is where the callback gets stuck since we will never receive the callback on the `last` record now.

The above was leading to a problem where we were never transitioning out of snapshot phase thus leading to a task getting stuck there.

## Solution

This PR implements the solution by introducing a timeout `last.callback.timeout.ms` where the logic is to publish the last snapshot record again which will ensure that we receive a callback on the last record of last snapshot batch and gracefully move ahead.