### PR TITLE
[#25143] Fix issue with handling of null values for money type

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/connection/ReplicationMessageColumnValueResolver.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/ReplicationMessageColumnValueResolver.java
@@ -152,7 +152,7 @@ public class ReplicationMessageColumnValueResolver {
                 return value.asLseg();
             case "money":
                 final Object v = value.asMoney();
-                return (v instanceof PGmoney) ? ((PGmoney) v).val : v;
+                return (v instanceof PGmoney) ? ((PGmoney) v).getValue() : v;
             case "path":
                 return value.asPath();
             case "point":


### PR DESCRIPTION
### Problem
In the current implementation a bug exists in the ReplicationMessageColumnValueResolver class resolveValue() method due to which when a null value for Money type column is received by the connector we send a default value (0.00$) to the client. 

### Solution
This PR fixes the bug by returning the appropriate value. Instead of returning the raw val we are now using the getter to return the correct value. The PGMoney class handles the null case thus solving the problem

### Tests
This issue was first seen in the stress tests. The PR adds a test which reproduces the exact failure which was observed in stress test. In addition a second test is added to assert that for all the data types null values are being correctly sent by the connector.