### PR TITLE
[DBZ] Use full partition ID for colocated tables

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YBPartition.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YBPartition.java
@@ -26,20 +26,9 @@ public class YBPartition implements Partition {
     private final String tabletId;
     private final String tableId;
 
-    private boolean colocated;
-
     public YBPartition(String tableId, String tabletId) {
         this.tableId = tableId;
         this.tabletId = tabletId;
-
-        // By default, assume that the table is not colocated.
-        this.colocated = false;
-    }
-
-    public YBPartition(String tableId, String tabletId, boolean isTableColocated) {
-        this.tableId = tableId;
-        this.tabletId = tabletId;
-        this.colocated = isTableColocated;
     }
 
     @Override
@@ -56,14 +45,9 @@ public class YBPartition implements Partition {
     }
 
     /**
-     * @return the ID of this partition in the format {@code tableId.tabletId} (if table is
-     * colocated) or {@code tabletId} (if table is not colocated)
+     * @return the ID of this partition in the format {@code tableId.tabletId}
      */
     public String getId() {
-        if (!isTableColocated()) {
-            return getTabletId();
-        }
-
         return getFullPartitionName();
     }
 
@@ -74,14 +58,6 @@ public class YBPartition implements Partition {
      */
     public String getFullPartitionName() {
         return getTableId() + "." + getTabletId();
-    }
-
-    public boolean isTableColocated() {
-        return this.colocated;
-    }
-
-    public void markTableAsColocated() {
-        this.colocated = true;
     }
 
     @Override
@@ -105,6 +81,16 @@ public class YBPartition implements Partition {
     @Override
     public String toString() {
         return String.format("YBPartition {tableId=%s, tabletId=%s}", this.tableId, this.tabletId);
+    }
+
+    public static YBPartition fromFullPartitionId(String fullPartitionId) {
+        String[] tableTablet = fullPartitionId.split("\\.");
+
+        if (tableTablet.length == 1) {
+            throw new RuntimeException("Full partition ID expected of the form tabletId.tabletId, provided " + fullPartitionId);
+        }
+
+        return new YBPartition(tableTablet[0], tableTablet[1]);
     }
 
     static class Provider implements Partition.Provider<YBPartition> {

--- a/src/main/java/io/debezium/connector/yugabytedb/consistent/Message.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/consistent/Message.java
@@ -25,9 +25,11 @@ public class Message implements Comparable<Message> {
     public final BigInteger recordTime;
     public final BigInteger snapShotTime;
     public final long sequence;
+    public final boolean colocated;
 
     public Message(CdcService.CDCSDKProtoRecordPB record, String tableId, String tablet, String txn,
-                   BigInteger commitTime, BigInteger recordTime, BigInteger snapShotTime, long sequence) {
+                   BigInteger commitTime, BigInteger recordTime, BigInteger snapShotTime, long sequence,
+                   boolean colocated) {
         this.record = record;
         this.tableId = tableId;
         this.tablet = tablet;
@@ -36,6 +38,7 @@ public class Message implements Comparable<Message> {
         this.recordTime = recordTime;
         this.snapShotTime = snapShotTime;
         this.sequence = sequence;
+        this.colocated = colocated;
     }
 
     /**
@@ -134,6 +137,7 @@ public class Message implements Comparable<Message> {
         private String tableId;
         private String tabletId;
         private long snapshotTime;
+        private boolean colocated;
 
         private final static AtomicLong sequence = new AtomicLong();
 
@@ -157,12 +161,17 @@ public class Message implements Comparable<Message> {
             return this;
         }
 
+        public Builder setColocated(boolean colocated) {
+            this.colocated = colocated;
+            return this;
+        }
+
         public Message build() {
             CdcService.RowMessage m = record.getRowMessage();
             return new Message(this.record, this.tableId, this.tabletId,
                     String.valueOf(m.getTransactionId()),
                     toUnsignedBigInteger(m.getCommitTime()), toUnsignedBigInteger(m.getRecordTime()), toUnsignedBigInteger(this.snapshotTime),
-                    sequence.incrementAndGet());
+                    sequence.incrementAndGet(), this.colocated);
         }
     }
 

--- a/src/test/java/io/debezium/connector/yugabytedb/SourceInfoTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/SourceInfoTest.java
@@ -45,7 +45,7 @@ public class SourceInfoTest extends YugabyteDBContainerTestBase {
             fail();
         }
 
-        YBPartition partition = new YBPartition(DUMMY_TABLE_ID, DUMMY_TABLET_ID, false);
+        YBPartition partition = new YBPartition(DUMMY_TABLE_ID, DUMMY_TABLET_ID);
 
         source.update(partition, OpId.valueOf("1:2:keyStrValue:4:5"), 123L, "txId",
                       new TableId("yugabyte", "public", DUMMY_TABLE_NAME), 123L);

--- a/src/test/java/io/debezium/connector/yugabytedb/consistent/MergerTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/consistent/MergerTest.java
@@ -27,7 +27,7 @@ class MergerTest {
                 BigInteger.valueOf(6822178296495259648L),
                 BigInteger.ZERO,
                 BigInteger.ZERO,
-                34);
+                34, false);
 
         CdcService.CDCSDKProtoRecordPB insertProtoRecord = CdcService.CDCSDKProtoRecordPB.newBuilder()
                 .setRowMessage(CdcService.RowMessage.newBuilder().setOp(CdcService.RowMessage.Op.INSERT).build())
@@ -36,7 +36,7 @@ class MergerTest {
                 "57b8705f-69cd-4709-ac9b-b6c57fa995ce",
                 BigInteger.valueOf(6822178296495259648L),
                 BigInteger.valueOf(6822178296477519872L),
-                BigInteger.ZERO, 35);
+                BigInteger.ZERO, 35, false);
 
         CdcService.CDCSDKProtoRecordPB commitProtoRecord = CdcService.CDCSDKProtoRecordPB.newBuilder()
                 .setRowMessage(CdcService.RowMessage.newBuilder().setOp(CdcService.RowMessage.Op.COMMIT).build())
@@ -46,7 +46,7 @@ class MergerTest {
                 BigInteger.valueOf(6822178296495259648L),
                 BigInteger.ZERO,
                 BigInteger.ZERO,
-                36);
+                36, false);
 
         merger.addMessage(begin);
         merger.addMessage(insert);
@@ -72,7 +72,7 @@ class MergerTest {
                 BigInteger.valueOf(6863526294757593088L),
                 BigInteger.valueOf(6863526294428749824L),
                 BigInteger.ZERO,
-                605244);
+                605244, false);
 
         CdcService.CDCSDKProtoRecordPB childProtoRecord = CdcService.CDCSDKProtoRecordPB.newBuilder()
                 .setRowMessage(CdcService.RowMessage.newBuilder().setOp(CdcService.RowMessage.Op.INSERT).build())
@@ -81,7 +81,7 @@ class MergerTest {
                 BigInteger.valueOf(6863526294757593088L),
                 BigInteger.valueOf(6863526294462816256L),
                 BigInteger.ZERO,
-                605228);
+                605228, false);
 
         // Purposely insert the child message first and verify the sorting after parent is inserted.
         merger.addMessage(child);
@@ -108,7 +108,7 @@ class MergerTest {
                 BigInteger.valueOf(6863526294757593088L),
                 BigInteger.valueOf(6863526294428749824L),
                 BigInteger.ZERO,
-                605244);
+                605244, false);
 
         CdcService.CDCSDKProtoRecordPB proto2 = CdcService.CDCSDKProtoRecordPB.newBuilder()
                 .setRowMessage(CdcService.RowMessage.newBuilder().setOp(CdcService.RowMessage.Op.INSERT).build())
@@ -117,7 +117,7 @@ class MergerTest {
                 BigInteger.valueOf(68635262947L), // Lower commit time than previous record.
                 BigInteger.valueOf(6863526294462816256L),
                 BigInteger.ZERO,
-                605228);
+                605228, false);
 
         Merger merger = new Merger(List.of(dummyTablet));
 
@@ -178,54 +178,54 @@ class MergerTest {
           BigInteger.valueOf(commitTime1),
           BigInteger.ZERO,
           BigInteger.ZERO,
-          1);
+          1, false);
         Message m2 = new Message(insert1, DUMMY_TABLE_ID, tablet1, txn,
           BigInteger.valueOf(commitTime1),
           BigInteger.ZERO,
           BigInteger.ZERO,
-          2);
+          2, false);
         Message m3 = new Message(commit1, DUMMY_TABLE_ID, tablet1, txn,
           BigInteger.valueOf(commitTime1),
           BigInteger.ZERO,
           BigInteger.ZERO,
-          3);
+          3, false);
 
         Message m4 = new Message(begin2, DUMMY_TABLE_ID, tablet1, txn,
           BigInteger.valueOf(commitTime2),
           BigInteger.ZERO,
           BigInteger.ZERO,
-          4);
+          4, false);
         Message m5 = new Message(insert2, DUMMY_TABLE_ID, tablet1, txn,
           BigInteger.valueOf(commitTime2),
           BigInteger.ZERO,
           BigInteger.ZERO,
-          5);
+          5, false);
         Message m6 = new Message(commit2, DUMMY_TABLE_ID, tablet1, txn,
           BigInteger.valueOf(commitTime2),
           BigInteger.ZERO,
           BigInteger.ZERO,
-          6);
+          6, false);
 
         Message m7 = new Message(begin3, DUMMY_TABLE_ID, tablet2, txn,
           BigInteger.valueOf(commitTime1),
           BigInteger.ZERO,
           BigInteger.ZERO,
-          7);
+          7, false);
         Message m8 = new Message(insert3, DUMMY_TABLE_ID, tablet2, txn,
           BigInteger.valueOf(commitTime1),
           BigInteger.ZERO,
           BigInteger.ZERO,
-          8);
+          8, false);
         Message m9 = new Message(commit3, DUMMY_TABLE_ID, tablet2, txn,
           BigInteger.valueOf(commitTime1),
           BigInteger.ZERO,
           BigInteger.ZERO,
-          9);
+          9, false);
 
         CdcService.CDCSDKProtoRecordPB sp = CdcService.CDCSDKProtoRecordPB.newBuilder()
                                                 .setRowMessage(CdcService.RowMessage.newBuilder().setOp(CdcService.RowMessage.Op.SAFEPOINT)
                                                    .setCommitTime(commitTime2).build()).build();
-        Message safepoint = new Message(sp, DUMMY_TABLE_ID, tablet2, txn, BigInteger.valueOf(commitTime2), BigInteger.ZERO, BigInteger.ZERO, 10);
+        Message safepoint = new Message(sp, DUMMY_TABLE_ID, tablet2, txn, BigInteger.valueOf(commitTime2), BigInteger.ZERO, BigInteger.ZERO, 10, false);
 
         merger.addMessage(m1);
         merger.addMessage(m2);

--- a/src/test/java/io/debezium/connector/yugabytedb/consistent/MessageTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/consistent/MessageTest.java
@@ -38,7 +38,7 @@ public class MessageTest {
                 BigInteger.valueOf(6822178296495259648L),
                 BigInteger.ZERO,
                 BigInteger.ZERO,
-                34);
+                34, false);
 
         CdcService.CDCSDKProtoRecordPB insertRecord = CdcService.CDCSDKProtoRecordPB.newBuilder()
                 .setRowMessage(CdcService.RowMessage.newBuilder()
@@ -47,7 +47,7 @@ public class MessageTest {
                 "57b8705f-69cd-4709-ac9b-b6c57fa995ce",
                 BigInteger.valueOf(6822178296495259648L),
                 BigInteger.valueOf(6822178296477519872L),
-                BigInteger.ZERO, 35);
+                BigInteger.ZERO, 35, false);
 
         CdcService.CDCSDKProtoRecordPB commitRecord = CdcService.CDCSDKProtoRecordPB.newBuilder()
                 .setRowMessage(CdcService.RowMessage.newBuilder()
@@ -57,7 +57,7 @@ public class MessageTest {
                 BigInteger.valueOf(6822178296495259648L),
                 BigInteger.ZERO,
                 BigInteger.ZERO,
-                36);
+                36, false);
 
         assertEquals(-1, begin.compareTo(commit));
         assertEquals(-1, begin.compareTo(insert));
@@ -79,12 +79,12 @@ public class MessageTest {
                 BigInteger.valueOf(6822178296495259648L),
                 BigInteger.ZERO,
                 BigInteger.ZERO,
-                34);
+                34, false);
 
         CdcService.CDCSDKProtoRecordPB record = CdcService.CDCSDKProtoRecordPB.newBuilder()
                 .setRowMessage(CdcService.RowMessage.newBuilder()
                         .setOp(op).build()).build();
-        Message m2 = new Message(record, DUMMY_TABLE_ID, tabletId, txn, commitTime, recordTime, snapshotTime, 35);
+        Message m2 = new Message(record, DUMMY_TABLE_ID, tabletId, txn, commitTime, recordTime, snapshotTime, 35, false);
 
         assertFalse(m1.equals(m2));
     }
@@ -102,14 +102,14 @@ public class MessageTest {
                 BigInteger.valueOf(6822178296495259648L),
                 BigInteger.ZERO,
                 BigInteger.ZERO,
-                34);
+                34, false);
 
         Message m2 = new Message(dummyRecord, DUMMY_TABLE_ID, "3fe122ffe3f24ad39c2cf8a57fa124b3",
                 "57b8705f-69cd-4709-ac9b-b6c57fa995ce",
                 BigInteger.valueOf(6822178296495259648L),
                 BigInteger.ZERO,
                 BigInteger.ZERO,
-                34);
+                34, false);
 
         assertTrue(m1.equals(m2));
     }
@@ -166,9 +166,9 @@ public class MessageTest {
                 .setRowMessage(rowMessage).build();
 
         Message m1 = new Message.Builder().setRecord(record).setTabletId("dummyTabletId")
-                .setTableId(DUMMY_TABLE_ID).setSnapshotTime(0).build();
+                .setTableId(DUMMY_TABLE_ID).setSnapshotTime(0).setColocated(false).build();
         Message m2 = new Message.Builder().setRecord(record).setTabletId("anotherDummyTablet")
-                .setTableId(DUMMY_TABLE_ID).setSnapshotTime(0).build();
+                .setTableId(DUMMY_TABLE_ID).setSnapshotTime(0).setColocated(false).build();
 
         assertTrue(Message.notBeginCommit(m1, m2));
     }


### PR DESCRIPTION
## Problem

Currently, the `YBPartition` class object returns a partition ID by the method `getId()` which depends whether the table is in colocated:
- colocated: `tableId.tabletId`
- non colocated: `tabletId`

So all the offsets, keys, OpIds, etc. are stored against this ID.

Now since the service had special handling for snapshot for colocated tables, we treat every `YBPartition` as a colocated object in the snapshot phase - what that means is that we can get the snapshot `GetChangesResponse` for each colocated table individually. While we treat every `YBPartition` in streaming phase as non-colocated since we do not have a way to get the changes for each tablet separately.

This creates a problem at the management level that we have to take care of properly creating the `YBPartition` object otherwise we'll end up returning a wrong ID if we use `YBPartition#getId` method.

## Solution

This PR removes the colocated property from the `YBPartition` class and introduces the following changes
- `YBPartition#getID` will now return full partition ID every time, this makes the ID a consistent value across snapshot and streaming phase.
- If a table is colocated and we're in the streaming phase, we will update the offset values for all the tables belonging to the colocated tablet upon every `GetChanges` call.
- The `tabletSafeTime` map is now moved to `YugabyteDBOffsetContext` so that it can be handled consistently for all the change event source classes.

### Test plan

Ran existing tests for colocated tables as well as non colocated tables to ensure this PR breaks nothing.