### PR TITLE
[DBZ][yugabyte/yugabyte-db#27248] Do not extract table name from transactional records

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -592,20 +592,21 @@ public class YugabyteDBStreamingChangeEventSource implements
                                     continue;
                                 }
 
-                                String pgSchemaNameInRecord = m.getPgschemaName();; 
-                                TableId tempTid;
-                                if (connectorConfig.isYSQLDbType()) {
-                                    // This is a hack to skip tables in case of colocated tables
-                                    tempTid = YugabyteDBSchema.parseWithSchema(message.getTable(), pgSchemaNameInRecord);
-                                } else {
-                                    tempTid = YugabyteDBSchema.parseWithKeyspace(message.getTable(),
+                                String pgSchemaNameInRecord = m.getPgschemaName();
+                                if (!message.isTransactionalMessage()) {
+                                    TableId tempTid;
+                                    if (connectorConfig.isYSQLDbType()) {
+                                        // This is a hack to skip tables in case of colocated tables
+                                        tempTid = YugabyteDBSchema.parseWithSchema(message.getTable(), pgSchemaNameInRecord);
+                                    } else {
+                                        tempTid = YugabyteDBSchema.parseWithKeyspace(message.getTable(),
                                                 connectorConfig.databaseName());
-                                }
-                            
-                                if (!message.isTransactionalMessage()
-                                      && !filters.tableFilter().isIncluded(tempTid) && !connectorConfig.cqlTableFilter().isIncluded(tempTid)) {
-                                    LOGGER.info("Skipping a record for table {} because it was not included", tempTid.table());
-                                    continue;
+                                    }
+
+                                    if (!filters.tableFilter().isIncluded(tempTid) && !connectorConfig.cqlTableFilter().isIncluded(tempTid)) {
+                                        LOGGER.info("Skipping a record for table {} because it was not included", tempTid.table());
+                                        continue;
+                                    }
                                 }
 
                                 // TODO: Rename to Checkpoint, since OpId is misleading.


### PR DESCRIPTION
## Problem
With the landing of this [revision](https://phorge.dev.yugabyte.com/D44144), we will not be sending the table name with the transactional records (i.e BEGIN & COMMIT records) from cdc service. In `YugabyteDBStreamingChangeEventSource::getChanges2()` table name is extracted from each record. This is done to filter out the records for colocated tables which are not present in table include list. This extraction will fail causing the connector to get stuck post the above mentioned change on service side.

## Solution
The transactional records are anyway not involved in the above mentioned filtering process. To solve this issue we will extract the table name only when the record is not a transactional record.

## Test Plan
Ran the existing unit tests against a yugabyted instance containing the changes from above mentioned diff.