### PR TITLE
[yugabyte/yugabyte-db#22550] Replace assertion while validating tablet ranges with IllegalStateException

### DIFF
--- a/src/test/java/io/debezium/connector/yugabytedb/connection/HashPartitionTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/connection/HashPartitionTest.java
@@ -132,7 +132,7 @@ public class HashPartitionTest {
 			partitions.add(d);
 		}
 
-		assertThrows(AssertionError.class, () -> HashPartition.validateCompleteRanges(partitions));
+		assertThrows(IllegalStateException.class, () -> HashPartition.validateCompleteRanges(partitions));
 	}
 
 


### PR DESCRIPTION
## Problem

The current check while validating tablet ranges uses assertions to validate the keys. According to [Oracle Java docs](https://docs.oracle.com/javase/7/docs/technotes/guides/language/assert.html), assertions are disabled by default in a deployed application and hence we will never hit this assertion error even when there's a genuine issue.

## Solution

This PR replaces the assertions with an `IllegalStateException` with a proper message to indicate whenever there's an error while validating whether or not we have received the tablets for the complete range.

This closes yugabyte/yugabyte-db#22550