### PR TITLE
[DBZ] Improve table filtering logic in consistent streaming source

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
@@ -296,11 +296,12 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
                                  YbProtoReplicationMessage message) throws SQLException {
         String pgSchemaNameInRecord = m.getPgschemaName();
 
-        // This is a hack to skip tables in case of colocated tables
-        TableId tempTid = YugabyteDBSchema.parseWithSchema(message.getTable(), pgSchemaNameInRecord);
-        if (!message.isTransactionalMessage()
-            && !filters.tableFilter().isIncluded(tempTid)) {
-            return;
+        if (!message.isTransactionalMessage()) {
+            // This is a hack to skip tables in case of colocated tables
+            TableId tempTid = YugabyteDBSchema.parseWithSchema(message.getTable(), pgSchemaNameInRecord);
+            if (!filters.tableFilter().isIncluded(tempTid)) {
+                return;
+            }
         }
 
         final OpId lsn = new OpId(record.getFromOpId().getTerm(),


### PR DESCRIPTION
## Problem
The table filtering logic in the consistent streaming source was nested within certain conditions. Also, the `TableId` for checking the filter was being calculated pre-emptively whether or not it was a transactional message and due to the recent changes in service, we will not be sending the schema name with the transactional message. These changes caused the `parseWithSchema()` method to fail as the schema name wasn't present.

## Solution
Refactored the code to:
1. Move the transactional message check to be the first condition.
2. Restructure the nested if statements for better readability and only calculate whether the message needs to be skipped in case of a non-transactional message.