### PR TITLE
[#25143] Fix value resolver for money type columns

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/connection/ReplicationMessageColumnValueResolver.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/ReplicationMessageColumnValueResolver.java
@@ -152,7 +152,11 @@ public class ReplicationMessageColumnValueResolver {
                 return value.asLseg();
             case "money":
                 final Object v = value.asMoney();
-                return (v instanceof PGmoney) ? ((PGmoney) v).getValue() : v;
+                if (v instanceof PGmoney) {
+                    PGmoney moneyObj = (PGmoney) v;
+                    return moneyObj.isNull ? null : moneyObj.val;
+                }
+                return v;
             case "path":
                 return value.asPath();
             case "point":


### PR DESCRIPTION
## Problem
In this [PR](https://github.com/yugabyte/debezium-connector-yugabytedb/pull/361), we replaced returning of the raw `val` with `getValue()` in ReplicationMessageColumnValueResolver class resolveValue() method for money type columns. This was done because in the case where money column contained null value the raw val returned was 0, resulting in 0.00$ value being sent to kafka.

However the getValue() returned a String as opposed to the double type `val` which was returned earlier. Though this fixed the behaviour with nulls, it broke the behaviour for non-nulls since YugabyteDBValueConverter could not work with String.

## Solution
Instead of using `getValue()` from PGMoney class, return the `val` if the object is non-null. Return null otherwise.

## Testing
The original commit which introduced this bug caused `YugabyteDBCompleteTypesTest#verifyAllWorkingDataTypesInSingleTable` to fail. With this fix the test has started passing again. Also tested manually in a docker based setup that money column works fine for both nulls and non-nulls.