### PR TITLE
Update protobuf version to 4.30.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
         <!-- Dependency Versions -->
         <version.postgresql.driver>42.7.2</version.postgresql.driver>
-        <version.com.google.protobuf>3.25.5</version.com.google.protobuf>
+        <version.com.google.protobuf>4.30.2</version.com.google.protobuf>
         <version.kafka>3.7.0</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>


### PR DESCRIPTION
## Changes
- Updated protobuf version from 3.25.5 to 4.30.2

## Purpose
- Upgrade protobuf to the latest stable version for improved compatibility and features

## Testing
- Existing tests should pass with the new protobuf version