### PR TITLE
FIX: readme update for basic CDC setup #324

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The YugabyteDB connector can also be used as a library without Kafka or Kafka Co
   export IP=$(ipconfig getifaddr en0)
 
   # Linux:
-  export IP=$(hostname -i)
+  export IP=$(hostname -I | awk '{print $1}')
   ```
 4. Start a cluster using yugabyted. Note that you need to run yugabyted with the IP of your machine; otherwise, it would consider localhost (which would be mapped to the docker host instead of your machine). The yugabyted binary along with other required binaries can be downloaded from [download.yugabyte.com](https://download.yugabyte.com/).
   ```sh
@@ -77,7 +77,7 @@ The YugabyteDB connector can also be used as a library without Kafka or Kafka Co
     -d '{
     "name": "ybconnector",
     "config": {
-        "connector.class": "io.debezium.connector.yugabytedb.YugabyteDBgRPCConnectorctor",
+        "connector.class": "io.debezium.connector.yugabytedb.YugabyteDBgRPCConnector",
         "database.hostname":"'$IP'",
         "database.port":"5433",
         "database.master.addresses": "'$IP':7100",


### PR DESCRIPTION
Updated the readme for running the basic CDC setup, will be the fix for issue #324

The command `hostname -i` outputs the IP address associated with the hostname of the machine, while `hostname -I` displays all network interfaces IP addresses on the machine.

When`advertise_address` is set as machine's hostname, and while deploying the connector configurations, error was returned. This can be fixed by passing one of the networks IP address.