### PR TITLE
Add schema history producer

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSchemaHistoryEvent.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSchemaHistoryEvent.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.yugabytedb;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * POJO representing a schema history event for JSON serialization.
+ *
+ * @author Michael Terranova
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class YugabyteDBSchemaHistoryEvent {
+
+    @JsonProperty("connector")
+    private String connector;
+
+    @JsonProperty("table")
+    private String table;
+
+    @JsonProperty("tablet")
+    private String tablet;
+
+    @JsonProperty("eventType")
+    private String eventType;
+
+    @JsonProperty("timestamp")
+    private String timestamp;
+
+    @JsonProperty("schemaChecksum")
+    private String schemaChecksum;
+
+    @JsonProperty("schema")
+    private SchemaInfo schema;
+
+    public YugabyteDBSchemaHistoryEvent() {
+        this.timestamp = Instant.now().toString();
+    }
+
+    public String getConnector() { return connector; }
+    public void setConnector(String connector) { this.connector = connector; }
+
+    public String getTable() { return table; }
+    public void setTable(String table) { this.table = table; }
+
+    public String getTablet() { return tablet; }
+    public void setTablet(String tablet) { this.tablet = tablet; }
+
+    public String getEventType() { return eventType; }
+    public void setEventType(String eventType) { this.eventType = eventType; }
+
+    public String getTimestamp() { return timestamp; }
+    public void setTimestamp(String timestamp) { this.timestamp = timestamp; }
+
+    public String getSchemaChecksum() { return schemaChecksum; }
+    public void setSchemaChecksum(String schemaChecksum) { this.schemaChecksum = schemaChecksum; }
+
+    public SchemaInfo getSchema() { return schema; }
+    public void setSchema(SchemaInfo schema) { this.schema = schema; }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class SchemaInfo {
+        @JsonProperty("columns")
+        private List<ColumnInfo> columns;
+
+        @JsonProperty("primaryKey")
+        private List<String> primaryKey;
+
+        public List<ColumnInfo> getColumns() { return columns; }
+        public void setColumns(List<ColumnInfo> columns) { this.columns = columns; }
+
+        public List<String> getPrimaryKey() { return primaryKey; }
+        public void setPrimaryKey(List<String> primaryKey) { this.primaryKey = primaryKey; }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ColumnInfo {
+        @JsonProperty("name")
+        private String name;
+
+        @JsonProperty("type")
+        private String type;
+
+        @JsonProperty("isNullable")
+        private Boolean isNullable;
+
+        @JsonProperty("isKey")
+        private Boolean isKey;
+
+        @JsonProperty("isHashKey")
+        private Boolean isHashKey;
+
+        @JsonProperty("oid")
+        private Integer oid;
+
+        @JsonProperty("length")
+        private Integer length;
+
+        @JsonProperty("scale")
+        private Integer scale;
+
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+
+        public String getType() { return type; }
+        public void setType(String type) { this.type = type; }
+
+        public Boolean getIsNullable() { return isNullable; }
+        public void setIsNullable(Boolean isNullable) { this.isNullable = isNullable; }
+
+        public Boolean getIsKey() { return isKey; }
+        public void setIsKey(Boolean isKey) { this.isKey = isKey; }
+
+        public Boolean getIsHashKey() { return isHashKey; }
+        public void setIsHashKey(Boolean isHashKey) { this.isHashKey = isHashKey; }
+
+        public Integer getOid() { return oid; }
+        public void setOid(Integer oid) { this.oid = oid; }
+
+        public Integer getLength() { return length; }
+        public void setLength(Integer length) { this.length = length; }
+
+        public Integer getScale() { return scale; }
+        public void setScale(Integer scale) { this.scale = scale; }
+    }
+}

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSchemaHistoryProducer.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSchemaHistoryProducer.java
@@ -1,0 +1,712 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.yugabytedb;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.debezium.connector.yugabytedb.metrics.YugabyteDBSchemaHistoryMetricsMXBean;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yb.cdc.CdcService;
+
+import javax.management.JMException;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A standalone producer for writing schema history to a Kafka topic.
+ * <p>
+ * Instantiated in {@link YugabyteDBStreamingChangeEventSource} to produce schema history events:
+ * <ul>
+ *   <li><b>SCHEMA_SNAPSHOT:</b> On connector startup with no existing offsets, publishes
+ *       the initial schema state for a schema history-configured table. /li>
+ *   <li><b>SCHEMA_CHANGE:</b> When table schema differs from cached schema, indicating
+ *       a DDL operation has occurred</li>
+ * </ul>
+ * </p>
+ * <p>
+ * This producer operates asynchronously and independently of the main change event capture
+ * pipeline. Producer failures do not impact connector health or change event processing.
+ * </p>
+ * <p>
+ * Schema history events include YugabyteDB-specific metadata such as primary key structure,
+ * hash key indicators, and PostgreSQL OID type information.
+ * </p>
+ *
+ * @author Michael Terranova
+ * @see YugabyteDBStreamingChangeEventSource
+ */
+
+public class YugabyteDBSchemaHistoryProducer implements YugabyteDBSchemaHistoryMetricsMXBean {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(YugabyteDBSchemaHistoryProducer.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final java.util.function.Function<String, String> topicNameGenerator;
+    private final String bootstrapServers;
+    private final String connectorName;
+    private final String securityProtocol;
+    private final String sslKeystoreLocation;
+    private final String sslKeystorePassword;
+    private final String sslKeystoreType;
+    private final String sslTruststoreLocation;
+    private final String sslTruststorePassword;
+    private final String sslTruststoreType;
+
+    private KafkaProducer<String, String> producer;
+    private final AtomicBoolean initialized = new AtomicBoolean(false);
+
+    // Metrics
+    private final AtomicLong schemaHistoryEventsSent = new AtomicLong(0);
+    private final AtomicLong schemaHistoryEventsFailed = new AtomicLong(0);
+    private final AtomicLong schemaHistoryEventsQueued = new AtomicLong(0);
+    private final AtomicLong lastSuccessfulSendTimestamp = new AtomicLong(0);
+    private final AtomicLong lastFailedSendTimestamp = new AtomicLong(0);
+    private volatile String lastErrorMessage = null;
+    private ObjectName mbeanName;
+
+    /**
+     * Creates a schema history producer with per-table topic derivation.
+     * Each task creates its own producer instance following MySQL connector pattern.
+     * @param topicNameGenerator function to derive topic name from tableId (e.g., "core.products" → "globaldb.core.products-schemachanges")
+     * @param connectorName the connector name (used as client ID prefix and in record metadata)
+     * @param bootstrapServers Kafka bootstrap servers
+     * @param securityProtocol Security protocol (SSL, PLAINTEXT, etc.)
+     * @param sslKeystoreLocation SSL keystore location (optional)
+     * @param sslKeystorePassword SSL keystore password (optional)
+     * @param sslKeystoreType SSL keystore type (PKCS12, JKS, etc.)
+     * @param sslTruststoreLocation SSL truststore location (optional)
+     * @param sslTruststorePassword SSL truststore password (optional)
+     * @param sslTruststoreType SSL truststore type (PKCS12, JKS, etc.)
+     */
+    public YugabyteDBSchemaHistoryProducer(
+            java.util.function.Function<String, String> topicNameGenerator,
+            String connectorName,
+            String bootstrapServers,
+            String securityProtocol,
+            String sslKeystoreLocation,
+            String sslKeystorePassword,
+            String sslKeystoreType,
+            String sslTruststoreLocation,
+            String sslTruststorePassword,
+            String sslTruststoreType) {
+        this.topicNameGenerator = topicNameGenerator;
+        this.connectorName = connectorName;
+        this.bootstrapServers = bootstrapServers;
+        this.securityProtocol = securityProtocol;
+        this.sslKeystoreLocation = sslKeystoreLocation;
+        this.sslKeystorePassword = sslKeystorePassword;
+        this.sslKeystoreType = sslKeystoreType;
+        this.sslTruststoreLocation = sslTruststoreLocation;
+        this.sslTruststorePassword = sslTruststorePassword;
+        this.sslTruststoreType = sslTruststoreType;
+        LOGGER.info("Schema history producer configured for connector: {} (per-table topics)", connectorName);
+
+        try {
+            String metricName = "debezium.yugabytedb:type=schema-history-producer,connector=" +
+                                org.apache.kafka.common.utils.Sanitizer.jmxSanitize(connectorName);
+            this.mbeanName = new ObjectName(metricName);
+            MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+            if (mBeanServer != null && !mBeanServer.isRegistered(mbeanName)) {
+                mBeanServer.registerMBean(this, mbeanName);
+                LOGGER.info("Registered schema history metrics MBean: {}", mbeanName);
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Failed to register schema history metrics MBean: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Lazily initializes the Kafka producer. If initialization fails, throws an exception
+     * to fail the connector task.
+     */
+    private synchronized void ensureInitialized() {
+        if (initialized.get()) {
+            return;
+        }
+        
+        try {
+            Properties props = new Properties();
+            props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+            props.put(ProducerConfig.CLIENT_ID_CONFIG, connectorName + "-schema-history");
+            props.put(ProducerConfig.ACKS_CONFIG, "all");
+            props.put(ProducerConfig.RETRIES_CONFIG, 3);
+            props.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 5000);
+            props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 5000);
+            props.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 10000);
+
+            // Add SSL configuration if security protocol is SSL
+            if (securityProtocol != null && securityProtocol.equalsIgnoreCase("SSL")) {
+                // Check if SSL certificate files exist
+                java.io.File keystoreFile = new java.io.File(sslKeystoreLocation);
+                java.io.File truststoreFile = new java.io.File(sslTruststoreLocation);
+
+                if (!keystoreFile.exists() || !truststoreFile.exists()) {
+                    LOGGER.warn("SSL certificate files not found (keystore: {}, truststore: {}), " +
+                            "falling back to PLAINTEXT, will silently fail if Kafka requires SSL",
+                            keystoreFile.exists(), truststoreFile.exists());
+                } else {
+                    props.put("security.protocol", "SSL");
+                    props.put("ssl.keystore.location", sslKeystoreLocation);
+                    props.put("ssl.keystore.type", sslKeystoreType);
+                    props.put("ssl.truststore.location", sslTruststoreLocation);
+                    props.put("ssl.truststore.type", sslTruststoreType);
+
+                    if (sslKeystorePassword != null) {
+                        props.put("ssl.keystore.password", sslKeystorePassword);
+                    }
+                    if (sslTruststorePassword != null) {
+                        props.put("ssl.truststore.password", sslTruststorePassword);
+                    }
+
+                    LOGGER.info("Schema history producer configured with SSL security");
+                }
+            }
+
+            StringSerializer keySerializer = new StringSerializer();
+            StringSerializer valueSerializer = new StringSerializer();
+            
+            Map<String, Object> configMap = new HashMap<>();
+            for (String name : props.stringPropertyNames()) {
+                configMap.put(name, props.getProperty(name));
+            }
+            keySerializer.configure(configMap, true);
+            valueSerializer.configure(configMap, false);
+            
+            this.producer = new KafkaProducer<>(props, keySerializer, valueSerializer);
+            initialized.set(true);
+            LOGGER.info("Schema history producer initialized successfully for connector: {} (per-table topics)", connectorName);
+        } catch (Throwable t) {
+            LOGGER.error("Failed to initialize schema history producer: {}", t.getMessage(), t);
+            throw new RuntimeException("Schema history producer failed to initialize - Kafka unreachable or misconfigured", t);
+        }
+    }
+
+    /**
+     * Records a schema change event (DDL).
+     * 
+     * @param tableId the table identifier (e.g., "core.products")
+     * @param tabletId the tablet identifier
+     * @param schema the schema protobuf
+     * @param eventType the type of event (e.g., "DDL", "INITIAL")
+     */
+    public void recordSchemaChange(String tableId, String tabletId, CdcService.CDCSDKSchemaPB schema, String eventType) {
+        try {
+            ensureInitialized();
+            if (producer == null) {
+                throw new IllegalStateException("Producer not initialized");
+            }
+            
+            // Derive per-table topic
+            String topicName = topicNameGenerator.apply(tableId);
+            // Key is just the table name for partitioning
+            String key = tableId;
+            String value = buildSchemaJson(tableId, tabletId, schema, eventType);
+            
+            ProducerRecord<String, String> record = new ProducerRecord<>(topicName, key, value);
+            
+            producer.send(record, (metadata, exception) -> {
+                if (exception != null) {
+                    schemaHistoryEventsFailed.incrementAndGet();
+                    lastFailedSendTimestamp.set(System.currentTimeMillis());
+                    lastErrorMessage = exception.getMessage();
+                    LOGGER.warn("Failed to send schema history record for table {} to topic {}: {}", tableId, topicName, exception.getMessage());
+                } else {
+                    schemaHistoryEventsSent.incrementAndGet();
+                    lastSuccessfulSendTimestamp.set(System.currentTimeMillis());
+                    LOGGER.debug("Schema history record sent for table {} to topic {} partition {} offset {}",
+                            tableId, topicName, metadata.partition(), metadata.offset());
+                }
+            });
+
+            schemaHistoryEventsQueued.incrementAndGet();
+            LOGGER.info("Schema history {} event queued for table: {} → topic: {}", eventType, tableId, topicName);
+        } catch (Throwable t) {
+            LOGGER.warn("Error recording schema change for table {}: {}", tableId, t.getMessage());
+        }
+    }
+
+    private String buildSchemaJson(String tableId, String tabletId, CdcService.CDCSDKSchemaPB schema, String eventType) {
+        try {
+            YugabyteDBSchemaHistoryEvent event = new YugabyteDBSchemaHistoryEvent();
+            event.setConnector(connectorName);
+            event.setTable(tableId);
+            event.setTablet(tabletId);
+            event.setEventType(eventType);
+            event.setSchemaChecksum(calculateSchemaChecksum(schema));
+
+            YugabyteDBSchemaHistoryEvent.SchemaInfo schemaInfo = new YugabyteDBSchemaHistoryEvent.SchemaInfo();
+            List<YugabyteDBSchemaHistoryEvent.ColumnInfo> columns = new ArrayList<>();
+
+            for (int i = 0; i < schema.getColumnInfoCount(); i++) {
+                CdcService.CDCSDKColumnInfoPB col = schema.getColumnInfo(i);
+                YugabyteDBSchemaHistoryEvent.ColumnInfo colInfo = new YugabyteDBSchemaHistoryEvent.ColumnInfo();
+                colInfo.setName(col.getName());
+                colInfo.setType(col.getType().getMain().name());
+                colInfo.setIsKey(col.getIsKey());
+                colInfo.setIsHashKey(col.getIsHashKey());
+                colInfo.setIsNullable(col.getIsNullable());
+                colInfo.setOid(col.getOid());
+                columns.add(colInfo);
+            }
+
+            schemaInfo.setColumns(columns);
+            event.setSchema(schemaInfo);
+
+            return OBJECT_MAPPER.writeValueAsString(event);
+        } catch (JsonProcessingException e) {
+            LOGGER.warn("Failed to serialize schema history event: {}", e.getMessage());
+            return "{}";
+        }
+    }
+
+    /**
+     * Calculates a deterministic checksum for a schema from protobuf representation.
+     * The checksum is based on column names, types, keys, and nullability to detect schema changes.
+     *
+     * @param schema the CDC schema protobuf
+     * @return hex string representation of SHA-256 hash
+     */
+    private String calculateSchemaChecksum(CdcService.CDCSDKSchemaPB schema) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            StringBuilder schemaString = new StringBuilder();
+
+            // Build deterministic string representation of schema
+            for (int i = 0; i < schema.getColumnInfoCount(); i++) {
+                CdcService.CDCSDKColumnInfoPB col = schema.getColumnInfo(i);
+                schemaString.append(col.getName()).append(":");
+                schemaString.append(col.getType().getMain().name()).append(":");
+                schemaString.append(col.getIsKey()).append(":");
+                schemaString.append(col.getIsHashKey()).append(":");
+                schemaString.append(col.getIsNullable()).append(":");
+                schemaString.append(col.getOid()).append(";");
+            }
+
+            byte[] hashBytes = digest.digest(schemaString.toString().getBytes(StandardCharsets.UTF_8));
+            return bytesToHex(hashBytes);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to calculate schema checksum: {}", e.getMessage());
+            return "unknown";
+        }
+    }
+
+    /**
+     * Calculates a deterministic checksum for a schema from Debezium Table representation.
+     *
+     * @param table the Debezium table object
+     * @return hex string representation of SHA-256 hash
+     */
+    private String calculateSchemaChecksum(Table table) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            StringBuilder schemaString = new StringBuilder();
+
+            List<Column> columns = table.columns();
+            for (Column col : columns) {
+                schemaString.append(col.name()).append(":");
+                schemaString.append(col.typeName()).append(":");
+                schemaString.append(col.isOptional()).append(":");
+                schemaString.append(col.length()).append(":");
+                schemaString.append(col.scale().orElse(null)).append(";");
+            }
+
+            List<String> pkColumns = table.primaryKeyColumnNames();
+            schemaString.append("PK:");
+            for (String pkCol : pkColumns) {
+                schemaString.append(pkCol).append(",");
+            }
+
+            byte[] hashBytes = digest.digest(schemaString.toString().getBytes(StandardCharsets.UTF_8));
+            return bytesToHex(hashBytes);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to calculate schema checksum: {}", e.getMessage());
+            return "unknown";
+        }
+    }
+
+    /**
+     * Converts byte array to hex string.
+     */
+    private String bytesToHex(byte[] bytes) {
+        StringBuilder hexString = new StringBuilder();
+        for (byte b : bytes) {
+            String hex = Integer.toHexString(0xff & b);
+            if (hex.length() == 1) hexString.append('0');
+            hexString.append(hex);
+        }
+        return hexString.toString();
+    }
+
+    /**
+     * Records schema change from Debezium's internal schema representation.
+     * This provides proper SQL types instead of protobuf types.
+     *
+     * @param tableId the table identifier (e.g., "core.products")
+     * @param tabletId the tablet identifier
+     * @param schema the YugabyteDB schema object
+     * @param eventType the type of event (e.g., "DDL", "INITIAL")
+     */
+    public void recordSchemaFromDebeziumSchema(
+            TableId tableId,
+            String tabletId,
+            YugabyteDBSchema schema,
+            String eventType) {
+        try {
+            ensureInitialized();
+            if (producer == null) {
+                throw new IllegalStateException("Producer not initialized");
+            }
+
+            Table table = schema.tableForTablet(tableId, tabletId);
+            if (table == null) {
+                LOGGER.warn("No schema found for table {} tablet {}", tableId, tabletId);
+                return;
+            }
+
+            String tableIdStr = tableId.schema() + "." + tableId.table();
+            String topicName = topicNameGenerator.apply(tableIdStr);
+            String key = tableIdStr;
+            String value = buildSchemaJsonFromDebeziumTable(tableIdStr, tabletId, table, eventType);
+
+            ProducerRecord<String, String> record = new ProducerRecord<>(topicName, key, value);
+
+            producer.send(record, (metadata, exception) -> {
+                if (exception != null) {
+                    schemaHistoryEventsFailed.incrementAndGet();
+                    lastFailedSendTimestamp.set(System.currentTimeMillis());
+                    lastErrorMessage = exception.getMessage();
+                    LOGGER.warn("Failed to send schema history record for table {} to topic {}: {}", tableId, topicName, exception.getMessage());
+                } else {
+                    schemaHistoryEventsSent.incrementAndGet();
+                    lastSuccessfulSendTimestamp.set(System.currentTimeMillis());
+                    LOGGER.debug("Schema history record sent for table {} to topic {} partition {} offset {}",
+                            tableId, topicName, metadata.partition(), metadata.offset());
+                }
+            });
+
+            schemaHistoryEventsQueued.incrementAndGet();
+            LOGGER.info("Schema history {} event queued for table: {} → topic: {}", eventType, tableId, topicName);
+        } catch (Throwable t) {
+            LOGGER.warn("Error recording schema change from Debezium schema for table {}: {}", tableId, t.getMessage());
+        }
+    }
+
+    /**
+     * Records schema snapshot by querying the database schema directly via JDBC once.
+     * This is used on connector startup to publish initial schema snapshots
+     * without waiting for CDC events.
+     *
+     * @param connection JDBC connection to the database
+     * @param schemaName the PostgreSQL schema name (e.g., "core")
+     * @param tableName the table name (e.g., "products")
+     * @param tabletId the tablet identifier
+     * @param eventType the type of event (e.g., "SCHEMA_SNAPSHOT")
+     */
+    public void recordSchemaFromJdbc(
+            java.sql.Connection connection,
+            String schemaName,
+            String tableName,
+            String tabletId,
+            String eventType) {
+        try {
+            ensureInitialized();
+            if (producer == null) {
+                throw new IllegalStateException("Producer not initialized");
+            }
+
+            String tableIdStr = schemaName + "." + tableName;
+            String topicName = topicNameGenerator.apply(tableIdStr);
+            String key = tableIdStr;
+            String value = buildSchemaJsonFromJdbc(connection, schemaName, tableName, tabletId, eventType);
+
+            if (value == null || value.equals("{}")) {
+                LOGGER.warn("No schema found for table {}.{}", schemaName, tableName);
+                return;
+            }
+
+            ProducerRecord<String, String> record = new ProducerRecord<>(topicName, key, value);
+
+            producer.send(record, (metadata, exception) -> {
+                if (exception != null) {
+                    schemaHistoryEventsFailed.incrementAndGet();
+                    lastFailedSendTimestamp.set(System.currentTimeMillis());
+                    lastErrorMessage = exception.getMessage();
+                    LOGGER.warn("Failed to send schema history record for table {}.{} to topic {}: {}",
+                            schemaName, tableName, topicName, exception.getMessage());
+                } else {
+                    schemaHistoryEventsSent.incrementAndGet();
+                    lastSuccessfulSendTimestamp.set(System.currentTimeMillis());
+                    LOGGER.debug("Schema history record sent for table {}.{} to topic {} partition {} offset {}",
+                            schemaName, tableName, topicName, metadata.partition(), metadata.offset());
+                }
+            });
+
+            schemaHistoryEventsQueued.incrementAndGet();
+            LOGGER.info("Schema history {} event queued for table: {}.{} → topic: {}", eventType, schemaName, tableName, topicName);
+        } catch (Throwable t) {
+            LOGGER.warn("Error recording schema from JDBC for table {}.{}: {}", schemaName, tableName, t.getMessage());
+        }
+    }
+
+    private String buildSchemaJsonFromJdbc(
+            java.sql.Connection connection,
+            String schemaName,
+            String tableName,
+            String tabletId,
+            String eventType) {
+        try {
+            List<YugabyteDBSchemaHistoryEvent.ColumnInfo> columns = new ArrayList<>();
+            List<String> primaryKeyColumns = new ArrayList<>();
+
+            String columnQuery = 
+                "SELECT column_name, data_type, is_nullable, character_maximum_length, numeric_precision, numeric_scale, ordinal_position " +
+                "FROM information_schema.columns " +
+                "WHERE table_schema = ? AND table_name = ? " +
+                "ORDER BY ordinal_position";
+
+            try (java.sql.PreparedStatement stmt = connection.prepareStatement(columnQuery)) {
+                stmt.setString(1, schemaName);
+                stmt.setString(2, tableName);
+                try (java.sql.ResultSet rs = stmt.executeQuery()) {
+                    while (rs.next()) {
+                        YugabyteDBSchemaHistoryEvent.ColumnInfo colInfo = new YugabyteDBSchemaHistoryEvent.ColumnInfo();
+                        colInfo.setName(rs.getString("column_name"));
+                        colInfo.setType(rs.getString("data_type"));
+                        colInfo.setIsNullable("YES".equals(rs.getString("is_nullable")));
+
+                        int charMaxLength = rs.getInt("character_maximum_length");
+                        if (!rs.wasNull() && charMaxLength > 0) {
+                            colInfo.setLength(charMaxLength);
+                        }
+
+                        int numericScale = rs.getInt("numeric_scale");
+                        if (!rs.wasNull()) {
+                            colInfo.setScale(numericScale);
+                        }
+
+                        columns.add(colInfo);
+                    }
+                }
+            }
+
+            if (columns.isEmpty()) {
+                LOGGER.warn("No columns found for table {}.{}", schemaName, tableName);
+                return "{}";
+            }
+
+            String pkQuery = 
+                "SELECT a.attname " +
+                "FROM pg_index i " +
+                "JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey) " +
+                "JOIN pg_class c ON c.oid = i.indrelid " +
+                "JOIN pg_namespace n ON n.oid = c.relnamespace " +
+                "WHERE i.indisprimary AND n.nspname = ? AND c.relname = ? " +
+                "ORDER BY array_position(i.indkey, a.attnum)";
+
+            try (java.sql.PreparedStatement stmt = connection.prepareStatement(pkQuery)) {
+                stmt.setString(1, schemaName);
+                stmt.setString(2, tableName);
+                try (java.sql.ResultSet rs = stmt.executeQuery()) {
+                    while (rs.next()) {
+                        primaryKeyColumns.add(rs.getString("attname"));
+                    }
+                }
+            }
+
+            YugabyteDBSchemaHistoryEvent event = new YugabyteDBSchemaHistoryEvent();
+            event.setConnector(connectorName);
+            event.setTable(schemaName + "." + tableName);
+            event.setTablet(tabletId);
+            event.setEventType(eventType);
+
+            StringBuilder schemaString = new StringBuilder();
+            for (YugabyteDBSchemaHistoryEvent.ColumnInfo col : columns) {
+                schemaString.append(col.getName()).append(":")
+                        .append(col.getType()).append(":")
+                        .append(col.getIsNullable()).append(";");
+            }
+            try {
+                java.security.MessageDigest digest = java.security.MessageDigest.getInstance("SHA-256");
+                byte[] hashBytes = digest.digest(schemaString.toString().getBytes(StandardCharsets.UTF_8));
+                event.setSchemaChecksum(bytesToHex(hashBytes));
+            } catch (Exception e) {
+                event.setSchemaChecksum("unknown");
+            }
+
+            YugabyteDBSchemaHistoryEvent.SchemaInfo schemaInfo = new YugabyteDBSchemaHistoryEvent.SchemaInfo();
+            schemaInfo.setColumns(columns);
+            schemaInfo.setPrimaryKey(primaryKeyColumns);
+            event.setSchema(schemaInfo);
+
+            return OBJECT_MAPPER.writeValueAsString(event);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to build schema from JDBC for {}.{}: {}", schemaName, tableName, e.getMessage());
+            return "{}";
+        }
+    }
+
+    private String buildSchemaJsonFromDebeziumTable(
+            String tableId,
+            String tabletId,
+            Table table,
+            String eventType) {
+        try {
+            YugabyteDBSchemaHistoryEvent event = new YugabyteDBSchemaHistoryEvent();
+            event.setConnector(connectorName);
+            event.setTable(tableId);
+            event.setTablet(tabletId);
+            event.setEventType(eventType);
+            event.setSchemaChecksum(calculateSchemaChecksum(table));
+
+            YugabyteDBSchemaHistoryEvent.SchemaInfo schemaInfo = new YugabyteDBSchemaHistoryEvent.SchemaInfo();
+            List<YugabyteDBSchemaHistoryEvent.ColumnInfo> columns = new ArrayList<>();
+
+            for (Column col : table.columns()) {
+                YugabyteDBSchemaHistoryEvent.ColumnInfo colInfo = new YugabyteDBSchemaHistoryEvent.ColumnInfo();
+                colInfo.setName(col.name());
+                colInfo.setType(col.typeName());
+                colInfo.setIsNullable(col.isOptional());
+                if (col.length() > 0) {
+                    colInfo.setLength(col.length());
+                }
+                if (col.scale().isPresent()) {
+                    colInfo.setScale(col.scale().get());
+                }
+                columns.add(colInfo);
+            }
+
+            schemaInfo.setColumns(columns);
+            schemaInfo.setPrimaryKey(table.primaryKeyColumnNames());
+            event.setSchema(schemaInfo);
+
+            return OBJECT_MAPPER.writeValueAsString(event);
+        } catch (JsonProcessingException e) {
+            LOGGER.warn("Failed to serialize schema history event: {}", e.getMessage());
+            return "{}";
+        }
+    }
+
+    /**
+     * Calculates checksum for a schema (public method for external use).
+     * Allows the streaming source to compare schemas before publishing.
+     *
+     * @param schema the CDC schema protobuf
+     * @return hex string representation of SHA-256 hash
+     */
+    public String getSchemaChecksum(CdcService.CDCSDKSchemaPB schema) {
+        return calculateSchemaChecksum(schema);
+    }
+
+    /**
+     * Calculates checksum for a Debezium table (public method for external use).
+     * Allows the streaming source to compare schemas before publishing.
+     *
+     * @param table the Debezium table object
+     * @return hex string representation of SHA-256 hash
+     */
+    public String getSchemaChecksum(Table table) {
+        return calculateSchemaChecksum(table);
+    }
+
+    /**
+     * Closes this schema history producer and releases its resources.
+     * This should be called by tasks when they're done using the producer.
+     */
+    public void close() {
+        if (mbeanName != null) {
+            try {
+                MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+                if (mBeanServer != null && mBeanServer.isRegistered(mbeanName)) {
+                    mBeanServer.unregisterMBean(mbeanName);
+                    LOGGER.info("Unregistered schema history metrics MBean: {}", mbeanName);
+                }
+            } catch (Exception e) {
+                LOGGER.warn("Failed to unregister schema history metrics MBean: {}", e.getMessage());
+            }
+        }
+
+        if (producer != null) {
+            try {
+                producer.flush();
+                producer.close();
+                LOGGER.info("Schema history producer closed for connector: {}", connectorName);
+            } catch (Throwable t) {
+                LOGGER.warn("Error closing schema history producer for {}: {}", connectorName, t.getMessage());
+            }
+        }
+    }
+
+    @Override
+    public String getTopicName() {
+        return "{server}.{table}-schemachanges";
+    }
+
+    @Override
+    public boolean isInitialized() {
+        return initialized.get();
+    }
+
+    @Override
+    public long getSchemaHistoryEventsSent() {
+        return schemaHistoryEventsSent.get();
+    }
+
+    @Override
+    public long getSchemaHistoryEventsFailed() {
+        return schemaHistoryEventsFailed.get();
+    }
+
+    @Override
+    public long getSchemaHistoryEventsQueued() {
+        return schemaHistoryEventsQueued.get();
+    }
+
+    @Override
+    public long getLastSuccessfulSendTimestamp() {
+        return lastSuccessfulSendTimestamp.get();
+    }
+
+    @Override
+    public long getLastFailedSendTimestamp() {
+        return lastFailedSendTimestamp.get();
+    }
+
+    @Override
+    public String getLastErrorMessage() {
+        return lastErrorMessage;
+    }
+
+    @Override
+    public void reset() {
+        schemaHistoryEventsSent.set(0);
+        schemaHistoryEventsFailed.set(0);
+        schemaHistoryEventsQueued.set(0);
+        lastSuccessfulSendTimestamp.set(0);
+        lastFailedSendTimestamp.set(0);
+        lastErrorMessage = null;
+    }
+}
+

