### PR TITLE
[DBZ] Disable IMPLICIT checkpointing support in connector

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -731,6 +731,12 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
             .withImportance(Importance.LOW)
             .withDefault(false);
 
+    public static final Field FORCE_USE_IMPLICIT_STREAM = Field.create("force.use.implicit.stream")
+              .withDisplayName("Flag to forcefully use implicit streams in connector")
+              .withType(Type.BOOLEAN)
+              .withImportance(Importance.LOW)
+              .withDefault(false);
+
     public static final Field CHAR_SET = Field.create(TASK_CONFIG_PREFIX + "charset")
             .withDisplayName("YugabyteDB charset")
             .withType(ConfigDef.Type.STRING)
@@ -1266,6 +1272,10 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
 
     public boolean ignoreExceptions() {
         return getConfig().getBoolean(IGNORE_EXCEPTIONS);
+    }
+
+    public boolean forceUseImplicitStream() {
+        return getConfig().getBoolean(FORCE_USE_IMPLICIT_STREAM);
     }
 
     public int maxNumTablets() {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBgRPCConnector.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBgRPCConnector.java
@@ -173,6 +173,14 @@ public class YugabyteDBgRPCConnector extends RelationalBaseSourceConnector {
             throw new DebeziumException(e);
         }
 
+        if (!enableExplicitCheckpointing && !this.yugabyteDBConnectorConfig.forceUseImplicitStream()) {
+            final String errorMessage = "The provided stream " + this.yugabyteDBConnectorConfig.streamId()
+                    + " is a IMPLICIT stream, create a stream with EXPLICIT checkpointing and try again."
+                    + " To forcefully use an IMPLICIT stream, set configuration property force.use.implicit.stream"
+                    + " to true";
+            throw new DebeziumException(errorMessage);
+        }
+
         if (this.yugabyteDBConnectorConfig.transactionOrdering() && !enableExplicitCheckpointing) {
             final String errorMessage = "Explicit checkpointing not enabled in consistent streaming mode, "
                     + "create a stream with explicit checkpointing and try again";

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBgRPCConnector.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBgRPCConnector.java
@@ -175,7 +175,7 @@ public class YugabyteDBgRPCConnector extends RelationalBaseSourceConnector {
 
         if (!enableExplicitCheckpointing && !this.yugabyteDBConnectorConfig.forceUseImplicitStream()) {
             final String errorMessage = "The provided stream " + this.yugabyteDBConnectorConfig.streamId()
-                    + " is a IMPLICIT stream, create a stream with EXPLICIT checkpointing and try again."
+                    + " is an IMPLICIT stream, create a stream with EXPLICIT checkpointing and try again."
                     + " To forcefully use an IMPLICIT stream, set configuration property force.use.implicit.stream"
                     + " to true";
             throw new DebeziumException(errorMessage);


### PR DESCRIPTION
This PR disables the deployment of `YugabyteDBgRPCConnector` with `IMPLICIT` checkpointing streams.