### PR TITLE
Add offset rebind feature

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -808,6 +808,13 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
                     "Whether or not to delete the logical replication stream when the connector finishes orderly" +
                             "By default the replication is kept so that on restart progress can resume from the last recorded location");
 
+    public static final Field ENABLE_OFFSET_REBIND = Field.create("yugabytedb.enable.offset.rebind")
+        .withDisplayName("Enable resume from saved offsets (rebind checkpoints)")
+        .withType(Type.BOOLEAN)
+        .withImportance(Importance.LOW)
+        .withDefault(false)
+        .withDescription("When true, on startup the connector sets per-tablet CDC checkpoints from saved offsets to resume after stream ID loss");
+
     public enum AutoCreateMode implements EnumeratedValue {
         /**
          * No Publication will be created, it's expected the user
@@ -1357,6 +1364,10 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
         return getConfig().getString(SSL_CLIENT_KEY);
     }
 
+    public boolean isEnableOffsetRebind() {
+        return getConfig().getBoolean(ENABLE_OFFSET_REBIND);
+    }
+
     protected LogicalDecoder plugin() {
         return LogicalDecoder.parse(getConfig().getString(PLUGIN_NAME));
     }
@@ -1533,7 +1544,8 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
                     SCHEMA_REFRESH_MODE,
                     TRUNCATE_HANDLING_MODE,
                     INCREMENTAL_SNAPSHOT_CHUNK_SIZE,
-                    TRANSACTION_ORDERING)
+                    TRANSACTION_ORDERING,
+                    ENABLE_OFFSET_REBIND)
             .excluding(INCLUDE_SCHEMA_CHANGES)
             .create();
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetRebindTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetRebindTest.java
@@ -1,0 +1,88 @@
+package io.debezium.connector.yugabytedb;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.*;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration test for the stream rebind feature controlled by the
+ * `yugabytedb.enable.offset.rebind` configuration property.
+ *
+ * The test validates that when a connector is initially started against one
+ * stream, stopped, and then restarted against a NEW stream id with rebind
+ * enabled, it resumes from the last committed offsets and therefore emits
+ * change events that were produced after the last committed offset.
+ */
+public class YugabyteDBOffsetRebindTest extends YugabyteDBContainerTestBase {
+
+    private static final String INSERT_STMT_FMT = "INSERT INTO t1 VALUES (%d, 'John', 'Doe', 32);";
+
+    @BeforeAll
+    public static void beforeAll() throws SQLException {
+        initializeYBContainer();
+        TestHelper.dropAllSchemas();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        shutdownYBContainer();
+    }
+
+    @BeforeEach
+    public void beforeEach() throws Exception {
+        initializeConnectorTestFramework();
+        TestHelper.executeDDL("yugabyte_create_tables.ddl");
+    }
+
+    @AfterEach
+    public void afterEach() throws Exception {
+        stopConnector();
+        TestHelper.executeDDL("drop_tables_and_databases.ddl");
+    }
+
+    @Test
+    public void testResumeFromOffsetsAcrossStreamRebind() throws Exception {
+        // 1) Create original stream and start the connector without rebind.
+        String originalStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", /*consistentSnapshot=*/false, /*useSnapshot=*/false);
+        Configuration.Builder initialConfig = TestHelper.getConfigBuilder("public.t1", originalStreamId);
+        startEngine(initialConfig);
+        awaitUntilConnectorIsReady();
+
+        // Produce 100 rows.
+        TestHelper.executeBulkWithRange(INSERT_STMT_FMT, 1, 101);
+
+        // Consume all 100 change events and assert.
+        List<SourceRecord> initialRecords = new ArrayList<>();
+        waitAndFailIfCannotConsume(initialRecords, 100);
+        assertEquals(100, initialRecords.size(), "Did not receive expected initial records");
+        assertNoRecordsToConsume();
+
+        // 2) Stop connector – offsets are now committed in the embedded engine.
+        stopConnector();
+
+        // 3) Drop the old stream implicitly (delete.on.stop=true in config builder) and create a NEW one.
+        String newStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", /*consistentSnapshot=*/false, /*useSnapshot=*/false);
+
+        // 4) Insert additional 20 rows (101-120) after restart.
+        TestHelper.executeBulkWithRange(INSERT_STMT_FMT, 101, 121);
+
+        // 5) Start connector again, pointing at the *new* stream id and enabling offset rebind.
+        Configuration.Builder rebindConfig = TestHelper.getConfigBuilder("public.t1", newStreamId)
+                .with(YugabyteDBConnectorConfig.ENABLE_OFFSET_REBIND, true);
+        startEngine(rebindConfig);
+        awaitUntilConnectorIsReady();
+
+        // 6) Verify that the new 20 change events are emitted.
+        List<SourceRecord> rebindRecords = new ArrayList<>();
+        waitAndFailIfCannotConsume(rebindRecords, 20);
+        assertEquals(20, rebindRecords.size(), "Unexpected number of records after rebind – offsets not honoured?");
+        assertNoRecordsToConsume();
+    }
+}


### PR DESCRIPTION
Adds a feature allowing an existing connector to resume from the last externally stored offsets (Kafka) in the case where the backing streamid is deleted or simply a new one is preferred. 

This feature allows clients to continue streaming events from the connector's last checkpointed spot (assuming intents are still available) even when issued a new streamid on restart. If `yugabytedb.enable.offset.rebind` is set to `false` or if the setting is omitted, the legacy behavior remains and the connector will only start streaming from the latest events available. 