--- a/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBSchemaHistoryMetricsMXBean.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBSchemaHistoryMetricsMXBean.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.yugabytedb.metrics;
+
+/**
+ * JMX MBean interface for YugabyteDB schema history producer metrics.
+ *
+ * @author Michael Terranova
+ */
+public interface YugabyteDBSchemaHistoryMetricsMXBean {
+
+    /**
+     * @return the Kafka topic where schema history is published
+     */
+    String getTopicName();
+
+    /**
+     * @return true if the producer has been initialized
+     */
+    boolean isInitialized();
+
+    /**
+     * @return total number of schema history events successfully sent
+     */
+    long getSchemaHistoryEventsSent();
+
+    /**
+     * @return total number of schema history events that failed to send
+     */
+    long getSchemaHistoryEventsFailed();
+
+    /**
+     * @return total number of schema history events queued for sending
+     */
+    long getSchemaHistoryEventsQueued();
+
+    /**
+     * @return timestamp (millis) of the last successful send, or 0 if none
+     */
+    long getLastSuccessfulSendTimestamp();
+
+    /**
+     * @return timestamp (millis) of the last failed send, or 0 if none
+     */
+    long getLastFailedSendTimestamp();
+
+    /**
+     * @return the last error message from a failed send, or null if none
+     */
+    String getLastErrorMessage();
+
+    /**
+     * Resets all counters to zero.
+     */
+    void reset();
+}


