### PR TITLE
Add config to allow for specifying size of getChanges requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.kafka>3.7.0</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.4.0</version.logback>
-        <version.ybclient>0.8.111-20260312.173733-1</version.ybclient>
+        <version.ybclient>0.8.112-20260323.131233-1</version.ybclient>
         <version.gson>2.8.9</version.gson>
 
         <!--

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -600,6 +600,9 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
     protected static final long DEFAULT_NEW_TABLE_POLL_INTERVAL_MS = 5 * 60 * 1000L;
     protected static final long DEFAULT_LOG_GET_CHANGES_INTERVAL_MS = 5 * 60 * 1000L;
     protected static final long DEFAULT_LOG_COMMIT_OFFSET_INTERVAL_MS = 10 * 60 * 1000L;
+    // Matches the YugabyteDB tserver default for cdc_stream_records_threshold_size_bytes (4 MB).
+    // A null value means the field is omitted from the request and the tserver flag governs.
+    protected static final Long DEFAULT_GETCHANGES_RESP_MAX_SIZE_BYTES = null;
     public static final int DEFAULT_MBEAN_REGISTRATION_RETRIES = 12;
     public static final long DEFAULT_MBEAN_REGISTRATION_RETRY_DELAY_MS = 5_000;
     public static final long DEFAULT_LAST_CALLBACK_TIMEOUT_MS = 3 * 60 * 1000;
@@ -745,6 +748,18 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
               .withType(Type.BOOLEAN)
               .withImportance(Importance.LOW)
               .withDefault(false);
+
+    public static final Field GETCHANGES_RESP_MAX_SIZE_BYTES =
+            Field.create("cdc.getchanges.resp.max.size.bytes")
+                    .withDisplayName("GetChanges response max size bytes")
+                    .withType(Type.LONG)
+                    .withImportance(Importance.LOW)
+                    .withDescription(
+                            "When set, overrides the tserver flag cdc_stream_records_threshold_size_bytes "
+                            + "for every GetChanges RPC issued by this connector, allowing per-connector "
+                            + "control over the maximum response payload size. Requires the tserver flag "
+                            + "enable_cdcsdk_setting_get_changes_response_byte_limit to be true (the default). "
+                            + "When unset (the default), the tserver flag value is used.");
 
     public static final Field CHAR_SET = Field.create(TASK_CONFIG_PREFIX + "charset")
             .withDisplayName("YugabyteDB charset")
@@ -1369,6 +1384,17 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
         return getConfig().getLong(LOG_COMMIT_OFFSET_INTERVAL_MS);
     }
 
+    /**
+     * Returns the value to send in the {@code getchanges_resp_max_size_bytes} proto field of every
+     * GetChanges RPC, or {@code null} if the field should be omitted (leaving the tserver flag
+     * {@code cdc_stream_records_threshold_size_bytes} in control).
+     */
+    public Long getchangesRespMaxSizeBytes() {
+        return getConfig().hasKey(GETCHANGES_RESP_MAX_SIZE_BYTES.name())
+                ? getConfig().getLong(GETCHANGES_RESP_MAX_SIZE_BYTES)
+                : DEFAULT_GETCHANGES_RESP_MAX_SIZE_BYTES;
+    }
+
     public String sslRootCert() {
         return getConfig().getString(SSL_ROOT_CERT);
     }
@@ -1545,10 +1571,11 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
                     LOG_GET_CHANGES,
                     LOG_GET_CHANGES_INTERVAL_MS,
                     LOG_COMMIT_OFFSET_INTERVAL_MS,
-              MBEAN_REGISTRATION_RETRIES,
+                    MBEAN_REGISTRATION_RETRIES,
                     MBEAN_REGISTRATION_RETRY_DELAY_MS,
                     CDC_POLL_INTERVAL_ACTIVE_MS,
