### PR TITLE
[yugabyte/yugabyte-db#21940] Update tablet safe hybrid time only after batch is processed

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
@@ -182,8 +182,6 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
                                             cp.getWrite_id(), cp.getTime(), schemaNeeded.get(tabletId),
                                             taskContext.shouldEnableExplicitCheckpointing() ? tabletToExplicitCheckpoint.get(part.getId()) : null,
                                             tabletSafeTime.getOrDefault(part.getId(), -1L), offsetContext.getWalSegmentIndex(part));
-
-                                    tabletSafeTime.put(part.getId(), response.getResp().getSafeHybridTime());
                                 } catch (CDCErrorException cdcException) {
                                     // Check if exception indicates a tablet split.
                                     if (cdcException.getCDCError().getCode() == CdcService.CDCErrorPB.Code.TABLET_SPLIT) {
@@ -229,6 +227,9 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
                                             response.getResp().getSafeHybridTime());
                                     offsetContext.updateWalPosition(part, finalOpid);
                                     offsetContext.updateWalSegmentIndex(part, response.getWalSegmentIndex());
+
+                                    tabletSafeTime.put(part.getId(), response.getResp().getSafeHybridTime());
+
                                     LOGGER.debug("The final opid for tablet {} is {}", part.getTabletId(), finalOpid);
                                 }
                             }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -552,8 +552,6 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                   LAST_EXPLICIT_CHECKPOINT = explicitCdcSdkCheckpoint;
                 }
 
-                tabletSafeTime.put(part.getId(), resp.getResp().getSafeHybridTime());
-
                 OpId finalOpId = new OpId(resp.getTerm(), resp.getIndex(), resp.getKey(),
                         resp.getWriteId(), resp.getSnapshotTime());
                 LOGGER.debug("Final OpId for tablet {} is {}", part.getId(), finalOpId);
@@ -730,6 +728,8 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                 }
 
                 previousOffset.updateWalPosition(part, finalOpId);
+
+                tabletSafeTime.put(part.getId(), resp.getResp().getSafeHybridTime());
             }
             
             // Reset the retry count here indicating that if the flow has reached here then

--- a/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
@@ -758,8 +758,8 @@ public final class TestHelper {
 
     public static Stream<Arguments> streamTypeProviderForStreaming() {
         return Stream.of(
-                Arguments.of(false, false), // Older stream
-                Arguments.of(true, false)); // NO_EXPORT stream
+                Arguments.of(false, false)); // Older stream
+//                Arguments.of(true, false)); // NO_EXPORT stream
     }
 
     public static Stream<Arguments> streamTypeProviderForSnapshot() {

--- a/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
@@ -758,8 +758,8 @@ public final class TestHelper {
 
     public static Stream<Arguments> streamTypeProviderForStreaming() {
         return Stream.of(
-                Arguments.of(false, false)); // Older stream
-//                Arguments.of(true, false)); // NO_EXPORT stream
+                Arguments.of(false, false), // Older stream
+                Arguments.of(true, false)); // NO_EXPORT stream
     }
 
     public static Stream<Arguments> streamTypeProviderForSnapshot() {

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
@@ -8,8 +8,10 @@ import java.util.concurrent.CompletableFuture;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
 import io.debezium.connector.yugabytedb.common.YugabytedTestBase;
 
+import io.debezium.junit.logging.LogInterceptor;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -27,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
  */
 
-public class YugabyteDBDatatypesTest extends YugabyteDBContainerTestBase {
+public class YugabyteDBDatatypesTest extends YugabytedTestBase {
     private static final String INSERT_STMT = "INSERT INTO s1.a (aa) VALUES (1);" +
             "INSERT INTO s2.a (aa) VALUES (1);";
     private static final String CREATE_TABLES_STMT = "DROP SCHEMA IF EXISTS s1 CASCADE;" +
@@ -190,7 +192,41 @@ public class YugabyteDBDatatypesTest extends YugabyteDBContainerTestBase {
                 .exceptionally(throwable -> {
                     throw new RuntimeException(throwable);
                 }).get();
+    }
 
+    @ParameterizedTest
+    @MethodSource("io.debezium.connector.yugabytedb.TestHelper#streamTypeProviderForStreaming")
+    public void shouldNotCauseDataLossIfThereIsErrorWhileProcessingBatch(
+        boolean consistentSnapshot, boolean useSnapshot) throws Exception {
+        TestHelper.dropAllSchemas();
+        TestHelper.executeDDL("yugabyte_create_tables.ddl");
+
+        LogInterceptor logInterceptor = new LogInterceptor(YugabyteDBStreamingChangeEventSource.class);
+
+        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", consistentSnapshot, useSnapshot);
+        Configuration.Builder configBuilder = TestHelper.getConfigBuilder("public.t1", dbStreamId);
+        configBuilder.with(YugabyteDBConnectorConfig.CONNECTOR_RETRY_DELAY_MS, 60_000);
+        startEngine(configBuilder);
+        final long recordsCount = 1;
+
+        awaitUntilConnectorIsReady();
+        insertRecords(recordsCount);
+
+        YugabyteDBStreamingChangeEventSource.TEST_FAIL_WHILE_PROCESSING_BATCH = true;
+
+        // Do not change the error message.
+        final String errorMessage = "[TEST ONLY] Failing while processing the batch of records";
+
+        // Wait till we have received the failure message.
+        Awaitility.await()
+          .atMost(Duration.ofSeconds(60))
+          .until(() -> logInterceptor.containsStacktraceElement(errorMessage));
+
+        // Revert the flag so that processing can resume normally.
+        YugabyteDBStreamingChangeEventSource.TEST_FAIL_WHILE_PROCESSING_BATCH = false;
+
+        List<SourceRecord> records = new ArrayList<>();
+        waitAndFailIfCannotConsume(records, recordsCount);
     }
 
     @ParameterizedTest

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
  */
 
-public class YugabyteDBDatatypesTest extends YugabytedTestBase {
+public class YugabyteDBDatatypesTest extends YugabyteDBContainerTestBase {
     private static final String INSERT_STMT = "INSERT INTO s1.a (aa) VALUES (1);" +
             "INSERT INTO s2.a (aa) VALUES (1);";
     private static final String CREATE_TABLES_STMT = "DROP SCHEMA IF EXISTS s1 CASCADE;" +


### PR DESCRIPTION
## Problem

In the connector flow, we call `GetChanges` and then immediately set the tablet safe hybrid time from the response i.e. https://github.com/yugabyte/debezium-connector-yugabytedb/blob/main/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java#L533 

Now suppose there’s a case where connector faced some errors while publishing the records from this response and it threw an error, the error handling mechanism would attempt a retry on the `from_op_id` but this time the tablet safe hybrid time value would be higher thus resulting in filtering of some records which would cause data loss.

## Solution

This diff moves the tablet safe time updation after the records have been processed successfully by the connector.

Closes yugabyte/yugabyte-db#21940