### PR DESCRIPTION
## Summary

Adds an optional feature to publish schema metadata events to dedicated per-table Kafka topics, enabling downstream consumers to track table schemas, detect schema changes, and deduplicate schema information across YugabyteDB's distributed tablet architecture.

## Motivation

YugabyteDB's distributed architecture creates unique challenges for schema tracking that standard Debezium patterns don't address:

- **No DDL capture**: CDC doesn't send `ALTER TABLE` statements like MySQL binlog or PostgreSQL WAL
- **Tablet distribution**: Tables are split across N tablets, each independently sending schema metadata
- **Self-describing CDC**: Each change event includes complete schema metadata (CDCSDKSchemaPB protobuf)

These architectural differences make Debezium's standard `SchemaHistory` interface (designed for binlog-based databases) unsuitable for YugabyteDB when downstream consumers need independent schema tracking.

**Use cases:**
- Schema versioning and governance
- Data pipeline validation
- Cross-environment schema comparison
- Migration support (tracking PK differences between source and target databases)
- Operational monitoring and alerting

---

## Feature Overview

When enabled, the connector publishes schema events to per-table Kafka topics whenever:
- **Connector starts with no existing offsets** (`SCHEMA_SNAPSHOT`) - Uses JDBC queries to `information_schema.columns`
- **Table schema changes via DDL operations** (`SCHEMA_CHANGE`) - Detected by comparing `CDCSDKSchemaPB` from CDC stream with cached schema

