### PR TITLE
[DBZ] Fix for unit test runs

### DIFF
--- a/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/TestHelper.java
@@ -635,11 +635,12 @@ public final class TestHelper {
     public static void executeDDL(String ddlFile, String databaseName) throws Exception {
         URL ddlTestFile = TestHelper.class.getClassLoader().getResource(ddlFile);
         assertNotNull(ddlTestFile, "Cannot locate " + ddlFile);
-        String statements = Files.readAllLines(Paths.get(ddlTestFile.toURI()))
-                .stream()
-                .collect(Collectors.joining(System.lineSeparator()));
+        List<String> statements = Files.readAllLines(Paths.get(ddlTestFile.toURI()));
         try (YugabyteDBConnection connection = createConnectionTo(databaseName)) {
-            connection.execute(statements);
+            for (String statement : statements) {
+                LOGGER.info("Executing: {}", statement);
+                connection.execute(statement);
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

After the PG15 merge, upon running the tests, we are getting the following error in tests:

```
org.postgresql.util.PSQLException: ERROR: DROP DATABASE cannot be executed within a pipeline
```

This behaviour was originally introduced in PG14 and YugabyteDB inherited it upon its move to PG15. As a result, the tests which executed the DDL files by combining all the statements in a batch - they started failing.

## Solution

To avoid the failure, the statements in the DDL files are now executed one at a time.

This closes yugabyte/yugabyte-db#27369.