-                    CDC_POLL_INTERVAL_IDLE_MS)
+                    CDC_POLL_INTERVAL_IDLE_MS,
+                    GETCHANGES_RESP_MAX_SIZE_BYTES)
             .events(
                     INCLUDE_UNKNOWN_DATATYPES)
             .connector(

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -552,7 +552,8 @@ public class YugabyteDBStreamingChangeEventSource implements
                                         table, streamId, tabletId, cp.getTerm(), cp.getIndex(), cp.getKey(),
                                         cp.getWrite_id(), cp.getTime(), schemaNeeded.get(part.getId()),
                                         explicitCheckpoint,
-                                        tabletSafeTime.getOrDefault(part.getId(), cp.getTime()), offsetContext.getWalSegmentIndex(part));
+                                        tabletSafeTime.getOrDefault(part.getId(), cp.getTime()), offsetContext.getWalSegmentIndex(part),
+                                        connectorConfig.getchangesRespMaxSizeBytes());
 
                                 // Test only.
                                 if (TEST_TRACK_EXPLICIT_CHECKPOINTS) {
@@ -898,7 +899,8 @@ public class YugabyteDBStreamingChangeEventSource implements
             GetChangesResponse resp = syncClient.getChangesCDCSDK(
               ybTable, connectorConfig.streamId(), partition.getTabletId(), fromOpId.getTerm(),
               fromOpId.getIndex(), fromOpId.getKey(), fromOpId.getWrite_id(), fromOpId.getTime(),
-              schemaNeeded, explicitCheckpoint, tabletSafeTime, walSegmentIndex);
+              schemaNeeded, explicitCheckpoint, tabletSafeTime, walSegmentIndex,
+              connectorConfig.getchangesRespMaxSizeBytes());
 
             // We do not update the tablet safetime we get from the response at this
             // point because the previous GetChanges call is supposed to throw

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBGetChangesRespMaxSizeBytesTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBGetChangesRespMaxSizeBytesTest.java
@@ -1,0 +1,58 @@
+package io.debezium.connector.yugabytedb;
+
+import io.debezium.config.Configuration;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests to verify the {@code getchangesRespMaxSizeBytes} configuration
+ * property is correctly parsed and surfaced by {@link YugabyteDBConnectorConfig}.
+ */
+public class YugabyteDBGetChangesRespMaxSizeBytesTest {
+
+    /**
+     * Builds a minimal {@link YugabyteDBConnectorConfig} from the supplied
+     * builder, adding only the properties required by the constructor.
+     */
+    private static YugabyteDBConnectorConfig buildConfig(Configuration.Builder builder) {
+        builder.with(RelationalDatabaseConnectorConfig.SERVER_NAME, "test-server")
+               .with(YugabyteDBConnectorConfig.MASTER_ADDRESSES, "127.0.0.1:7100")
+               .with(YugabyteDBConnectorConfig.DATABASE_NAME, "yugabyte")
+               .with(YugabyteDBConnectorConfig.HOSTNAME, "127.0.0.1")
+               .with(YugabyteDBConnectorConfig.PORT, 5433)
+               .with(YugabyteDBConnectorConfig.USER, "yugabyte")
+               .with(YugabyteDBConnectorConfig.PASSWORD, "yugabyte");
+        return new YugabyteDBConnectorConfig(builder.build());
+    }
+
+    @Test
+    public void shouldReturnNullWhenPropertyIsNotSet() {
+        YugabyteDBConnectorConfig config = buildConfig(Configuration.create());
+
+        assertNull(config.getchangesRespMaxSizeBytes(),
+                "Expected null when cdc.getchanges.resp.max.size.bytes is not configured");
+    }
+
+    @Test
+    public void shouldReturnConfiguredValueWhenPropertyIsSet() {
+        long expectedBytes = 8_388_608L; // 8 MB
+        YugabyteDBConnectorConfig config = buildConfig(
+                Configuration.create()
+                        .with(YugabyteDBConnectorConfig.GETCHANGES_RESP_MAX_SIZE_BYTES, expectedBytes));
+
+        assertEquals(expectedBytes, config.getchangesRespMaxSizeBytes(),
+                "Expected the explicitly configured value to be returned");
+    }
+
+    @Test
+    public void shouldReturnZeroWhenPropertyIsSetToZero() {
+        YugabyteDBConnectorConfig config = buildConfig(
+                Configuration.create()
+                        .with(YugabyteDBConnectorConfig.GETCHANGES_RESP_MAX_SIZE_BYTES, 0L));
+
+        assertEquals(0L, config.getchangesRespMaxSizeBytes(),
+                "Expected 0 when the property is explicitly set to zero");
+    }
+}


### PR DESCRIPTION
Counterpart to https://github.com/yugabyte/yugabyte-db/pull/30647

Adds a config to specify the size of changes from a tablet sent from the CDC service on calls to `getChangesCDCSDK` as defined in https://github.com/yugabyte/yugabyte-db/pull/30647