### Topic Naming

**Pattern**: `{server}.{schema}.{table}-schemachanges`

**Examples**:
- `myserver.public.orders-schemachanges`
- `myserver.inventory.products-schemachanges`

### Event Format

```json
{
  "connector": "myconnector",
  "table": "public.orders",
  "tablet": "76d5e365162840508fc3c86fe82fcbcb",
  "eventType": "SCHEMA_SNAPSHOT",
  "timestamp": "2025-12-03T13:55:35.657758834Z",
  "schemaChecksum": "d20c65f5fcd9c5e1d7d81ca1e4f1607eb15f2d98bae42fbcdd616438dd9c0f3f",
  "schema": {
    "columns": [
      {
        "name": "order_id",
        "type": "INT64",
        "isKey": true,
        "isHashKey": true,
        "isNullable": false,
        "oid": 20
      },
      {
        "name": "customer_name",
        "type": "STRING",
        "isKey": false,
        "isHashKey": false,
        "isNullable": true,
        "oid": 1043
      }
    ],
    "primaryKey": ["order_id"]
  }
}
```

### Key Features

- **Per-table topics**: Each table publishes to its own dedicated topic
- **JDBC-based snapshots**: On startup, queries database directly for immediate schema availability
- **Deterministic checksums**: SHA-256 hash enables deduplication across tablets
- **Tablet-aware**: Includes tablet ID for distributed system visibility
- **Optional**: Disabled by default, no impact on existing deployments
- **Fail-fast**: Misconfiguration stops connector task immediately

