### PR TITLE
[yugabyte/yugabyte-db#31778] Add validation for mutually exclusive Stream ID and Slot Name

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -626,7 +626,6 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTION, 9))
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.HIGH)
-            .withValidation(YugabyteDBConnectorConfig::validateStreamIdAndSlotNameMutuallyExclusive)
             .withDescription("ID of the Stream created in YugabyteDB");
 
     protected static final Field TASK_ID = Field.create("yugabytedb.task.id")
@@ -1589,17 +1588,6 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
             "Cannot set both %s and a non-default %s. "
                     + "Use slot.name (and publication.name) without a stream ID, "
                     + "or use a stream ID and leave slot.name at its default (%s).";
-
-    private static int validateStreamIdAndSlotNameMutuallyExclusive(Configuration config, Field field, Field.ValidationOutput problems) {
-        if (hasStreamIdAndSlotNameConflict(config)) {
-            problems.accept(field, config.getString(field),
-                    String.format(STREAM_ID_SLOT_CONFLICT_MSG,
-                            STREAM_ID.name(), SLOT_NAME.name(),
-                            ReplicationConnection.Builder.DEFAULT_SLOT_NAME));
-            return 1;
-        }
-        return 0;
-    }
 
     public static void assertStreamIdAndSlotNameMutuallyExclusive(Configuration config) {
         if (hasStreamIdAndSlotNameConflict(config)) {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -626,6 +626,7 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTION, 9))
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.HIGH)
+            .withValidation(YugabyteDBConnectorConfig::validateStreamIdAndSlotNameMutuallyExclusive)
             .withDescription("ID of the Stream created in YugabyteDB");
 
     protected static final Field TASK_ID = Field.create("yugabytedb.task.id")
@@ -1571,6 +1572,42 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
 
     public static ConfigDef configDef() {
         return CONFIG_DEFINITION.configDef();
+    }
+
+    /**
+     * Returns {@code true} when both {@code database.streamid} and a non-default {@code slot.name}
+     * are configured. The two options represent mutually exclusive CDC paths.
+     */
+    public static boolean hasStreamIdAndSlotNameConflict(Configuration config) {
+        String streamId = config.getString(STREAM_ID);
+        String slotName = config.getString(SLOT_NAME);
+        return streamId != null && !streamId.isBlank()
+                && slotName != null && !slotName.equals(ReplicationConnection.Builder.DEFAULT_SLOT_NAME);
+    }
+
+    private static final String STREAM_ID_SLOT_CONFLICT_MSG =
+            "Cannot set both %s and a non-default %s. "
+                    + "Use slot.name (and publication.name) without a stream ID, "
+                    + "or use a stream ID and leave slot.name at its default (%s).";
+
+    private static int validateStreamIdAndSlotNameMutuallyExclusive(Configuration config, Field field, Field.ValidationOutput problems) {
+        if (hasStreamIdAndSlotNameConflict(config)) {
+            problems.accept(field, config.getString(field),
+                    String.format(STREAM_ID_SLOT_CONFLICT_MSG,
+                            STREAM_ID.name(), SLOT_NAME.name(),
+                            ReplicationConnection.Builder.DEFAULT_SLOT_NAME));
+            return 1;
+        }
+        return 0;
+    }
+
+    public static void assertStreamIdAndSlotNameMutuallyExclusive(Configuration config) {
+        if (hasStreamIdAndSlotNameConflict(config)) {
+            throw new DebeziumException(
+                    String.format(STREAM_ID_SLOT_CONFLICT_MSG,
+                            STREAM_ID.name(), SLOT_NAME.name(),
+                            ReplicationConnection.Builder.DEFAULT_SLOT_NAME));
+        }
     }
 
     // Source of the validation rules - https://doxygen.postgresql.org/slot_8c.html#afac399f07320b9adfd2c599cf822aaa3

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -1577,7 +1577,7 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
      * Returns {@code true} when both {@code database.streamid} and a non-default {@code slot.name}
      * are configured. The two options represent mutually exclusive CDC paths.
      */
