### PR TITLE
[yugabyte/yugabyte-db#30391] Handle NPE in isBeforeImageEnabled when using Logical Replication

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YBClientUtils.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YBClientUtils.java
@@ -348,7 +348,8 @@ public class YBClientUtils {
     if (recordType == null) {
       // If the record_type option is not found, it means that the stream is configured with a slot + publication path.
       // In this case, we return true to indicate that before image is enabled.
-      LOGGER.warn("record_type option not found in stream options.");
+      LOGGER.info("record_type option not found in stream options, the stream is likely configured"
+          + " via slot + publication path; returning before_image as enabled (true)");
       return true;
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YBClientUtils.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YBClientUtils.java
@@ -344,10 +344,16 @@ public class YBClientUtils {
       return false;
     }
 
-    return (cdcStreamInfo.getOptions().get("record_type").equals(CDCRecordType.ALL.name())
-           || cdcStreamInfo.getOptions().get("record_type").equals(CDCRecordType.MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES.name()))
-           || (cdcStreamInfo.getOptions().get("record_type").equals(CDCRecordType.PG_FULL.name())
-           || cdcStreamInfo.getOptions().get("record_type").equals(CDCRecordType.PG_CHANGE_OLD_NEW.name()));
+    String recordType = cdcStreamInfo.getOptions().get("record_type");
+    if (recordType == null) {
+      LOGGER.warn("record_type option not found in stream options");
+      return false;
+    }
+
+    return recordType.equals(CDCRecordType.ALL.name())
+           || recordType.equals(CDCRecordType.MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES.name())
+           || recordType.equals(CDCRecordType.PG_FULL.name())
+           || recordType.equals(CDCRecordType.PG_CHANGE_OLD_NEW.name());
   }
 
   /**

--- a/src/main/java/io/debezium/connector/yugabytedb/YBClientUtils.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YBClientUtils.java
@@ -346,8 +346,10 @@ public class YBClientUtils {
 
     String recordType = cdcStreamInfo.getOptions().get("record_type");
     if (recordType == null) {
-      LOGGER.warn("record_type option not found in stream options");
-      return false;
+      // If the record_type option is not found, it means that the stream is configured with a slot + publication path.
+      // In this case, we return true to indicate that before image is enabled.
+      LOGGER.warn("record_type option not found in stream options.");
+      return true;
     }
 
     return recordType.equals(CDCRecordType.ALL.name())

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBPublicationReplicationTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBPublicationReplicationTest.java
@@ -11,7 +11,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
+import org.awaitility.core.ConditionTimeoutException;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
 import io.debezium.connector.yugabytedb.common.YugabytedTestBase;
 import io.debezium.connector.yugabytedb.connection.YugabyteDBConnection;
@@ -41,11 +43,16 @@ public class YugabyteDBPublicationReplicationTest extends YugabyteDBContainerTes
 
     public static String insertStatementFormatfort2 = "INSERT INTO t2 values (%d);";
     public static String insertStatementFormatfort3 = "INSERT INTO t3 values (%d);";
+    private final String formatInsertString =
+        "INSERT INTO t1 VALUES (%d, 'Vaibhav', 'Kushwaha', 12.345);";
+
+    private static final String PUB_NAME = "pub";
+    private static final String SLOT_NAME = "test_replication_slot";
 
     @BeforeAll
     public static void beforeClass() throws SQLException {
-        setMasterFlags("ysql_yb_enable_replication_commands=true");
-        setTserverFlags("ysql_yb_enable_replication_commands=true");
+        setMasterFlags("ysql_yb_enable_replication_commands=true,ysql_cdc_active_replication_slot_window_ms=0");
+        setTserverFlags("ysql_yb_enable_replication_commands=true,ysql_cdc_active_replication_slot_window_ms=0");
         initializeYBContainer( );
         TestHelper.dropAllSchemas();
     }
@@ -53,12 +60,14 @@ public class YugabyteDBPublicationReplicationTest extends YugabyteDBContainerTes
     @BeforeEach
     public void before() throws Exception {
         initializeConnectorTestFramework();
+        dropReplicationSlot();
         TestHelper.executeDDL("yugabyte_create_tables.ddl");
     }
 
     @AfterEach
     public void after() throws Exception {
         stopConnector();
+        Thread.sleep(10000);
         Awaitility.await()
             .atMost(Duration.ofSeconds(65))
             .until(() -> {
@@ -98,12 +107,13 @@ public class YugabyteDBPublicationReplicationTest extends YugabyteDBContainerTes
 
     @Test
     public void testPublicationReplicationSnapshotConsumption() throws Exception {
-        String insertStatement = "INSERT INTO t2 values (%d);";
+        TestHelper.execute("CREATE TABLE IF NOT EXISTS t2_snapshot (id int primary key);");
+        TestHelper.execute(String.format(TestHelper.createPublicationForTableStatement, "pub", "t2_snapshot"));
+        TestHelper.execute(TestHelper.createReplicationSlotStatement);
+
+        String insertStatement = "INSERT INTO t2_snapshot values (%d);";
         final int recordsCount = 1000;
         TestHelper.executeBulk(insertStatement, recordsCount);
-
-        TestHelper.execute(String.format(TestHelper.createPublicationForTableStatement, "pub", "t2"));
-        TestHelper.execute(TestHelper.createReplicationSlotStatement);
 
         Configuration.Builder configBuilder = TestHelper.getConfigBuilderWithPublication("yugabyte", "pub", "test_replication_slot"); 
         configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE, YugabyteDBConnectorConfig.SnapshotMode.INITIAL.getValue());
@@ -112,6 +122,7 @@ public class YugabyteDBPublicationReplicationTest extends YugabyteDBContainerTes
         awaitUntilConnectorIsReady();
 
         verifyRecordCount(recordsCount);
+        // TestHelper.execute("DROP TABLE IF EXISTS t2_snapshot;");
     }
 
     @Test
@@ -159,8 +170,8 @@ public class YugabyteDBPublicationReplicationTest extends YugabyteDBContainerTes
 
     @Test
     public void oldConfigStreamIDShouldNotBePartOfReplicationSlot() throws Exception {
-        TestHelper.execute(String.format(TestHelper.createPublicationForTableStatement, "pub", "t1"));
         TestHelper.execute(TestHelper.createReplicationSlotStatement);
+        TestHelper.execute(String.format(TestHelper.createPublicationForTableStatement, "pub", "t1"));
         String streamId = TestHelper.getStreamIdFromSlot("test_replication_slot");
 
         LOGGER.info("Using stream ID =  " + streamId);
@@ -174,6 +185,7 @@ public class YugabyteDBPublicationReplicationTest extends YugabyteDBContainerTes
          "Stream ID %s is associated with replication slot %s. Please use slot name in the config instead of Stream ID.",
                 streamId, "test_replication_slot");
         assertTrue(exception.getMessage().contains(errorMessage));
+
     }
 
     @Test
@@ -236,6 +248,184 @@ public class YugabyteDBPublicationReplicationTest extends YugabyteDBContainerTes
 
     }
 
+    @Test
+    public void testReplicaIdentityFull() throws Exception {
+        TestHelper.initDB("yugabyte_create_tables.ddl");
+
+        TestHelper.execute("ALTER TABLE t1 REPLICA IDENTITY FULL;");
+        TestHelper.execute(String.format(TestHelper.createPublicationForTableStatement, PUB_NAME, "t1"));
+        TestHelper.execute(TestHelper.createReplicationSlotStatement);
+
+        startEngine(getPublicationConfig());
+        awaitUntilConnectorIsReady();
+
+        TestHelper.execute(String.format(formatInsertString, 1));
+        TestHelper.execute("UPDATE t1 SET first_name='VKVK', hours=56.78 WHERE id = 1;");
+        TestHelper.execute("DELETE FROM t1 WHERE id = 1;");
+
+        List<SourceRecord> records = new ArrayList<>();
+        CompletableFuture.runAsync(() -> getRecords(records, 4, 20000)).get();
+
+        // INSERT: no before image
+        SourceRecord insertRecord = records.get(0);
+        assertValueField(insertRecord, "before", null);
+        assertAfterImage(insertRecord, 1, "Vaibhav", "Kushwaha", 12.345);
+
+        // UPDATE: full before image with all columns
+        SourceRecord updateRecord = records.get(1);
+        assertBeforeImage(updateRecord, 1, "Vaibhav", "Kushwaha", 12.345);
+        assertAfterImage(updateRecord, 1, "VKVK", "Kushwaha", 56.78);
+
+        // DELETE: full before image, null after
+        SourceRecord deleteRecord = records.get(2);
+        assertBeforeImage(deleteRecord, 1, "VKVK", "Kushwaha", 56.78);
+        assertValueField(deleteRecord, "after", null);
+
+        assertTombstone(records.get(3));
+    }
+
+    /**
+     * REPLICA IDENTITY DEFAULT: before image is null for UPDATE and
+     *  contains only the primary key columns for DELETE.
+     */
+    @Test
+    public void testReplicaIdentityDefault() throws Exception {
+        TestHelper.initDB("yugabyte_create_tables.ddl");
+
+        TestHelper.execute("ALTER TABLE t1 REPLICA IDENTITY DEFAULT;");
+        TestHelper.execute(String.format(TestHelper.createPublicationForTableStatement, PUB_NAME, "t1"));
+        TestHelper.execute(TestHelper.createReplicationSlotStatement);
+
+        startEngine(getPublicationConfig());
+        awaitUntilConnectorIsReady();
+
+        TestHelper.execute(String.format(formatInsertString, 1));
+        TestHelper.execute("UPDATE t1 SET first_name='VKVK', hours=56.78 WHERE id = 1;");
+        TestHelper.execute("DELETE FROM t1 WHERE id = 1;");
+
+        List<SourceRecord> records = new ArrayList<>();
+        CompletableFuture.runAsync(() -> getRecords(records, 4, 20000)).get();
+
+        // INSERT: no before image
+        SourceRecord insertRecord = records.get(0);
+        assertValueField(insertRecord, "before", null);
+        assertAfterImage(insertRecord, 1, "Vaibhav", "Kushwaha", 12.345);
+
+        // UPDATE: before image is null
+        SourceRecord updateRecord = records.get(1);
+        assertValueField(insertRecord, "before", null);
+        assertAfterImage(updateRecord, 1, "VKVK", "Kushwaha", 56.78);
+
+        // DELETE: before image has only the PK, null after
+        SourceRecord deleteRecord = records.get(2);
+        assertValueField(deleteRecord, "before/id/value", 1);
+        assertValueField(deleteRecord, "after", null);
+
+        assertTombstone(records.get(3));
+    }
+
+    /**
+     * REPLICA IDENTITY NOTHING: UPDATE and DELETE are disallowed by the database
+     * because the table has no replica identity and publishes updates/deletes.
+     */
+    @Test
+    public void testReplicaIdentityNothing() throws Exception {
+        TestHelper.initDB("yugabyte_create_tables.ddl");
+
+        TestHelper.execute("ALTER TABLE t1 REPLICA IDENTITY NOTHING;");
+        TestHelper.execute(String.format(TestHelper.createPublicationForTableStatement, PUB_NAME, "t1"));
+        TestHelper.execute(TestHelper.createReplicationSlotStatement);
+
+        startEngine(getPublicationConfig());
+        awaitUntilConnectorIsReady();
+
+        TestHelper.execute(String.format(formatInsertString, 1));
+
+        RuntimeException updateEx = assertThrows(RuntimeException.class,
+            () -> TestHelper.execute("UPDATE t1 SET first_name='VKVK', hours=56.78 WHERE id = 1;"));
+        assertTrue(updateEx.getMessage().contains(
+            "cannot update table \"t1\" because it does not have a replica identity and publishes updates"));
+
+        RuntimeException deleteEx = assertThrows(RuntimeException.class,
+            () -> TestHelper.execute("DELETE FROM t1 WHERE id = 1;"));
+        assertTrue(deleteEx.getMessage().contains(
+            "cannot delete from table \"t1\" because it does not have a replica identity and publishes deletes"));
+
+        List<SourceRecord> records = new ArrayList<>();
+        CompletableFuture.runAsync(() -> getRecords(records, 1, 20000)).get();
+
+        // INSERT: no before image
+        SourceRecord insertRecord = records.get(0);
+        assertValueField(insertRecord, "before", null);
+        assertAfterImage(insertRecord, 1, "Vaibhav", "Kushwaha", 12.345);
+    }
+
+    /**
+     * REPLICA IDENTITY CHANGE:
+     * - INSERT: before=null, after=full new row
+     * - UPDATE: before=null, after=PK + changed columns
+     * - DELETE: before=PK only, after=null
+     */
+    @Test
+    public void testReplicaIdentityChange() throws Exception {
+        TestHelper.initDB("yugabyte_create_tables.ddl");
+
+        TestHelper.execute("ALTER TABLE t1 REPLICA IDENTITY CHANGE;");
+        TestHelper.execute(String.format(TestHelper.createPublicationForTableStatement, PUB_NAME, "t1"));
+        TestHelper.execute(TestHelper.createReplicationSlotStatement);
+
+        startEngine(getPublicationConfig());
+        awaitUntilConnectorIsReady();
+
+        TestHelper.execute(String.format(formatInsertString, 1));
+        TestHelper.execute("UPDATE t1 SET last_name='KK', hours=56.78 WHERE id = 1;");
+        TestHelper.execute("DELETE FROM t1 WHERE id = 1;");
+
+        List<SourceRecord> records = new ArrayList<>();
+        CompletableFuture.runAsync(() -> getRecords(records, 4, 20000)).get();
+
+        // INSERT: no before image, full new row in after
+        SourceRecord insertRecord = records.get(0);
+        assertValueField(insertRecord, "before", null);
+        assertAfterImage(insertRecord, 1, "Vaibhav", "Kushwaha", 12.345);
+
+        // UPDATE: no before image, after has PK + changed columns
+        SourceRecord updateRecord = records.get(1);
+        assertValueField(updateRecord, "before", null);
+        assertValueField(updateRecord, "after/id/value", 1);
+        assertValueField(updateRecord, "after/last_name/value", "KK");
+        assertValueField(updateRecord, "after/hours/value", 56.78);
+
+        // DELETE: before has PK only, null after
+        SourceRecord deleteRecord = records.get(2);
+        assertValueField(deleteRecord, "before/id/value", 1);
+        assertValueField(deleteRecord, "after", null);
+
+        assertTombstone(records.get(3));
+    }
+
+    // ---- Helpers ----
+
+    private Configuration.Builder getPublicationConfig() throws Exception {
+        return TestHelper.getConfigBuilderWithPublication("yugabyte", PUB_NAME, SLOT_NAME);
+    }
+
+    private void assertBeforeImage(SourceRecord record, Integer id, String firstName,
+                                   String lastName, Double hours) {
+        assertValueField(record, "before/id/value", id);
+        assertValueField(record, "before/first_name/value", firstName);
+        assertValueField(record, "before/last_name/value", lastName);
+        assertValueField(record, "before/hours/value", hours);
+    }
+
+    private void assertAfterImage(SourceRecord record, Integer id, String firstName,
+                                  String lastName, Double hours) {
+        assertValueField(record, "after/id/value", id);
+        assertValueField(record, "after/first_name/value", firstName);
+        assertValueField(record, "after/last_name/value", lastName);
+        assertValueField(record, "after/hours/value", hours);
+    }
+
     private void insertRecords(long numOfRowsToBeInserted) throws Exception {
         String formatInsertString = "INSERT INTO t1 VALUES (%d, 'Vaibhav', 'Kushwaha', 30);";
         CompletableFuture.runAsync(() -> {
@@ -264,8 +454,18 @@ public class YugabyteDBPublicationReplicationTest extends YugabyteDBContainerTes
         try (YugabyteDBConnection ybConnection = TestHelper.create();
              Connection connection = ybConnection.connection()) {
             final Statement statement = connection.createStatement();
-            final ResultSet rs = statement.executeQuery(TestHelper.dropReplicationSlotStatement);
-            return rs.next();
+
+            ResultSet check = statement.executeQuery(
+                "SELECT 1 FROM pg_replication_slots WHERE slot_name = 'test_replication_slot';");
+            if (!check.next()) {
+                return true;
+            }
+
+            statement.execute(TestHelper.dropReplicationSlotStatement);
+
+            ResultSet verify = statement.executeQuery(
+                "SELECT 1 FROM pg_replication_slots WHERE slot_name = 'test_replication_slot';");
+            return !verify.next();
         } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
@@ -275,6 +475,33 @@ public class YugabyteDBPublicationReplicationTest extends YugabyteDBContainerTes
 
     private void verifyRecordCount(long recordsCount) {
         waitAndFailIfCannotConsume(new ArrayList<>(), recordsCount);
+    }
+
+    private void getRecords(List<SourceRecord> records, long totalRecordsToConsume,
+                            long milliSecondsToWait) {
+        AtomicLong totalConsumedRecords = new AtomicLong();
+        long seconds = milliSecondsToWait / 1000;
+        try {
+            Awaitility.await()
+                .atMost(Duration.ofSeconds(seconds))
+                .until(() -> {
+                    int consumed = consumeAvailableRecords(record -> {
+                        LOGGER.debug("The record being consumed is " + record);
+                        records.add(record);
+                    });
+                    if (consumed > 0) {
+                        totalConsumedRecords.addAndGet(consumed);
+                        LOGGER.debug("Consumed " + totalConsumedRecords + " records");
+                    }
+
+                    return totalConsumedRecords.get() == totalRecordsToConsume;
+                });
+        } catch (ConditionTimeoutException exception) {
+            fail("Failed to consume " + totalRecordsToConsume + " records in " + seconds
+                 + " seconds", exception);
+        }
+
+        assertEquals(totalRecordsToConsume, totalConsumedRecords.get());
     }
 
 }

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBPublicationReplicationTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBPublicationReplicationTest.java
@@ -79,6 +79,7 @@ public class YugabyteDBPublicationReplicationTest extends YugabyteDBContainerTes
             });
         TestHelper.execute(TestHelper.dropPublicationStatement);
         TestHelper.executeDDL("drop_tables_and_databases.ddl");
+        TestHelper.execute("DROP TABLE IF EXISTS ri_full, ri_default, ri_nothing, ri_change;");
     }
 
     @AfterAll
@@ -402,6 +403,133 @@ public class YugabyteDBPublicationReplicationTest extends YugabyteDBContainerTes
         assertValueField(deleteRecord, "after", null);
 
         assertTombstone(records.get(3));
+    }
+
+    /**
+     * Combined test with 4 tables, each having a different REPLICA IDENTITY
+     * (FULL, DEFAULT, NOTHING, CHANGE), all part of the same publication
+     * and replication slot.
+     */
+    @Test
+    public void testMixedReplicaIdentitiesInSameStream() throws Exception {
+        String createTableFmt =
+            "CREATE TABLE IF NOT EXISTS %s (id INT PRIMARY KEY, first_name TEXT NOT NULL, last_name VARCHAR(40), hours DOUBLE PRECISION);";
+        TestHelper.execute(String.format(createTableFmt, "ri_full"));
+        TestHelper.execute(String.format(createTableFmt, "ri_default"));
+        TestHelper.execute(String.format(createTableFmt, "ri_nothing"));
+        TestHelper.execute(String.format(createTableFmt, "ri_change"));
+
+        TestHelper.execute("ALTER TABLE ri_full REPLICA IDENTITY FULL;");
+        TestHelper.execute("ALTER TABLE ri_default REPLICA IDENTITY DEFAULT;");
+        TestHelper.execute("ALTER TABLE ri_nothing REPLICA IDENTITY NOTHING;");
+        TestHelper.execute("ALTER TABLE ri_change REPLICA IDENTITY CHANGE;");
+
+        TestHelper.execute(String.format(
+            "CREATE PUBLICATION %s FOR TABLE ri_full, ri_default, ri_nothing, ri_change;", PUB_NAME));
+        TestHelper.execute(TestHelper.createReplicationSlotStatement);
+
+        startEngine(getPublicationConfig());
+        awaitUntilConnectorIsReady();
+
+        String insertFmt = "INSERT INTO %s VALUES (1, 'Vaibhav', 'Kushwaha', 12.345);";
+        String updateFmt = "UPDATE %s SET first_name='VKVK', hours=56.78 WHERE id = 1;";
+        String deleteFmt = "DELETE FROM %s WHERE id = 1;";
+
+        // ri_full: INSERT, UPDATE, DELETE
+        TestHelper.execute(String.format(insertFmt, "ri_full"));
+        TestHelper.execute(String.format(updateFmt, "ri_full"));
+        TestHelper.execute(String.format(deleteFmt, "ri_full"));
+
+        // ri_default: INSERT, UPDATE, DELETE
+        TestHelper.execute(String.format(insertFmt, "ri_default"));
+        TestHelper.execute(String.format(updateFmt, "ri_default"));
+        TestHelper.execute(String.format(deleteFmt, "ri_default"));
+
+        // ri_nothing: only INSERT is allowed
+        TestHelper.execute(String.format(insertFmt, "ri_nothing"));
+
+        RuntimeException updateEx = assertThrows(RuntimeException.class,
+            () -> TestHelper.execute(String.format(updateFmt, "ri_nothing")));
+        assertTrue(updateEx.getMessage().contains(
+            "cannot update table \"ri_nothing\" because it does not have a replica identity and publishes updates"));
+
+        RuntimeException deleteEx = assertThrows(RuntimeException.class,
+            () -> TestHelper.execute(String.format(deleteFmt, "ri_nothing")));
+        assertTrue(deleteEx.getMessage().contains(
+            "cannot delete from table \"ri_nothing\" because it does not have a replica identity and publishes deletes"));
+
+        // ri_change: INSERT, UPDATE, DELETE
+        TestHelper.execute(String.format(insertFmt, "ri_change"));
+        TestHelper.execute("UPDATE ri_change SET last_name='KK', hours=56.78 WHERE id = 1;");
+        TestHelper.execute(String.format(deleteFmt, "ri_change"));
+
+        // Expect: ri_full(4) + ri_default(4) + ri_nothing(1) + ri_change(4) = 13 records
+        List<SourceRecord> allRecords = new ArrayList<>();
+        CompletableFuture.runAsync(() -> getRecords(allRecords, 13, 30000)).get();
+
+        String topicPrefix = TestHelper.TEST_SERVER + ".public.";
+        Map<String, List<SourceRecord>> byTopic = new HashMap<>();
+        for (SourceRecord r : allRecords) {
+            byTopic.computeIfAbsent(r.topic(), k -> new ArrayList<>()).add(r);
+        }
+
+        // --- ri_full: FULL before image on UPDATE and DELETE ---
+        List<SourceRecord> fullRecords = byTopic.get(topicPrefix + "ri_full");
+        assertNotNull(fullRecords, "Expected records for ri_full");
+        assertEquals(4, fullRecords.size());
+
+        assertValueField(fullRecords.get(0), "before", null);
+        assertAfterImage(fullRecords.get(0), 1, "Vaibhav", "Kushwaha", 12.345);
+
+        assertBeforeImage(fullRecords.get(1), 1, "Vaibhav", "Kushwaha", 12.345);
+        assertAfterImage(fullRecords.get(1), 1, "VKVK", "Kushwaha", 56.78);
+
+        assertBeforeImage(fullRecords.get(2), 1, "VKVK", "Kushwaha", 56.78);
+        assertValueField(fullRecords.get(2), "after", null);
+
+        assertTombstone(fullRecords.get(3));
+
+        // --- ri_default: null before on UPDATE, PK-only before on DELETE ---
+        List<SourceRecord> defaultRecords = byTopic.get(topicPrefix + "ri_default");
+        assertNotNull(defaultRecords, "Expected records for ri_default");
+        assertEquals(4, defaultRecords.size());
+
+        assertValueField(defaultRecords.get(0), "before", null);
+        assertAfterImage(defaultRecords.get(0), 1, "Vaibhav", "Kushwaha", 12.345);
+
+        assertValueField(defaultRecords.get(1), "before", null);
+        assertAfterImage(defaultRecords.get(1), 1, "VKVK", "Kushwaha", 56.78);
+
+        assertValueField(defaultRecords.get(2), "before/id/value", 1);
+        assertValueField(defaultRecords.get(2), "after", null);
+
+        assertTombstone(defaultRecords.get(3));
+
+        // --- ri_nothing: only INSERT ---
+        List<SourceRecord> nothingRecords = byTopic.get(topicPrefix + "ri_nothing");
+        assertNotNull(nothingRecords, "Expected records for ri_nothing");
+        assertEquals(1, nothingRecords.size());
+
+        assertValueField(nothingRecords.get(0), "before", null);
+        assertAfterImage(nothingRecords.get(0), 1, "Vaibhav", "Kushwaha", 12.345);
+
+        // --- ri_change: null before on UPDATE (after has PK + changed cols), PK-only before on DELETE ---
+        List<SourceRecord> changeRecords = byTopic.get(topicPrefix + "ri_change");
+        assertNotNull(changeRecords, "Expected records for ri_change");
+        assertEquals(4, changeRecords.size());
+
+        assertValueField(changeRecords.get(0), "before", null);
+        assertAfterImage(changeRecords.get(0), 1, "Vaibhav", "Kushwaha", 12.345);
+
+        assertValueField(changeRecords.get(1), "before", null);
+        assertValueField(changeRecords.get(1), "after/id/value", 1);
+        assertValueField(changeRecords.get(1), "after/last_name/value", "KK");
+        assertValueField(changeRecords.get(1), "after/hours/value", 56.78);
+
+        assertValueField(changeRecords.get(2), "before/id/value", 1);
+        assertValueField(changeRecords.get(2), "after", null);
+
+        assertTombstone(changeRecords.get(3));
     }
 
     // ---- Helpers ----


### PR DESCRIPTION
Jira Link: [DB-20273](https://yugabyte.atlassian.net/browse/DB-20273)
## Description

While validating gRPC connector support for Logical Replication (using a replication slot + publication instead of a stream created via yb-admin), the connector crashes during initialization with a NullPointerException in YBClientUtils.isBeforeImageEnabled().
```
Error while trying to get before image status
java.lang.NullPointerException
  at io.debezium.connector.yugabytedb.YBClientUtils.isBeforeImageEnabled(YBClientUtils.java:347)
  at io.debezium.connector.yugabytedb.YugabyteDBgRPCConnector.taskConfigs(YugabyteDBgRPCConnector.java:167)
```
## Solution

When using a replication slot + publication instead of a yb-admin stream, the CDC stream options may not contain a `record_type` key, causing `cdcStreamInfo.getOptions().get("record_type")` to return null and the subsequent .equals() call to throw an NPE. Added a null check in `YBClientUtils.isBeforeImageEnabled()` — if record_type is missing, log a warning and return true (before image enabled).

## Test Plan 
```
mvn test -Dtest=YugabyteDBPublicationReplicationTest
```