---

## Why Not Use Debezium's SchemaHistory Interface?

Debezium's `SchemaHistory` interface was designed for binlog-based databases where:
1. DDL statements are captured as text (`"ALTER TABLE products ADD COLUMN price DECIMAL"`)
2. Schema must be reconstructed by replaying DDL through a parser
3. Single stream per database (no deduplication needed)

### YugabyteDB CDC is Fundamentally Different

**Traditional Path (MySQL/PostgreSQL):**
```
Database → [DDL Event] → Binlog/WAL → Connector → SchemaHistory → DdlParser → Tables
                ↓                                        ↓
          "ALTER TABLE..."                     Replay to rebuild schema
```

**Proposed path, YugabyteDB:**
```
Database → [Change + Schema Metadata] → CDC Stream → Connector
                    ↓
          CDCSDKSchemaPB (Protobuf with full schema definition)
```

### Key Architectural Differences

| Aspect | Binlog-based | YugabyteDB CDC |
|--------|--------------|----------------|
| DDL capture | Text statements | No DDL text |
| Schema format | Requires parsing | Structured protobuf |
| Stream architecture | Single source | Multiple tablets |
| Schema in events | Not included | Embedded in each event |
| Connector dependency | Requires SchemaHistory | Optional enhancement |

### Deduplication Challenge

