### PR TITLE
[yugabyte/yugabyte-db#27255] Modify YBExtractNewRecordState to introduce property "delete.to.tombstone"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
         <!-- Dependency Versions -->
         <version.postgresql.driver>42.7.2</version.postgresql.driver>
-        <version.com.google.protobuf>3.25.5</version.com.google.protobuf>
+        <version.com.google.protobuf>4.30.2</version.com.google.protobuf>
         <version.kafka>3.7.0</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
         <!-- Dependency Versions -->
         <version.postgresql.driver>42.7.2</version.postgresql.driver>
-        <version.com.google.protobuf>4.30.2</version.com.google.protobuf>
+        <version.com.google.protobuf>3.25.5</version.com.google.protobuf>
         <version.kafka>3.7.0</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>

--- a/src/main/java/io/debezium/connector/yugabytedb/transforms/YBExtractNewRecordState.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/transforms/YBExtractNewRecordState.java
@@ -50,6 +50,9 @@ public class YBExtractNewRecordState<R extends ConnectRecord<R>> extends Extract
         final R ret = super.apply(record);
         if (ret == null || (ret.value() != null && !(ret.value() instanceof Struct))) {
             // If ret == null, it means that the base SMT has dropped the record.
+            // The other condition is to check if the record is a valid envelope record
+            // (DML record) and not a metadata record like a transactional or heartbeat
+            // record, as the latter ones need to be passed through as is.
             LOGGER.trace("Returning the value as returned by the base transform");
             return ret;
         }

--- a/src/main/java/io/debezium/connector/yugabytedb/transforms/YBExtractNewRecordState.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/transforms/YBExtractNewRecordState.java
@@ -29,9 +29,10 @@ public class YBExtractNewRecordState<R extends ConnectRecord<R>> extends Extract
 
     @Override
     public void configure(Map<String, ?> configs) {
-        // The config will be null when the user will not provide anything. We are falling back on
-        // Boolean.valueOf() in that case as it would return false when the provided argument is null.
-        convertDeleteToTombstone = Boolean.valueOf((String) configs.get(DELETE_TO_TOMBSTONE));
+        // Explicitly set default value to false when config is not provided.
+        String deleteToTombstoneConfig = (String) configs.get(DELETE_TO_TOMBSTONE);
+        convertDeleteToTombstone = deleteToTombstoneConfig != null ?
+                                    Boolean.parseBoolean(deleteToTombstoneConfig) : false;
 
         // Create a mutable copy of configs to allow modifications
         Map<String, Object> mutableConfigs = new java.util.HashMap<>(configs);

--- a/src/main/java/io/debezium/connector/yugabytedb/transforms/YBExtractNewRecordState.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/transforms/YBExtractNewRecordState.java
@@ -57,6 +57,10 @@ import io.debezium.transforms.ExtractNewRecordStateConfigDefinition;
 public class YBExtractNewRecordState<R extends ConnectRecord<R>> extends ExtractNewRecordState<R> {
     private static final Logger LOGGER = LoggerFactory.getLogger(YBExtractNewRecordState.class);
 
+    // This is a connector property, which, when set, will read the delete records and convert them
+    // all to tombstone records and subsequently drop all the tombstone records explicitly received
+    // from the source connector. This is useful when the downstream consumers expect
+    // tombstone records to process deletes.
     public static final String DELETE_TO_TOMBSTONE = "delete.to.tombstone";
 
     private Cache<Schema, Schema> schemaUpdateCache = new SynchronizedCache<>(new LRUCache<>(256));

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
@@ -358,10 +358,16 @@ public class YugabyteDBDatatypesTest extends YugabytedTestBase {
             }
         }
 
-        assertEquals(2, records.size());
+        assertEquals(3, records.size());
 
-        // Validate that instead of delete, we have received a tombstone record.
-        VerifyRecord.isValidTombstone(records.get(0));
+        // Validate that the last record is a tombstone record.
+        VerifyRecord.isValidTombstone(records.get(2));
+
+        // Record 2 will be a delete, check that it becomes a tombstone after transformation.
+        VerifyRecord.isValidTombstone(transformation.apply(records.get(1)));
+
+        // The actual tombstone record will be null after transformation.
+        assertNull(transformation.apply(records.get(2)));
     }
 
     @ParameterizedTest

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
@@ -335,10 +335,10 @@ public class YugabyteDBDatatypesTest extends YugabyteDBContainerTestBase {
 
             awaitUntilConnectorIsReady();
 
-            // insert rows in the table t1 with values <some-pk, 'Vaibhav', 'Kushwaha', 30>
+            // Insert rows in the table t1 with values <some-pk, 'Vaibhav', 'Kushwaha', 30>.
             insertRecords(rowsCount);
 
-            // delete rows in the table t1 where id is <some-pk>
+            // Delete rows in the table t1 where id is <some-pk>.
             deleteRecords(rowsCount);
 
             // Wait for 10 iterations to ensure there's nothing left to consume.

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
  */
 
-public class YugabyteDBDatatypesTest extends YugabytedTestBase {
+public class YugabyteDBDatatypesTest extends YugabyteDBContainerTestBase {
     private static final String INSERT_STMT = "INSERT INTO s1.a (aa) VALUES (1);" +
             "INSERT INTO s2.a (aa) VALUES (1);";
     private static final String CREATE_TABLES_STMT = "DROP SCHEMA IF EXISTS s1 CASCADE;" +
@@ -328,6 +328,9 @@ public class YugabyteDBDatatypesTest extends YugabytedTestBase {
 
             Map<String, Object> configs = new HashMap<String, Object>();
             configs.put(YBExtractNewRecordState.DELETE_TO_TOMBSTONE, "true");
+            // The following config is used to indicate the base SMT and this shouldn't have any
+            // impact on the outcome of the test as we essentially need to drop the tombstone -
+            // it doesn't matter whether we drop the tombstone or the base SMT does.
             configs.put(ExtractNewRecordStateConfigDefinition.DROP_TOMBSTONES.toString(), String.valueOf(dropTombstones));
             transformation.configure(configs);
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBDatatypesTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
  */
 
-public class YugabyteDBDatatypesTest extends YugabytedTestBase {
+public class YugabyteDBDatatypesTest extends YugabyteDBContainerTestBase {
     private static final String INSERT_STMT = "INSERT INTO s1.a (aa) VALUES (1);" +
             "INSERT INTO s2.a (aa) VALUES (1);";
     private static final String CREATE_TABLES_STMT = "DROP SCHEMA IF EXISTS s1 CASCADE;" +


### PR DESCRIPTION
## Problem

The current behaviour with the connector is that a tombstone record is published immediately after the delete record (when tombstones are enabled), this tombstone record has the same `OpId` as the delete record. A rough flow looks like:

```java
queue.enqueue(deleteRecord);

if (tombstonesEnabled) {
  queue.enqueue(tombstoneRecord);
}
```

Now there can be a situation where the connector crashes after adding the delete record to the queue and before it can add the tombstone record, it crashes or restarts - in that situation we might end up losing the tombstone record.

Since the tombstone record is essential to process delete records by some of the downstream connectors like the `io.confluent.connect.jdbc.JdbcSinkConnector` - these connectors will not be able to process deletes which would eventually be manifested as a data loss.

## Solution

To avoid getting into such a situation where we lose tombstone records, we have introduced a new configuration property here `delete.to.tombstone` which takes in a boolean value and it converts all the delete records to tombstone records. Now since we have the tombstone records already, we do not need the ones published by the connector so those records are dropped by this SMT.

> Another way to not get the original tombstone records is to disable tombstone publishing by the connector by setting `tombstones.on.delete=false` so that the connector doesn't produce any tombstone records itself.

### Testing

This PR also adds a test which can be run by using the command: 
```
mvn clean test -Dtest=YugabyteDBDatatypesTest#deletesShouldBeConvertedToTombstoneWhenTransformationEnabled
```

Closes yugabyte/yugabyte-db#27255.
Closes yugabyte/yugabyte-db#27048.