### PR TITLE
[DBZ] Bug fix for snapshot not transitioning to streaming

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorTask.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorTask.java
@@ -453,7 +453,8 @@ public class YugabyteDBConnectorTask
 
                         if (LOGGER.isDebugEnabled()) {
                             for (Map.Entry<String, ?> entry : ybOffset.entrySet()) {
-                                LOGGER.debug("Committing offset {} for partition {}", entry.getValue(), entry.getKey());
+                                LOGGER.debug("{} | Committing offset {} for partition {}",
+                                             taskContext.getTaskId(), entry.getValue(), entry.getKey());
                             }
                         }
 
@@ -493,7 +494,7 @@ public class YugabyteDBConnectorTask
         for (Map.Entry<String, ?> entry : offsets.entrySet()) {
             if ((entry.getKey().contains(".") && !isTaskInSnapshotPhase())
                   || (!entry.getKey().contains(".") && isTaskInSnapshotPhase())) {
-                LOGGER.debug("Skipping the offset for entry {}", entry.getKey());
+                LOGGER.debug("{} | Skipping the offset for entry {}", taskContext.getTaskId(), entry.getKey());
                 continue;
             }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorTask.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorTask.java
@@ -514,7 +514,7 @@ public class YugabyteDBConnectorTask
      * status whether this task is in the snapshot phase.
      */
     protected boolean isTaskInSnapshotPhase() {
-        return (this.coordinator == null) && this.coordinator.isSnapshotInProgress();
+        return (this.coordinator == null) || this.coordinator.isSnapshotInProgress();
     }
 
     public YugabyteDBTaskContext getTaskContext() {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -987,7 +987,8 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
     protected CdcSdkCheckpoint getExplicitCheckpoint(YBPartition partition, OpId fromOpId) {
       CdcSdkCheckpoint explicitCheckpoint = tabletToExplicitCheckpoint.get(partition.getId());
 
-      if (fromOpId.isLesserThanOrEqualTo(explicitCheckpoint)) {
+      if (fromOpId.isLesserThanOrEqualTo(explicitCheckpoint)
+            && !isLastSnapshotRecordOfLastBatch(OpId.from(explicitCheckpoint))) {
         LOGGER.debug("Request OpId for partition {} ({}) is less than or equal to explicit checkpoint ({})",
           partition.getId(), fromOpId.toSerString(), explicitCheckpoint);
         return fromOpId.toCdcSdkCheckpoint();


### PR DESCRIPTION
## Problem

There are two bugs which were introduced when #348 and #352 were merged.

1. Wrong logic for the method `YugabyteDBConnectorTask#isTaskInSnapshotPhase`

```
protected boolean isTaskInSnapshotPhase() {
    return (this.coordinator == null) && this.coordinator.isSnapshotInProgress();
}
```

The above logic will always return `false` indicating that the task is never in snapshot phase.

2. The method `YugabyteDBSnapshotChangeEventSource#getExplicitCheckpoint` does not consider the checkpoint for last record of last snapshot batch.

## Solution

1. This PR fixes the method `YugabyteDBConnectorTask#isTaskInSnapshotPhase` by modifying the condition to use an `OR` operator.

2. For the method `YugabyteDBSnapshotChangeEventSource#getExplicitCheckpoint`, the condition is modified to check if the explicit checkpoint belongs to the last record of last snapshot batch then we should use that checkpoint.