With a table split across 4 tablets, forcing YugabyteDB into the `SchemaHistory` interface would cause:

```java
// Each tablet would trigger schema recording
schemaHistory.record(source, position, "database", syntheticDDL);  // Tablet 1
schemaHistory.record(source, position, "database", syntheticDDL);  // Tablet 2 (duplicate!)
schemaHistory.record(source, position, "database", syntheticDDL);  // Tablet 3 (duplicate!)
schemaHistory.record(source, position, "database", syntheticDDL);  // Tablet 4 (duplicate!)

// On recovery:
schemaHistory.recover(offsets, tables, ddlParser);
// Would replay same DDL 4 times → parser errors or incorrect state
```

### Different Use Case

**Standard SchemaHistory:**
- **Audience**: Connector internal state management
- **Purpose**: Recover schema on connector restart
- **Format**: DDL statements for parsing
- **Required**: Connector cannot function without it

**YugabyteDB Schema History (this feature):**
- **Audience**: Downstream consumers
- **Purpose**: Track schema evolution, enable data governance
- **Format**: Structured JSON for direct consumption
- **Optional**: Connector functions normally without it

**Result**: A lightweight, purpose-built publisher that leverages YugabyteDB's strengths (self-describing CDC) rather than working around them.

---

## Implementation Details

