### PR TITLE
[WIP] Create a JDBC connection only while decoding array types

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeEventSourceFactory.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeEventSourceFactory.java
@@ -32,7 +32,6 @@ public class YugabyteDBChangeEventSourceFactory implements ChangeEventSourceFact
     private static final Logger LOGGER = LoggerFactory.getLogger(YugabyteDBChangeEventSourceFactory.class);
 
     private final YugabyteDBConnectorConfig configuration;
-    private final YugabyteDBConnection jdbcConnection;
     private final ErrorHandler errorHandler;
     private final YugabyteDBEventDispatcher<TableId> dispatcher;
     private final Clock clock;
@@ -46,7 +45,6 @@ public class YugabyteDBChangeEventSourceFactory implements ChangeEventSourceFact
 
     public YugabyteDBChangeEventSourceFactory(YugabyteDBConnectorConfig configuration,
                                               Snapshotter snapshotter,
-                                              YugabyteDBConnection jdbcConnection,
                                               ErrorHandler errorHandler,
                                               YugabyteDBEventDispatcher<TableId> dispatcher,
                                               Clock clock, YugabyteDBSchema schema,
@@ -56,7 +54,6 @@ public class YugabyteDBChangeEventSourceFactory implements ChangeEventSourceFact
                                               SlotState startingSlotInfo,
                                               ChangeEventQueue<DataChangeEvent> queue) {
         this.configuration = configuration;
-        this.jdbcConnection = jdbcConnection;
         this.errorHandler = errorHandler;
         this.dispatcher = dispatcher;
         this.clock = clock;
@@ -76,7 +73,6 @@ public class YugabyteDBChangeEventSourceFactory implements ChangeEventSourceFact
                 configuration,
                 taskContext,
                 snapshotter,
-                jdbcConnection,
                 schema,
                 dispatcher,
                 clock,
@@ -91,7 +87,6 @@ public class YugabyteDBChangeEventSourceFactory implements ChangeEventSourceFact
             return new YugabyteDBStreamingChangeEventSource(
                     configuration,
                     snapshotter,
-                    jdbcConnection,
                     dispatcher,
                     errorHandler,
                     clock,
@@ -104,7 +99,6 @@ public class YugabyteDBChangeEventSourceFactory implements ChangeEventSourceFact
             return new YugabyteDBConsistentStreamingSource(
                     configuration,
                     snapshotter,
-                    jdbcConnection,
                     dispatcher,
                     errorHandler,
                     clock,
@@ -119,14 +113,6 @@ public class YugabyteDBChangeEventSourceFactory implements ChangeEventSourceFact
     public Optional<IncrementalSnapshotChangeEventSource<YBPartition, ? extends DataCollectionId>> getIncrementalSnapshotChangeEventSource(YugabyteDBOffsetContext offsetContext,
                                                                                                                               SnapshotProgressListener snapshotProgressListener,
                                                                                                                               DataChangeEventListener dataChangeEventListener) {
-        final SignalBasedIncrementalSnapshotChangeEventSource<YBPartition, TableId> incrementalSnapshotChangeEventSource = new SignalBasedIncrementalSnapshotChangeEventSource<YBPartition, TableId>(
-                configuration,
-                jdbcConnection,
-                dispatcher,
-                schema,
-                clock,
-                snapshotProgressListener,
-                dataChangeEventListener);
-        return Optional.of(incrementalSnapshotChangeEventSource);
+        return Optional.empty();
     }
 }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeRecordEmitter.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeRecordEmitter.java
@@ -196,8 +196,7 @@ public class YugabyteDBChangeRecordEmitter extends RelationalChangeRecordEmitter
             undeliveredToastableColumns.remove(columnName);
             int position = getPosition(columnName, table, values);
             if (position != -1) {
-                Object value = column.getValue(() -> (BaseConnection) connection.connection(),
-                        connectorConfig.includeUnknownDatatypes());
+                Object value = column.getValue(connection, connectorConfig.includeUnknownDatatypes());
                 // values[position] = value;
                 values[position] = new Object[]{ value, Boolean.TRUE };
             }
@@ -240,8 +239,7 @@ public class YugabyteDBChangeRecordEmitter extends RelationalChangeRecordEmitter
 
             int position = getPosition(columnName, table, values);
             if (position != -1) {
-                Object value = column.getValue(() -> (BaseConnection) connection.connection(),
-                        connectorConfig.includeUnknownDatatypes());
+                Object value = column.getValue(connection, connectorConfig.includeUnknownDatatypes());
 
                 values[position] = new Object[]{ value, Boolean.TRUE };
             }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
@@ -115,9 +115,11 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
         }
         String serializedNameToType = "";
         String serializedOidToType = "";
-        try (YugabyteDBConnection connection = new YugabyteDBConnection(yugabyteDBConnectorConfig.getJdbcConfig(), YugabyteDBConnection.CONNECTION_GENERAL)) {
+        try (YugabyteDBConnection connection = new YugabyteDBConnection(yugabyteDBConnectorConfig.getJdbcConfig(), YugabyteDBConnection.CONNECTION_VALIDATE_CONNECTION)) {
             if (yugabyteDBConnectorConfig.isYSQLDbType()) {
+                LOGGER.info("Creating type registry");
                 YugabyteDBTypeRegistry typeRegistry = new YugabyteDBTypeRegistry(connection);
+                LOGGER.info("After creating type registry");
                 Map<String, YugabyteDBType> nameToType = typeRegistry.getNameToType();
                 Map<Integer, YugabyteDBType> oidToType = typeRegistry.getOidToType();
                 try {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
@@ -29,14 +29,13 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
 
     public YugabyteDBConsistentStreamingSource(YugabyteDBConnectorConfig connectorConfig,
                                                Snapshotter snapshotter,
-                                               YugabyteDBConnection connection,
                                                YugabyteDBEventDispatcher<TableId> dispatcher,
                                                ErrorHandler errorHandler, Clock clock,
                                                YugabyteDBSchema schema,
                                                YugabyteDBTaskContext taskContext,
                                                ReplicationConnection replicationConnection,
                                                ChangeEventQueue<DataChangeEvent> queue) {
-        super(connectorConfig, snapshotter, connection, dispatcher, errorHandler, clock, schema,
+        super(connectorConfig, snapshotter, dispatcher, errorHandler, clock, schema,
               taskContext, replicationConnection, queue);
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBEventDispatcher.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBEventDispatcher.java
@@ -55,7 +55,6 @@ public class YugabyteDBEventDispatcher<T extends DataCollectionId> extends Event
     private final InconsistentSchemaHandler<YBPartition, T> inconsistentSchemaHandler;
     private final Signal<YBPartition> signal;
     private final boolean neverSkip;
-    private final Heartbeat heartbeat;
     private final EnumSet<Envelope.Operation> skippedOperations;
     private final DataCollectionFilters.DataCollectionFilter<T> filter;
     private final YugabyteDBTransactionMonitor transactionMonitor;
@@ -64,8 +63,7 @@ public class YugabyteDBEventDispatcher<T extends DataCollectionId> extends Event
     public YugabyteDBEventDispatcher(YugabyteDBConnectorConfig connectorConfig, TopicSelector<T> topicSelector,
                                    DatabaseSchema<T> schema, ChangeEventQueue<DataChangeEvent> queue, DataCollectionFilters.DataCollectionFilter<T> filter,
                                    ChangeEventCreator changeEventCreator, InconsistentSchemaHandler<YBPartition, T> inconsistentSchemaHandler,
-                                   EventMetadataProvider metadataProvider, HeartbeatFactory<T> heartbeatFactory, SchemaNameAdjuster schemaNameAdjuster,
-                                   JdbcConnection jdbcConnection) {
+                                   EventMetadataProvider metadataProvider, HeartbeatFactory<T> heartbeatFactory, SchemaNameAdjuster schemaNameAdjuster) {
         super(connectorConfig, topicSelector, schema, queue, filter, changeEventCreator, inconsistentSchemaHandler, metadataProvider,
                 heartbeatFactory, schemaNameAdjuster);
         this.connectorConfig = connectorConfig;
@@ -74,7 +72,6 @@ public class YugabyteDBEventDispatcher<T extends DataCollectionId> extends Event
         this.logicalDecodingMessageMonitor = new LogicalDecodingMessageMonitor(connectorConfig, this::enqueueLogicalDecodingMessage);
         this.messageFilter = connectorConfig.getMessageFilter();
         this.topicSelector = topicSelector;
-        this.heartbeat = heartbeatFactory.createHeartbeat();
         this.streamingReceiver = new YugabyteDBStreamingChangeRecordReceiver();
         this.inconsistentSchemaHandler = inconsistentSchemaHandler != null ? inconsistentSchemaHandler : this::errorOnMissingSchema;
         this.signal = new Signal<>(connectorConfig, this);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -83,24 +83,21 @@ public class YugabyteDBOffsetContext implements OffsetContext {
     }
 
     public static YugabyteDBOffsetContext initialContextForSnapshot(YugabyteDBConnectorConfig connectorConfig,
-                                                                    YugabyteDBConnection jdbcConnection,
                                                                     Clock clock,
                                                                     Set<YBPartition> partitions) {
-        return initialContext(connectorConfig, jdbcConnection, clock, snapshotStartLsn(),
+        return initialContext(connectorConfig, clock, snapshotStartLsn(),
                               snapshotStartLsn(), partitions);
     }
 
     public static YugabyteDBOffsetContext initialContext(YugabyteDBConnectorConfig connectorConfig,
-                                                         YugabyteDBConnection jdbcConnection,
                                                          Clock clock,
                                                          Set<YBPartition> partitions) {
         LOGGER.info("Initializing streaming context");
-        return initialContext(connectorConfig, jdbcConnection, clock, streamingStartLsn(),
+        return initialContext(connectorConfig, clock, streamingStartLsn(),
                               streamingStartLsn(), partitions);
     }
 
     public static YugabyteDBOffsetContext initialContext(YugabyteDBConnectorConfig connectorConfig,
-                                                         YugabyteDBConnection jdbcConnection,
                                                          Clock clock,
                                                          OpId lastCommitLsn,
                                                          OpId lastCompletelyProcessedLsn,

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSchema.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSchema.java
@@ -373,15 +373,19 @@ public class YugabyteDBSchema extends RelationalDatabaseSchema {
     }
 
     private int getLength(int oid) {
-        return getTypeRegistry().get(oid).getDefaultLength();
+//        return getTypeRegistry().get(oid).getDefaultLength();
+        return -1;
     }
 
     private int getScale(int oid) {
-        return getTypeRegistry().get(oid).getDefaultScale();
+//        return getTypeRegistry().get(oid).getDefaultScale();
+        return -1;
     }
 
     private int resolveNativeType(int oid) {
-        return getTypeRegistry().get(oid).getRootType().getOid();
+        int nativeOid = getTypeRegistry().get(oid).getRootType().getOid();
+        LOGGER.info("VKVK native type oid is " + nativeOid);
+        return nativeOid;
     }
 
     private int resolveQLType(QLType type)

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -101,12 +101,11 @@ public class YugabyteDBStreamingChangeEventSource implements
     protected Set<String> splitTabletsWaitingForCallback;
     protected List<HashPartition> partitionRanges;
 
-    public YugabyteDBStreamingChangeEventSource(YugabyteDBConnectorConfig connectorConfig, Snapshotter snapshotter,
-                                                YugabyteDBConnection connection, YugabyteDBEventDispatcher<TableId> dispatcher, ErrorHandler errorHandler, Clock clock,
+    public YugabyteDBStreamingChangeEventSource(YugabyteDBConnectorConfig connectorConfig, Snapshotter snapshotter, YugabyteDBEventDispatcher<TableId> dispatcher, ErrorHandler errorHandler, Clock clock,
                                                 YugabyteDBSchema schema, YugabyteDBTaskContext taskContext, ReplicationConnection replicationConnection,
                                                 ChangeEventQueue<DataChangeEvent> queue) {
         this.connectorConfig = connectorConfig;
-        this.connection = connection;
+        this.connection = new YugabyteDBConnection(connectorConfig.getJdbcConfig(), YugabyteDBConnection.CONNECTION_GENERAL);
         this.dispatcher = dispatcher;
         this.errorHandler = errorHandler;
         this.clock = clock;
@@ -144,7 +143,7 @@ public class YugabyteDBStreamingChangeEventSource implements
 
         if (!hasStartLsnStoredInContext) {
             LOGGER.info("No start opid found in the context.");
-                offsetContext = YugabyteDBOffsetContext.initialContext(connectorConfig, connection, clock, partitions);
+                offsetContext = YugabyteDBOffsetContext.initialContext(connectorConfig, clock, partitions);
         }
         try {
             // Populate partition ranges.

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/AbstractColumnValue.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/AbstractColumnValue.java
@@ -13,6 +13,7 @@ import java.time.OffsetTime;
 import java.time.ZoneOffset;
 
 import org.apache.kafka.connect.errors.ConnectException;
+import org.postgresql.core.BaseConnection;
 import org.postgresql.geometric.PGbox;
 import org.postgresql.geometric.PGcircle;
 import org.postgresql.geometric.PGline;
@@ -191,10 +192,10 @@ public abstract class AbstractColumnValue<T> implements ReplicationMessage.Colum
     }
 
     @Override
-    public Object asArray(String columnName, YugabyteDBType type, String fullType, PgConnectionSupplier connection) {
+    public Object asArray(String columnName, YugabyteDBType type, String fullType, YugabyteDBConnection connection) {
         try {
             final String dataString = asString();
-            return new PgArray(connection.get(), type.getOid(), dataString);
+            return new PgArray((BaseConnection) connection.connection(), type.getOid(), dataString);
         }
         catch (SQLException e) {
             LOGGER.warn("Unexpected exception trying to process PgArray ({}) column '{}', {}", fullType, columnName, e);
@@ -204,7 +205,7 @@ public abstract class AbstractColumnValue<T> implements ReplicationMessage.Colum
 
     @Override
     public Object asDefault(YugabyteDBTypeRegistry yugabyteDBTypeRegistry, int columnType, String columnName, String fullType, boolean includeUnknownDatatypes,
-                            PgConnectionSupplier connection) {
+                            YugabyteDBConnection connection) {
         if (includeUnknownDatatypes) {
             // this includes things like PostGIS geoemetries or other custom types
             // leave up to the downstream message recipient to deal with

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/ReplicationMessage.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/ReplicationMessage.java
@@ -12,6 +12,7 @@ import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.util.List;
 
+import io.debezium.jdbc.JdbcConnection;
 import org.postgresql.geometric.PGbox;
 import org.postgresql.geometric.PGcircle;
 import org.postgresql.geometric.PGline;
@@ -65,7 +66,7 @@ public interface ReplicationMessage {
          */
         ColumnTypeMetadata getTypeMetadata();
 
-        Object getValue(final PgConnectionSupplier connection, boolean includeUnknownDatatypes);
+        Object getValue(final YugabyteDBConnection connection, boolean includeUnknownDatatypes);
 
         boolean isOptional();
 
@@ -133,9 +134,9 @@ public interface ReplicationMessage {
 
         boolean isArray(YugabyteDBType type);
 
-        Object asArray(String columnName, YugabyteDBType type, String fullType, PgConnectionSupplier connection);
+        Object asArray(String columnName, YugabyteDBType type, String fullType, YugabyteDBConnection connection);
 
-        Object asDefault(YugabyteDBTypeRegistry typeRegistry, int columnType, String columnName, String fullType, boolean includeUnknownDatatypes, PgConnectionSupplier connection);
+        Object asDefault(YugabyteDBTypeRegistry typeRegistry, int columnType, String columnName, String fullType, boolean includeUnknownDatatypes, YugabyteDBConnection connection);
     }
 
     /**

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/ReplicationMessageColumnValueResolver.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/ReplicationMessageColumnValueResolver.java
@@ -16,6 +16,8 @@ import io.debezium.connector.yugabytedb.YugabyteDBTypeRegistry;
 import io.debezium.connector.yugabytedb.connection.ReplicationMessage.ColumnValue;
 import org.yb.QLType;
 
+import java.sql.SQLException;
+
 /**
  * @author Chris Cranford
  */
@@ -37,7 +39,7 @@ public class ReplicationMessageColumnValueResolver {
      * @return
      */
     public static Object resolveValue(String columnName, YugabyteDBType type, String fullType,
-                                      ColumnValue value, final PgConnectionSupplier connection,
+                                      ColumnValue value, final YugabyteDBConnection connection,
                                       boolean includeUnknownDatatypes,
                                       YugabyteDBTypeRegistry yugabyteDBTypeRegistry) {
         if (value.isNull()) {
@@ -52,8 +54,7 @@ public class ReplicationMessageColumnValueResolver {
                     includeUnknownDatatypes, yugabyteDBTypeRegistry);
         }
 
-        // CDCSDK this too we can avoid using connection.
-        // only date and string requires
+        // We will only open a connection once we detect that it is an array type.
         if (value.isArray(type)) {
             return value.asArray(columnName, type, fullType, connection);
         }

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/YugabyteDBConnection.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/YugabyteDBConnection.java
@@ -58,6 +58,8 @@ public class YugabyteDBConnection extends JdbcConnection {
     public static final String CONNECTION_VALIDATE_CONNECTION = "Debezium Validate Connection";
     public static final String CONNECTION_HEARTBEAT = "Debezium Heartbeat";
     public static final String CONNECTION_GENERAL = "Debezium General";
+    public static final String CONNECTION_TYPE_REGISTRY = "Debezium Type Registry";
+    public static final String CONNECTION_TEST = "Debezium Test";
 
     private static Logger LOGGER = LoggerFactory.getLogger(YugabyteDBConnection.class);
 

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/pgoutput/YbOutputMessageDecoder.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/pgoutput/YbOutputMessageDecoder.java
@@ -683,7 +683,7 @@ public class YbOutputMessageDecoder extends AbstractMessageDecoder {
                         new AbstractReplicationMessageColumn(columnName, columnType, typeExpression,
                                 optional, true) {
                             @Override
-                            public Object getValue(PgConnectionSupplier connection,
+                            public Object getValue(YugabyteDBConnection connection,
                                                    boolean includeUnknownDatatypes) {
                                 return YbOutputReplicationMessage.getValue(columnName, columnType,
                                         typeExpression, valueStr, connection,
@@ -702,7 +702,7 @@ public class YbOutputMessageDecoder extends AbstractMessageDecoder {
                         new AbstractReplicationMessageColumn(columnName, columnType, typeExpression,
                                 true, true) {
                             @Override
-                            public Object getValue(PgConnectionSupplier connection,
+                            public Object getValue(YugabyteDBConnection connection,
                                                    boolean includeUnknownDatatypes) {
                                 return null;
                             }

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/pgoutput/YbOutputReplicationMessage.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/pgoutput/YbOutputReplicationMessage.java
@@ -14,6 +14,7 @@ import io.debezium.connector.yugabytedb.YugabyteDBType;
 import io.debezium.connector.yugabytedb.YugabyteDBTypeRegistry;
 import io.debezium.connector.yugabytedb.connection.ReplicationMessage;
 import io.debezium.connector.yugabytedb.connection.ReplicationMessageColumnValueResolver;
+import io.debezium.connector.yugabytedb.connection.YugabyteDBConnection;
 
 /**
  * @author Gunnar Morling
@@ -91,7 +92,7 @@ public class YbOutputReplicationMessage implements ReplicationMessage {
      *
      * @return the value; may be null
      */
-    public static Object getValue(String columnName, YugabyteDBType type, String fullType, String rawValue, final PgConnectionSupplier connection,
+    public static Object getValue(String columnName, YugabyteDBType type, String fullType, String rawValue, final YugabyteDBConnection connection,
                                   boolean includeUnknownDataTypes, YugabyteDBTypeRegistry yugabyteDBTypeRegistry) {
         final YbOutputColumnValue columnValue = new YbOutputColumnValue(rawValue);
         return ReplicationMessageColumnValueResolver.resolveValue(columnName, type, fullType, columnValue, connection, includeUnknownDataTypes, yugabyteDBTypeRegistry);

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/pgproto/YbProtoColumnValue.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/pgproto/YbProtoColumnValue.java
@@ -16,6 +16,8 @@ import java.time.OffsetTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 
+import io.debezium.connector.yugabytedb.connection.YugabyteDBConnection;
+import org.postgresql.core.BaseConnection;
 import org.postgresql.geometric.PGpoint;
 import org.postgresql.jdbc.PgArray;
 import org.postgresql.util.PGmoney;
@@ -310,7 +312,7 @@ public class YbProtoColumnValue extends AbstractColumnValue<Common.DatumMessageP
     }
 
     @Override
-    public Object asArray(String columnName, YugabyteDBType type, String fullType, PgConnectionSupplier connection) {
+    public Object asArray(String columnName, YugabyteDBType type, String fullType, YugabyteDBConnection connection) {
         // Currently the logical decoding plugin sends unhandled types as a byte array containing the string
         // representation (in Postgres) of the array value.
         // The approach to decode this is sub-optimal but the only way to improve this is to update the plugin.
@@ -328,7 +330,7 @@ public class YbProtoColumnValue extends AbstractColumnValue<Common.DatumMessageP
              * }
              */
             final String dataString = asString();
-            return new PgArray(connection.get(), type.getOid(), dataString);
+            return new PgArray((BaseConnection) connection.connection(), type.getOid(), dataString);
             /*
              * String dataString = new String(data, Charset.forName("UTF-8"));
              * PgArray arrayData = new PgArray(connection.get(), (int) value.getColumnType(), dataString);
@@ -344,7 +346,7 @@ public class YbProtoColumnValue extends AbstractColumnValue<Common.DatumMessageP
 
     @Override
     public Object asDefault(YugabyteDBTypeRegistry yugabyteDBTypeRegistry, int columnType, String columnName, String fullType, boolean includeUnknownDatatypes,
-                            PgConnectionSupplier connection) {
+                            YugabyteDBConnection connection) {
         final YugabyteDBType type = yugabyteDBTypeRegistry.get(columnType);
         if (type.getOid() == yugabyteDBTypeRegistry.geometryOid() ||
                 type.getOid() == yugabyteDBTypeRegistry.geographyOid() ||

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/pgproto/YbProtoReplicationMessage.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/pgproto/YbProtoReplicationMessage.java
@@ -13,6 +13,7 @@ import java.util.OptionalLong;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import io.debezium.connector.yugabytedb.connection.YugabyteDBConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yb.Common;
@@ -124,7 +125,7 @@ public class YbProtoReplicationMessage implements ReplicationMessage {
                         return new AbstractReplicationMessageColumn(columnName, type, fullType,
                                 typeInfo.map(CdcService.TypeInfo::getValueOptional).orElse(Boolean.FALSE), hasTypeMetadata()) {
                             @Override
-                            public Object getValue(PgConnectionSupplier connection, boolean includeUnknownDatatypes) {
+                            public Object getValue(YugabyteDBConnection connection, boolean includeUnknownDatatypes) {
                                 return YbProtoReplicationMessage.this.getValue(columnName, type,
                                         fullType, datum, connection, includeUnknownDatatypes);
                             }
@@ -139,7 +140,7 @@ public class YbProtoReplicationMessage implements ReplicationMessage {
                         return new AbstractReplicationMessageColumn(columnName, type, fullType,
                                 typeInfo.map(CdcService.TypeInfo::getValueOptional).orElse(Boolean.FALSE), hasTypeMetadata()) {
                             @Override
-                            public Object getValue(PgConnectionSupplier connection, boolean includeUnknownDatatypes) {
+                            public Object getValue(YugabyteDBConnection connection, boolean includeUnknownDatatypes) {
                                 return YbProtoReplicationMessage.this.getValue(columnName, type, datum);
                             }
                             @Override
@@ -160,7 +161,7 @@ public class YbProtoReplicationMessage implements ReplicationMessage {
 
     public Object getValue(String columnName, YugabyteDBType type, String fullType,
                            Common.DatumMessagePB datumMessage,
-                           final PgConnectionSupplier connection,
+                           final YugabyteDBConnection connection,
                            boolean includeUnknownDatatypes) {
         final YbProtoColumnValue columnValue = new YbProtoColumnValue(datumMessage);
         return ReplicationMessageColumnValueResolver.resolveValue(columnName, type, fullType,

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/wal2json/Wal2JsonReplicationMessage.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/wal2json/Wal2JsonReplicationMessage.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.OptionalLong;
 import java.util.regex.Matcher;
 
+import io.debezium.connector.yugabytedb.connection.YugabyteDBConnection;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
@@ -123,7 +124,7 @@ class Wal2JsonReplicationMessage implements ReplicationMessage {
             columns.add(new AbstractReplicationMessageColumn(columnName, columnType, columnTypeName, columnOptional, true) {
 
                 @Override
-                public Object getValue(PgConnectionSupplier connection, boolean includeUnknownDatatypes) {
+                public Object getValue(YugabyteDBConnection connection, boolean includeUnknownDatatypes) {
                     return Wal2JsonReplicationMessage.this.getValue(columnName, columnType, columnTypeName, rawValue, connection, includeUnknownDatatypes);
                 }
 
@@ -167,7 +168,7 @@ class Wal2JsonReplicationMessage implements ReplicationMessage {
      *
      * @return the value; may be null
      */
-    public Object getValue(String columnName, YugabyteDBType type, String fullType, Value rawValue, final PgConnectionSupplier connection,
+    public Object getValue(String columnName, YugabyteDBType type, String fullType, Value rawValue, final YugabyteDBConnection connection,
                            boolean includeUnknownDatatypes) {
         final Wal2JsonColumnValue columnValue = new Wal2JsonColumnValue(rawValue);
         return ReplicationMessageColumnValueResolver.resolveValue(columnName, type, fullType, columnValue, connection, includeUnknownDatatypes, yugabyteDBTypeRegistry);

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletableFuture;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
 import io.debezium.connector.yugabytedb.common.YugabytedTestBase;
 
+import io.debezium.connector.yugabytedb.connection.YugabyteDBConnection;
 import io.debezium.junit.logging.LogInterceptor;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -29,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
  */
 
-public class YugabyteDBDatatypesTest extends YugabyteDBContainerTestBase {
+public class YugabyteDBDatatypesTest extends YugabytedTestBase {
     private static final String INSERT_STMT = "INSERT INTO s1.a (aa) VALUES (1);" +
             "INSERT INTO s2.a (aa) VALUES (1);";
     private static final String CREATE_TABLES_STMT = "DROP SCHEMA IF EXISTS s1 CASCADE;" +
@@ -192,6 +193,13 @@ public class YugabyteDBDatatypesTest extends YugabyteDBContainerTestBase {
                 .exceptionally(throwable -> {
                     throw new RuntimeException(throwable);
                 }).get();
+
+        // Since this table has no datatypes which require a JDBC connection to be decoded,
+        // we shouldn't have opened any connections.
+        assertEquals(0, TestHelper.getConnectionCount(YugabyteDBConnection.CONNECTION_GENERAL));
+
+        LOGGER.info("Waiting for 2 minutes");
+        TestHelper.waitFor(Duration.ofMinutes(2));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Problem

The `YugabyteDBConnector` opens a global JDBC connection which is used to decode data types, this connection is created only once per task and is retained for the complete lifetime of the task. However, one task per connection creates a problem when the task count is high and we end up in a state where we have a lot of JDBC connections open.

Since the change events the connector receives are already decoded in case of non-array types, a JDBC connection is not really needed to decode them so unless there's an array type in the table the connector is polling, the connection keeps hogging resources.

## Solution

This PR aims to change the behaviour and only uses a JDBC connection while decoding array types.