-    public static boolean hasStreamIdAndSlotNameConflict(Configuration config) {
+    private static boolean hasStreamIdAndSlotNameConflict(Configuration config) {
         String streamId = config.getString(STREAM_ID);
         String slotName = config.getString(SLOT_NAME);
         return streamId != null && !streamId.isEmpty()
@@ -1589,7 +1589,7 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
             + "Use slot.name (and publication.name) without a stream ID, "
             + "or use a stream ID and leave slot.name at its default (%s).";
 
-    public static String buildStreamIdAndSlotNameConflictMessage(Configuration config, String additionalMessage) {
+    private static String buildStreamIdAndSlotNameConflictMessage(Configuration config, String additionalMessage) {
         String streamId = config.getString(STREAM_ID);
         String slotName = config.getString(SLOT_NAME);
         String msg = String.format(STREAM_ID_SLOT_CONFLICT_MSG,

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -1580,21 +1580,34 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
     public static boolean hasStreamIdAndSlotNameConflict(Configuration config) {
         String streamId = config.getString(STREAM_ID);
         String slotName = config.getString(SLOT_NAME);
-        return streamId != null && !streamId.isBlank()
+        return streamId != null && !streamId.isEmpty()
                 && slotName != null && !slotName.equals(ReplicationConnection.Builder.DEFAULT_SLOT_NAME);
     }
 
     private static final String STREAM_ID_SLOT_CONFLICT_MSG =
-            "Cannot set both %s and a non-default %s. "
-                    + "Use slot.name (and publication.name) without a stream ID, "
-                    + "or use a stream ID and leave slot.name at its default (%s).";
+            "Cannot set both stream id: %s and a non-default slot name: %s. "
+            + "Use slot.name (and publication.name) without a stream ID, "
+            + "or use a stream ID and leave slot.name at its default (%s).";
+
+    public static String buildStreamIdAndSlotNameConflictMessage(Configuration config, String additionalMessage) {
+        String streamId = config.getString(STREAM_ID);
+        String slotName = config.getString(SLOT_NAME);
+        String msg = String.format(STREAM_ID_SLOT_CONFLICT_MSG,
+                streamId, slotName,
+                ReplicationConnection.Builder.DEFAULT_SLOT_NAME);
+        if (additionalMessage != null && !additionalMessage.isEmpty()) {
+            msg = msg + " " + additionalMessage;
+        }
+        return msg;
+    }
 
     public static void assertStreamIdAndSlotNameMutuallyExclusive(Configuration config) {
+        assertStreamIdAndSlotNameMutuallyExclusive(config, null);
+    }
+
+    public static void assertStreamIdAndSlotNameMutuallyExclusive(Configuration config, String additionalMessage) {
         if (hasStreamIdAndSlotNameConflict(config)) {
-            throw new DebeziumException(
-                    String.format(STREAM_ID_SLOT_CONFLICT_MSG,
-                            STREAM_ID.name(), SLOT_NAME.name(),
-                            ReplicationConnection.Builder.DEFAULT_SLOT_NAME));
+            throw new DebeziumException(buildStreamIdAndSlotNameConflictMessage(config, additionalMessage));
         }
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBgRPCConnector.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBgRPCConnector.java
@@ -265,6 +265,16 @@ public class YugabyteDBgRPCConnector extends RelationalBaseSourceConnector {
         }
 
         if (YugabyteDBConnectorConfig.hasStreamIdAndSlotNameConflict(config)) {
+            String msg = String.format(
+                    "Cannot set both %s and a non-default %s. "
+                            + "Use slot.name (and publication.name) without a stream ID, "
+                            + "or use a stream ID and leave slot.name at its default.",
+                    YugabyteDBConnectorConfig.STREAM_ID.name(),
+                    YugabyteDBConnectorConfig.SLOT_NAME.name());
+            ConfigValue streamIdConfig = configValues.get(YugabyteDBConnectorConfig.STREAM_ID.name());
+            if (streamIdConfig != null) {
+                streamIdConfig.addErrorMessage(msg);
+            }
             return;
         }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBgRPCConnector.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBgRPCConnector.java
@@ -267,8 +267,9 @@ public class YugabyteDBgRPCConnector extends RelationalBaseSourceConnector {
         if (YugabyteDBConnectorConfig.hasStreamIdAndSlotNameConflict(config)) {
             String msg = String.format(
                     "Cannot set both %s and a non-default %s. "
-                            + "Use slot.name (and publication.name) without a stream ID, "
-                            + "or use a stream ID and leave slot.name at its default.",
+                        + "Use slot.name (and publication.name) without a stream ID, "
+                        + "or use a stream ID and leave slot.name at its default. "
+                        + "Note: Publication is not supported with stream ID.",
                     YugabyteDBConnectorConfig.STREAM_ID.name(),
                     YugabyteDBConnectorConfig.SLOT_NAME.name());
             ConfigValue streamIdConfig = configValues.get(YugabyteDBConnectorConfig.STREAM_ID.name());

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBgRPCConnector.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBgRPCConnector.java
@@ -264,17 +264,13 @@ public class YugabyteDBgRPCConnector extends RelationalBaseSourceConnector {
             return;
         }
 
-        if (YugabyteDBConnectorConfig.hasStreamIdAndSlotNameConflict(config)) {
-            String msg = String.format(
-                    "Cannot set both %s and a non-default %s. "
-                        + "Use slot.name (and publication.name) without a stream ID, "
-                        + "or use a stream ID and leave slot.name at its default. "
-                        + "Note: Publication is not supported with stream ID.",
-                    YugabyteDBConnectorConfig.STREAM_ID.name(),
-                    YugabyteDBConnectorConfig.SLOT_NAME.name());
+        try {
+            YugabyteDBConnectorConfig.assertStreamIdAndSlotNameMutuallyExclusive(
+                    config, "Note: Publication is not supported with stream ID.");
+        } catch (DebeziumException e) {
             ConfigValue streamIdConfig = configValues.get(YugabyteDBConnectorConfig.STREAM_ID.name());
             if (streamIdConfig != null) {
-                streamIdConfig.addErrorMessage(msg);
+                streamIdConfig.addErrorMessage(e.getMessage());
             }
             return;
         }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBgRPCConnector.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBgRPCConnector.java
@@ -73,6 +73,8 @@ public class YugabyteDBgRPCConnector extends RelationalBaseSourceConnector {
         LOGGER.debug("Props " + props);
         Configuration config = Configuration.from(this.props);
 
+        YugabyteDBConnectorConfig.assertStreamIdAndSlotNameMutuallyExclusive(config);
+
         String streamId = config.getString(YugabyteDBConnectorConfig.STREAM_ID);
         String tableIncludeList = config.getString(YugabyteDBConnectorConfig.TABLE_INCLUDE_LIST);
         
@@ -259,6 +261,10 @@ public class YugabyteDBgRPCConnector extends RelationalBaseSourceConnector {
     protected void validateConnection(Map<String, ConfigValue> configValues, Configuration config) {
         final ConfigValue databaseValue = configValues.get(RelationalDatabaseConnectorConfig.DATABASE_NAME.name());
         if (!databaseValue.errorMessages().isEmpty()) {
+            return;
+        }
+
+        if (YugabyteDBConnectorConfig.hasStreamIdAndSlotNameConflict(config)) {
             return;
         }
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConfigTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConfigTest.java
@@ -11,6 +11,7 @@ import io.debezium.DebeziumException;
 import io.debezium.config.Configuration;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
 import io.debezium.connector.yugabytedb.common.YugabytedTestBase;
+import io.debezium.connector.yugabytedb.connection.ReplicationConnection;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -65,6 +66,35 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
             }
         }
         assertEquals(recordsCount, totalConsumedRecords);
+    }
+
+    @Test
+    public void shouldRejectStreamIdWithNonDefaultSlotName() {
+        Configuration config = TestHelper.defaultConfig()
+                .with(YugabyteDBConnectorConfig.STREAM_ID, "any-stream-id")
+                .with(YugabyteDBConnectorConfig.SLOT_NAME, "custom_slot")
+                .build();
+        DebeziumException ex = assertThrows(DebeziumException.class,
+                () -> YugabyteDBConnectorConfig.assertStreamIdAndSlotNameMutuallyExclusive(config));
+        assertTrue(ex.getMessage().contains("Cannot set both"));
+    }
+
+    @Test
+    public void shouldAllowStreamIdWithDefaultSlotName() {
+        Configuration config = TestHelper.defaultConfig()
+                .with(YugabyteDBConnectorConfig.STREAM_ID, "any-stream-id")
+                .with(YugabyteDBConnectorConfig.SLOT_NAME, ReplicationConnection.Builder.DEFAULT_SLOT_NAME)
+                .build();
+        assertDoesNotThrow(() -> YugabyteDBConnectorConfig.assertStreamIdAndSlotNameMutuallyExclusive(config));
+    }
+
+    @Test
+    public void shouldAllowCustomSlotNameWithoutStreamId() {
+        Configuration config = TestHelper.defaultConfig()
+                .with(YugabyteDBConnectorConfig.STREAM_ID, "")
+                .with(YugabyteDBConnectorConfig.SLOT_NAME, "custom_slot")
+                .build();
+        assertDoesNotThrow(() -> YugabyteDBConnectorConfig.assertStreamIdAndSlotNameMutuallyExclusive(config));
     }
 
     // This verifies that the connector should not be running if a wrong table.include.list is provided


### PR DESCRIPTION
Jira Link: [DB-20880](https://yugabyte.atlassian.net/browse/DB-20880)
## Description

The YugabyteDB connector supports two mutually exclusive CDC paths: a gRPC stream created via `yb-admin` (configured via `database.streamid`) and a logical replication slot + publication (configured via `slot.name`). When a user accidentally sets both `database.streamid` and a non-default `slot.name`, the connector previously did not detect the conflict at submit time, leading to ambiguous runtime behavior.

## Solution

Added connector-level validation that rejects configurations where both `database.streamid` and a non-default `slot.name` are set.

- Added `hasStreamIdAndSlotNameConflict` and `buildStreamIdAndSlotNameConflictMessage` helpers (private static) plus `assertStreamIdAndSlotNameMutuallyExclusive` (with an overload that accepts an additional message) in `YugabyteDBConnectorConfig`.
- Wired validation into `YugabyteDBgRPCConnector#validateConnection` so the error is surfaced on the `database.streamid` field at config-submit time, and into the connector start path so it runs once at the connector level rather than per task.
- Error message names both values, e.g. `Cannot set both stream id: <streamId> and a non-default slot name: <slotName>. Use slot.name (and publication.name) without a stream ID, or use a stream ID and leave slot.name at its default (<default>).`

## Test Plan
```
mvn test -Dtest=YugabyteDBConnectorConfigTest
mvn test -Dtest=YugabyteDBgRPCConnectorTest
```