### 1. Schema History Producer

**Class**: `YugabyteDBSchemaHistoryProducer`

- Per-task Kafka producer instance (one per connector task)
- Publishes to per-table Kafka topics (not a single topic)
- Client ID: `{connectorName}-schema-history`
- Lifecycle: Lazy initialization on first schema event, closed on task stop
- Thread-safe for concurrent schema events
- Supports full Kafka security (SSL/TLS)

### 2. Event Type Logic

**Location**: `YugabyteDBStreamingChangeEventSource`

```java
// SCHEMA_SNAPSHOT: On connector startup with no existing offsets
if (!previousOffsetPresent) {
    // Query information_schema.columns via JDBC
    // Publish one event per table (deduplicated across tablets)
}

// SCHEMA_CHANGE: During runtime when schema differs
if (receivedSchema != cachedSchema) {
    producer.recordSchemaChange(tableId, tabletId, receivedSchema, "SCHEMA_CHANGE");
}
```

**Event Types:**
- `SCHEMA_SNAPSHOT`: Initial schema capture via JDBC on connector startup
- `SCHEMA_CHANGE`: Schema modification detected from CDC stream

**Why JDBC for snapshots?**
- Schema treated as independent infrastructure metadata, not tied to row changes
- Ensures schema available immediately, even if no DML events occur
- Provides consistent initial state for all tables

### 3. Schema Checksum

**Algorithm**: SHA-256 hash of normalized schema structure

**Includes:**
- Column name
- Data type (normalized, e.g., "INT32" not "MAIN: INT32")
- Nullability (`isNullable`)
- Key flags (`isKey`, `isHashKey`)
- PostgreSQL OID

**Purpose**: Enables consumer-side deduplication across tablets

**Property**: Deterministic - same schema → same checksum regardless of tablet

### 4. Message Key Format

**Format**: `{table}` (e.g., `"public.orders"`)

**Benefits:**
- Enables Kafka partition ordering per table
- Natural grouping for stream processing
- All events for same table go to same partition

### 5. Connector Topology Considerations

**Unlike MySQL** (one connector per database):
- YugabyteDB deployments may use multiple connectors for horizontal scaling
- Each connector handles a subset of tables (all tablets for those tables)
- **Tables are never split across connectors** - all tablets for a given table belong to one connector
- Schema history topics are per-table, not per-connector
- Deduplication with `HashSet<String>` ensures one `SCHEMA_SNAPSHOT` per table at startup

### 6. Integration Point

Schema events are published when:
1. **Connector startup** (`!previousOffsetPresent`): JDBC queries to `information_schema.columns`
2. **DDL operations**: CDC sends schema metadata, compared with cached schema
3. **Schema mismatch**: Cached schema differs from CDC schema

---

## Configuration

### Configuration Fields

All fields have `Importance.LOW` - feature is completely optional:

```properties
# Required to enable feature
schema.history.kafka.topic={server}.{table}-schemachanges

# Kafka connection (defaults to connector's bootstrap servers if not set)
schema.history.internal.kafka.bootstrap.servers=kafka:9092

# Security configuration (optional)
schema.history.internal.producer.security.protocol=SSL
schema.history.internal.producer.ssl.keystore.location=/ssl/keystore.p12
schema.history.internal.producer.ssl.keystore.password=${env:KEYSTORE_PASSWORD}
schema.history.internal.producer.ssl.keystore.type=PKCS12
schema.history.internal.producer.ssl.truststore.location=/ssl/truststore.p12
schema.history.internal.producer.ssl.truststore.password=${env:TRUSTSTORE_PASSWORD}
schema.history.internal.producer.ssl.truststore.type=PKCS12
```

**Note**: `schema.history.kafka.topic` is a template pattern. The actual topics are derived per-table.

### Enabling the Feature

1. Set `schema.history.kafka.topic` to topic naming pattern
2. Optionally configure Kafka connection and security
3. Feature activates automatically on connector start/restart

### Disabling the Feature

- Omit `schema.history.kafka.topic` or set to empty string
- No schema events published
- Zero performance impact

---

## Testing & Validation

### Example Test Scenario

**Setup:**
- Table: `public.orders` with 4 tablets
- Test: Fresh start (deleted offsets, restarted connector)

**Expected Behavior:**
- One `SCHEMA_SNAPSHOT` event published (deduplicated across tablets)
- All events for same table have identical checksums

**Example event**:
```json
{
  "table": "public.orders",
  "tablet": "76d5e365...",
  "schemaChecksum": "d20c65f5...dd9c0f3f",
  "eventType": "SCHEMA_SNAPSHOT"
}
```

Only **one** event published to `myserver.public.orders-schemachanges`, despite 4 tablets.

**Validation:**
- Deduplication working (1 event per table, not per tablet)
- Checksums deterministic across tablets
- Schema content matches database definition
- Timestamps within expected range

### Unit Tests

**File**: `YugabyteDBSchemaHistoryProducerTest.java`

**Coverage:**
- Producer instantiation and lifecycle
- Schema checksum determinism
- Schema checksum changes on different schemas
- JSON structure validation
- Null/empty configuration handling
- Idempotent close operations
- Concurrent access scenarios

---

## Consumer Usage Example

### Basic Deduplication

Consume events from per-table topics. Each event includes a `schemaChecksum` field (SHA-256 hash) for identifying unique schema versions:

  ```java
  // Track processed schemas by checksum
  Set<String> processedSchemas = new HashSet<>();

  consumer.subscribe(Pattern.compile(".*-schemachanges"));
  while (true) {
      for (ConsumerRecord<String, String> record : consumer.poll(Duration.ofMillis(100))) {
          SchemaEvent event = parseSchemaEvent(record.value());
          if (processedSchemas.add(event.getSchemaChecksum())) {
              handleSchemaChange(event);
          }
      }
  }


**Note**: With per-table topics and in-connector deduplication, consumers typically don't need additional deduplication logic. This example shows how to handle edge cases if needed.

---

## Shopify Use Cases

### 1. Migration Support

**Problem**: Source database has simple primary keys, target YugabyteDB uses composite PKs

**Solution**:
- Schema history topics provide YugabyteDB's composite PK structure
- Migration tools can compare schemas and identify differences
- Enables automated validation and compatibility checks

### 2. Schema Registry Alternative

Provides lightweight schema versioning without dedicated infrastructure:
- Track primary key definitions across all tables
- Detect schema drift between environments
- Enable schema compatibility validation in pipelines

### 3. Data Governance

- Compliance audit trail for schema changes
- Correlate schema changes with data anomalies
- Track schema evolution over time

### 4. Operational Monitoring

- Alert on unexpected schema changes
- Track schema change frequency
- Monitor tablet-level schema consistency

---

## Deployment Considerations

### Topic Configuration

**Recommended settings:**
```properties
cleanup.policy: delete
message.timestamp.type: CreateTime
retention.ms: -1
retention.bytes: -1
```

**Reasoning**:
- `retention.ms: -1`: Schema history retained indefinitely
- `retention.bytes: -1`: Schema changes are infrequent, minimal storage impact
- `cleanup.policy: delete`: Preserve all schema evolution history
- `message.timestamp.type: CreateTime`: Use producer timestamp

### Monitoring

**JMX Metrics Available**:

MBean: `debezium.yugabytedb:type=schema-history-producer,connector=<connector-name>`

Metrics:
- `SchemaHistoryEventsSent`: Total events published
- `SchemaHistoryEventsFailed`: Failed publish attempts
- `SchemaHistoryEventsQueued`: Events in producer buffer
- `LastSuccessfulSendTimestamp`: Last successful publish (milliseconds)
- `LastFailedSendTimestamp`: Last failed publish (milliseconds)
- `LastErrorMessage`: Last error message from failed send
- `TopicName`: Configured topic name pattern
- `Initialized`: Whether producer has been initialized

**Alert On:**
- `SchemaHistoryEventsFailed` > 0
- Gap between `LastSuccessfulSendTimestamp` and current time > threshold

### Security

- Schema history producer inherits connector's Kafka credentials by default
- Separate credentials can be configured via `schema.history.internal.producer.*`
- Topic ACLs should grant WRITE permission to connector principal

### Resource Impact

- Minimal: One Kafka producer per connector task
- Lazy initialization: Producer created on first schema event
- Events only published on schema changes (infrequent)
- JDBC queries: Only on connector startup with no existing offsets

---

## Alternatives Considered

### 1. Force-fit SchemaHistory Interface

**Approach**: Generate synthetic DDL from protobuf, use standard interface

**Rejected because:**
- Requires reverse-engineering DDL text from structured schema
- Parser would be a no-op (parse synthetic DDL back to structure)
- No deduplication mechanism for multi-tablet architecture
- Adds complexity without benefit

### 2. Schema Per Tablet

**Approach**: Publish schema for each tablet independently

**Rejected because:**
- N× redundancy for same schema information
- Consumer complexity to deduplicate
- Unnecessary network and storage overhead

### 3. Schema in Data Topic

**Approach**: Embed schema in each change event

**Rejected because:**
- Massive bandwidth overhead (schema in every event)
- Tight coupling between data and schema streams
- Consumers must filter schema from data events

### 4. Single Schema History Topic

**Approach**: All tables publish to one shared topic

**Rejected because:**
- Consumer filtering complexity
- Harder to scale (single partition bottleneck)
- Per-table topics provide natural isolation

---

## Backward Compatibility

- Feature is **disabled by default**
- Can be enabled with config updates
- **No breaking changes introduced**
- **Zero impact** on connectors without configuration

**Migration path:**
1. Deploy connector with schema history code
2. Connectors without `schema.history.kafka.topic` see no change
3. Enable feature by adding topic configuration
4. Schema events begin publishing on next connector restart

---

## Files Changed

### New Files

- `YugabyteDBSchemaHistoryProducer.java` - Core producer implementation
- `YugabyteDBSchemaHistoryEvent.java` - JSON event schema POJO
- `YugabyteDBSchemaHistoryMetricsMXBean.java` - JMX metrics interface
- `YugabyteDBSchemaHistoryProducerTest.java` - Unit tests

### Modified Files

- `YugabyteDBConnectorConfig.java` - Added 9 configuration fields
- `YugabyteDBConnectorTask.java` - Producer lifecycle management
- `YugabyteDBStreamingChangeEventSource.java` - Producer integration and deduplication
- `pom.xml` - Dependency scope adjustment
