### PR TITLE
Add optimizations to connector bootstrap steps

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YBClientUtils.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YBClientUtils.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -41,6 +42,12 @@ import org.yb.master.MasterTypes.NamespaceIdentifierPB;
 public class YBClientUtils {
   private final static Logger LOGGER = LoggerFactory.getLogger(YBClientUtils.class);
 
+  /**
+   * Cache for isYSQLStream results keyed by stream ID. Since a stream's query language
+   * never changes, this is safe to cache indefinitely.
+   */
+  private static final ConcurrentHashMap<String, Boolean> isYSQLCache = new ConcurrentHashMap<>();
+
   public static boolean isTableIncludedInStreamId(GetDBStreamInfoResponse resp, String tableId) {
     for (MasterReplicationOuterClass.GetCDCDBStreamInfoResponsePB.TableInfo tableInfo : resp.getTableInfoList()) {
         if (Objects.equals(tableId, tableInfo.getTableId().toStringUtf8())) {
@@ -53,15 +60,35 @@ public class YBClientUtils {
   }
 
   /**
-   * Get the list of all the table UUIDs to be included for streaming
+   * Get the list of all the table UUIDs to be included for streaming.
+   * This overload fetches the DB stream info internally (one RPC per table — slow for large streams).
+   * Prefer the overload that accepts a pre-fetched {@link GetDBStreamInfoResponse}.
    * @param ybClient the {@link YBClient} instance
    * @param connectorConfig connector configuration for the connector
    * @return a Set of the tableIDs
    */
   public static Set<String> fetchTableList(YBClient ybClient,
                                            YugabyteDBConnectorConfig connectorConfig) {
+    try {
+      GetDBStreamInfoResponse streamInfoResponse = ybClient.getDBStreamInfo(connectorConfig.streamId());
+      return fetchTableList(ybClient, connectorConfig, streamInfoResponse);
+    } catch (Exception e) {
+      throw new DebeziumException(e);
+    }
+  }
+
+  /**
+   * Get the list of all the table UUIDs to be included for streaming, using a pre-fetched
+   * {@link GetDBStreamInfoResponse} to avoid redundant per-table RPCs.
+   * @param ybClient the {@link YBClient} instance
+   * @param connectorConfig connector configuration for the connector
+   * @param streamInfoResponse pre-fetched DB stream info response (used for stream membership checks)
+   * @return a Set of the tableIDs
+   */
+  public static Set<String> fetchTableList(YBClient ybClient,
+                                           YugabyteDBConnectorConfig connectorConfig,
+                                           GetDBStreamInfoResponse streamInfoResponse) {
     LOGGER.info("Fetching all the tables from the source");
-    String dbName = connectorConfig.getJdbcConfig().getDatabase();
     
     Set<String> tableIds = new HashSet<>();
       try {
@@ -88,23 +115,13 @@ public class YBClientUtils {
                               tableInfo.getName()));
                       continue;
                   }
-                  
-                  // Filter out the tables that are not in the database specified in the connector 
-                  // configuration
-                  // TODO(#29369): Filter out tables that don't belong to the database specified
-                  // in the connector config. This filtering should be done in YBClient itself.
-                  if (dbName != null
-                          && !dbName.equalsIgnoreCase(tableInfo.getNamespace().getName())) {
-                      continue;
-                  }
+
                   fqlTableName = tableInfo.getNamespace().getName() + "."
                                   + tableInfo.getPgschemaName() + "."
                                   + tableInfo.getName();
+                  tableId = YugabyteDBSchema.parseWithSchema(fqlTableName,
+                              tableInfo.getPgschemaName());
 
-                  tableId = YugabyteDBSchema.createTableIdWithCatalog(
-                    tableInfo.getNamespace().getName(),
-                    tableInfo.getPgschemaName(),
-                    tableInfo.getName());
               }
               else {
                   // Since there is no concept of schema in CQL we will be using namespaceName.tableName 
@@ -112,14 +129,11 @@ public class YBClientUtils {
                                   + tableInfo.getName();
                   tableId = YugabyteDBSchema.parseWithKeyspace(fqlTableName, tableInfo.getNamespace().getName());
               }
-              // Retrieve the list of tables in the stream ID,
-              GetDBStreamInfoResponse dbStreamInfoResponse = ybClient.getDBStreamInfo(
-                                                               connectorConfig.streamId());
 
               if (connectorConfig.getTableFilters().dataCollectionFilter().isIncluded(tableId)
                       && connectorConfig.databaseFilter().isIncluded(tableId)) {
                   // Throw an exception if the table in the include list is not a part of stream ID
-                  if (!isTableIncludedInStreamId(dbStreamInfoResponse, 
+                  if (!isTableIncludedInStreamId(streamInfoResponse, 
                                                  tableInfo.getId().toStringUtf8())) {
                       String warningMessageFormat = "The table %s is not a part of the "
                                                             + "stream ID %s. Ignoring the table.";
@@ -327,16 +341,23 @@ public class YBClientUtils {
 
   /**
    * Check whether the passed stream ID in the connector configuration has before image enabled.
-   * Make sure this function is not called often since this involves multiple RPC calls which
-   * will end up slowing down the connector operations.
+   * This overload fetches stream info internally (multiple RPCs). Prefer the overload that
+   * accepts a pre-fetched {@link CDCStreamInfo}.
    * @param connectorConfig the configuration properties for the connector
    * @return true if before image is enabled, false otherwise
    * @throws Exception if API cannot get the DB stream Info or if it cannot list the CDC streams.
    */
   public static boolean isBeforeImageEnabled(YugabyteDBConnectorConfig connectorConfig)
       throws Exception {
-    CDCStreamInfo cdcStreamInfo = getStreamInfo(connectorConfig);
+    return isBeforeImageEnabled(getStreamInfo(connectorConfig));
+  }
 
+  /**
+   * Check whether the given CDC stream has before image enabled.
+   * @param cdcStreamInfo the pre-fetched stream info
+   * @return true if before image is enabled, false otherwise
+   */
+  public static boolean isBeforeImageEnabled(CDCStreamInfo cdcStreamInfo) {
     // If streamInfo is null, it would mean that either there are no tables configured with the
     // given stream ID.
     if (cdcStreamInfo == null) {
@@ -344,30 +365,31 @@ public class YBClientUtils {
       return false;
     }
 
-    String recordType = cdcStreamInfo.getOptions().get("record_type");
-    if (recordType == null) {
-      // If the record_type option is not found, it means that the stream is configured with a slot + publication path.
-      // In this case, we return true to indicate that before image is enabled.
-      LOGGER.info("record_type option not found in stream options, the stream is likely configured"
-          + " via slot + publication path; returning before_image as enabled (true)");
-      return true;
-    }
-
-    return recordType.equals(CDCRecordType.ALL.name())
-           || recordType.equals(CDCRecordType.MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES.name())
-           || recordType.equals(CDCRecordType.PG_FULL.name())
-           || recordType.equals(CDCRecordType.PG_CHANGE_OLD_NEW.name());
+    return (cdcStreamInfo.getOptions().get("record_type").equals(CDCRecordType.ALL.name())
+           || cdcStreamInfo.getOptions().get("record_type").equals(CDCRecordType.MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES.name()))
+           || (cdcStreamInfo.getOptions().get("record_type").equals(CDCRecordType.PG_FULL.name())
+           || cdcStreamInfo.getOptions().get("record_type").equals(CDCRecordType.PG_CHANGE_OLD_NEW.name()));
   }
 
   /**
    * Check whether the stream has EXPLICIT checkpointing enabled.
+   * This overload fetches stream info internally (multiple RPCs). Prefer the overload that
+   * accepts a pre-fetched {@link CDCStreamInfo}.
    * @param connectorConfig the connector configuration
    * @return true if stream has EXPLICIT checkpointing enabled, false otherwise
    * @throws Exception
    */
   public static boolean isExplicitCheckpointingEnabled(YugabyteDBConnectorConfig connectorConfig)
           throws Exception {
-      CDCStreamInfo cdcStreamInfo = getStreamInfo(connectorConfig);
+      return isExplicitCheckpointingEnabled(getStreamInfo(connectorConfig));
+  }
+
+  /**
+   * Check whether the given CDC stream has EXPLICIT checkpointing enabled.
+   * @param cdcStreamInfo the pre-fetched stream info
+   * @return true if stream has EXPLICIT checkpointing enabled, false otherwise
+   */
+  public static boolean isExplicitCheckpointingEnabled(CDCStreamInfo cdcStreamInfo) {
       Objects.requireNonNull(cdcStreamInfo);
 
       return cdcStreamInfo.getOptions().get("checkpoint_type")
@@ -375,9 +397,16 @@ public class YBClientUtils {
   }
 
   public static Boolean isYSQLStream(Configuration configuration) {
+    final String streamId = configuration.getString(YugabyteDBConnectorConfig.STREAM_ID);
+
+    // Return cached result if available — a stream's query language never changes.
+    Boolean cached = isYSQLCache.get(streamId);
+    if (cached != null) {
+      return cached;
+    }
+
     GetDBStreamInfoResponse cdcStreamInfo = null;
     ListNamespacesResponse resp = null;
-    final String streamId = configuration.getString(YugabyteDBConnectorConfig.STREAM_ID);
 
     try (YBClient ybClient = getYbClient(configuration)) {
       cdcStreamInfo = ybClient.getDBStreamInfo(streamId);
@@ -400,17 +429,22 @@ public class YBClientUtils {
 
     Objects.requireNonNull(dbType);
 
+    boolean result;
     if (dbType.equals(YQLDatabase.YQL_DATABASE_PGSQL)) {
       LOGGER.info("Query Language used for tables is ysql");
-      return true;
+      result = true;
     } else {
       LOGGER.info("Query Language used for tables is ycql");
-      return false;
+      result = false;
     }
+
+    isYSQLCache.put(streamId, result);
+    return result;
   }
 
   /**
-   * Call getTabletListToPollForCDC rpc with retries
+   * Call getTabletListToPollForCDC rpc with retries, creating a new {@link YBClient} per attempt.
+   * Prefer the overload that accepts an existing {@link YBClient} to avoid repeated TLS handshakes.
    * @param table the {@link YBTable} instance of the table
    * @param tableId the UUID of the table for which we need the tablets to poll for
    * @param connectorConfig the configs used by the connector
@@ -458,6 +492,60 @@ public class YBClientUtils {
      }
      
      return resp;
+  }
+
+  /**
+   * Call getTabletListToPollForCDC rpc with retries, reusing an existing {@link YBClient}
+   * to avoid repeated TLS handshakes and connection overhead.
+   * @param ybClient existing client to reuse (caller manages lifecycle)
+   * @param table the {@link YBTable} instance of the table
+   * @param tableId the UUID of the table for which we need the tablets to poll for
+   * @param connectorConfig the configs used by the connector
+   * @return an RPC response containing the list of tablets to poll for
+   * @throws Exception when there are error after trying {@link YugabyteDBConnectorConfig#maxConnectorRetries()} times
+   */
+  public static GetTabletListToPollForCDCResponse getTabletListToPollForCDCWithRetry(
+      YBClient ybClient, YBTable table, String tableId,
+      YugabyteDBConnectorConfig connectorConfig) throws Exception {
+    int retryCount = 0;
+    Exception exception = null;
+    GetTabletListToPollForCDCResponse resp = null;
+
+    while (retryCount <= connectorConfig.maxConnectorRetries()) {
+      try {
+        resp = ybClient.getTabletListToPollForCdc(table, connectorConfig.streamId(), tableId);
+
+        if (resp.getTabletCheckpointPairListSize() == 0) {
+          throw new RuntimeException("Received an empty tablet list for table " + tableId);
+        }
+
+        return resp;
+      } catch (Exception e) {
+        retryCount++;
+        exception = e;
+        if (retryCount > connectorConfig.maxConnectorRetries()) {
+          LOGGER.error("Too many errors while trying to get the tablet list to poll, all the {} retries failed ", connectorConfig.maxConnectorRetries());
+          throw e;
+        }
+
+        LOGGER.warn("Error while trying to get the tablet list to poll for CDC; will attempt retry {} of {} after {} milli-seconds. Exception: {}",
+                             retryCount, connectorConfig.maxConnectorRetries(), connectorConfig.connectorRetryDelayMs(), e);
+
+        try {
+          final Metronome retryMetronome = Metronome.parker(Duration.ofMillis(connectorConfig.connectorRetryDelayMs()), Clock.SYSTEM);
+          retryMetronome.pause();
+        } catch (InterruptedException ie) {
+          LOGGER.warn("Connector retry sleep interrupted by exception: {}", ie);
+          Thread.currentThread().interrupt();
+        }
+      }
+    }
+
+    if (exception != null) {
+      throw exception;
+    }
+
+    return resp;
   }
 
   /**

--- a/src/main/java/io/debezium/connector/yugabytedb/YBClientUtils.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YBClientUtils.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -41,6 +42,12 @@ import org.yb.master.MasterTypes.NamespaceIdentifierPB;
 public class YBClientUtils {
   private final static Logger LOGGER = LoggerFactory.getLogger(YBClientUtils.class);
 
+  /**
+   * Cache for {@link #isYSQLStream(Configuration)} results, keyed by stream ID. A stream's query
+   * language never changes, so this is safe to cache indefinitely for the connector's lifetime.
+   */
+  private static final ConcurrentHashMap<String, Boolean> isYSQLCache = new ConcurrentHashMap<>();
+
   public static boolean isTableIncludedInStreamId(GetDBStreamInfoResponse resp, String tableId) {
     for (MasterReplicationOuterClass.GetCDCDBStreamInfoResponsePB.TableInfo tableInfo : resp.getTableInfoList()) {
         if (Objects.equals(tableId, tableInfo.getTableId().toStringUtf8())) {
@@ -53,13 +60,43 @@ public class YBClientUtils {
   }
 
   /**
-   * Get the list of all the table UUIDs to be included for streaming
+   * Get the list of all the table UUIDs to be included for streaming.
+   * <p>
+   * This overload fetches the DB stream info once, up front, and then delegates to
+   * {@link #fetchTableList(YBClient, YugabyteDBConnectorConfig, GetDBStreamInfoResponse)}.
+   * Prefer that overload directly when the caller already holds a {@link GetDBStreamInfoResponse},
+   * to avoid the extra RPC.
    * @param ybClient the {@link YBClient} instance
    * @param connectorConfig connector configuration for the connector
    * @return a Set of the tableIDs
    */
   public static Set<String> fetchTableList(YBClient ybClient,
                                            YugabyteDBConnectorConfig connectorConfig) {
+    try {
+      GetDBStreamInfoResponse streamInfoResponse =
+              ybClient.getDBStreamInfo(connectorConfig.streamId());
+      return fetchTableList(ybClient, connectorConfig, streamInfoResponse);
+    }
+    catch (Exception e) {
+      // We are ultimately throwing this exception since this will be thrown while initializing
+      // the connector and at this point if this exception is thrown, we should not proceed
+      // forward with the connector.
+      throw new DebeziumException(e);
+    }
+  }
+
+  /**
+   * Get the list of all the table UUIDs to be included for streaming, using a pre-fetched
+   * {@link GetDBStreamInfoResponse} for the stream-membership checks. This avoids re-fetching
+   * the DB stream info once per table, which is a significant cost on streams with many tables.
+   * @param ybClient the {@link YBClient} instance
+   * @param connectorConfig connector configuration for the connector
+   * @param streamInfoResponse pre-fetched DB stream info response used for stream-membership checks
+   * @return a Set of the tableIDs
+   */
+  public static Set<String> fetchTableList(YBClient ybClient,
+                                           YugabyteDBConnectorConfig connectorConfig,
+                                           GetDBStreamInfoResponse streamInfoResponse) {
     LOGGER.info("Fetching all the tables from the source");
     String dbName = connectorConfig.getJdbcConfig().getDatabase();
     
@@ -112,14 +149,10 @@ public class YBClientUtils {
                                   + tableInfo.getName();
                   tableId = YugabyteDBSchema.parseWithKeyspace(fqlTableName, tableInfo.getNamespace().getName());
               }
-              // Retrieve the list of tables in the stream ID,
-              GetDBStreamInfoResponse dbStreamInfoResponse = ybClient.getDBStreamInfo(
-                                                               connectorConfig.streamId());
-
               if (connectorConfig.getTableFilters().dataCollectionFilter().isIncluded(tableId)
                       && connectorConfig.databaseFilter().isIncluded(tableId)) {
                   // Throw an exception if the table in the include list is not a part of stream ID
-                  if (!isTableIncludedInStreamId(dbStreamInfoResponse, 
+                  if (!isTableIncludedInStreamId(streamInfoResponse, 
                                                  tableInfo.getId().toStringUtf8())) {
                       String warningMessageFormat = "The table %s is not a part of the "
                                                             + "stream ID %s. Ignoring the table.";
@@ -327,16 +360,24 @@ public class YBClientUtils {
 
   /**
    * Check whether the passed stream ID in the connector configuration has before image enabled.
-   * Make sure this function is not called often since this involves multiple RPC calls which
-   * will end up slowing down the connector operations.
+   * This overload fetches the stream info internally (an RPC). Prefer
+   * {@link #isBeforeImageEnabled(CDCStreamInfo)} when the caller already holds a
+   * {@link CDCStreamInfo}, so the stream info is fetched only once.
    * @param connectorConfig the configuration properties for the connector
    * @return true if before image is enabled, false otherwise
    * @throws Exception if API cannot get the DB stream Info or if it cannot list the CDC streams.
    */
   public static boolean isBeforeImageEnabled(YugabyteDBConnectorConfig connectorConfig)
       throws Exception {
-    CDCStreamInfo cdcStreamInfo = getStreamInfo(connectorConfig);
+    return isBeforeImageEnabled(getStreamInfo(connectorConfig));
+  }
 
+  /**
+   * Check whether the given CDC stream has before image enabled.
+   * @param cdcStreamInfo the pre-fetched stream info (may be null)
+   * @return true if before image is enabled, false otherwise
+   */
+  public static boolean isBeforeImageEnabled(CDCStreamInfo cdcStreamInfo) {
     // If streamInfo is null, it would mean that either there are no tables configured with the
     // given stream ID.
     if (cdcStreamInfo == null) {
@@ -361,13 +402,24 @@ public class YBClientUtils {
 
   /**
    * Check whether the stream has EXPLICIT checkpointing enabled.
+   * This overload fetches the stream info internally (an RPC). Prefer
+   * {@link #isExplicitCheckpointingEnabled(CDCStreamInfo)} when the caller already holds a
+   * {@link CDCStreamInfo}, so the stream info is fetched only once.
    * @param connectorConfig the connector configuration
    * @return true if stream has EXPLICIT checkpointing enabled, false otherwise
    * @throws Exception
    */
   public static boolean isExplicitCheckpointingEnabled(YugabyteDBConnectorConfig connectorConfig)
           throws Exception {
-      CDCStreamInfo cdcStreamInfo = getStreamInfo(connectorConfig);
+      return isExplicitCheckpointingEnabled(getStreamInfo(connectorConfig));
+  }
+
+  /**
+   * Check whether the given CDC stream has EXPLICIT checkpointing enabled.
+   * @param cdcStreamInfo the pre-fetched stream info
+   * @return true if stream has EXPLICIT checkpointing enabled, false otherwise
+   */
+  public static boolean isExplicitCheckpointingEnabled(CDCStreamInfo cdcStreamInfo) {
       Objects.requireNonNull(cdcStreamInfo);
 
       return cdcStreamInfo.getOptions().get("checkpoint_type")
@@ -375,9 +427,24 @@ public class YBClientUtils {
   }
 
   public static Boolean isYSQLStream(Configuration configuration) {
+    final String streamId = configuration.getString(YugabyteDBConnectorConfig.STREAM_ID);
+
+    // A null or empty stream ID is a legitimate config shape (e.g. slot + publication path, see
+    // shouldUsePublication()). ConcurrentHashMap forbids null keys, so don't attempt to cache it;
+    // fall through to the RPC path, which preserves the original diagnostics
+    // ("Could not get Stream info for null ...") instead of surfacing a bare NPE from the map.
+    if (streamId == null || streamId.isEmpty()) {
+      return computeIsYSQLStream(configuration, streamId);
+    }
+
+    // A stream's query language never changes, so cache the result keyed by stream ID.
+    // computeIfAbsent ensures that concurrent task startups don't each issue the RPC.
+    return isYSQLCache.computeIfAbsent(streamId, id -> computeIsYSQLStream(configuration, id));
+  }
+
+  private static Boolean computeIsYSQLStream(Configuration configuration, String streamId) {
     GetDBStreamInfoResponse cdcStreamInfo = null;
     ListNamespacesResponse resp = null;
-    final String streamId = configuration.getString(YugabyteDBConnectorConfig.STREAM_ID);
 
     try (YBClient ybClient = getYbClient(configuration)) {
       cdcStreamInfo = ybClient.getDBStreamInfo(streamId);
@@ -410,7 +477,15 @@ public class YBClientUtils {
   }
 
   /**
-   * Call getTabletListToPollForCDC rpc with retries
+   * Call getTabletListToPollForCDC rpc with retries, creating a fresh {@link YBClient} for each
+   * attempt.
+   * <p>
+   * The per-attempt client is deliberate for the long-lived streaming and snapshot sources: a
+   * fresh client re-resolves the master leader and re-establishes the connection, so the retry
+   * loop can recover from a dead connection or a master leader change. Callers that are already
+   * holding a healthy, short-lived client (e.g. bootstrap validation) should prefer
+   * {@link #getTabletListToPollForCDCWithRetry(YBClient, YBTable, String, YugabyteDBConnectorConfig)}
+   * to avoid a TLS handshake per table.
    * @param table the {@link YBTable} instance of the table
    * @param tableId the UUID of the table for which we need the tablets to poll for
    * @param connectorConfig the configs used by the connector
@@ -458,6 +533,66 @@ public class YBClientUtils {
      }
      
      return resp;
+  }
+
+  /**
+   * Call getTabletListToPollForCDC rpc with retries, reusing an existing {@link YBClient}.
+   * <p>
+   * Unlike {@link #getTabletListToPollForCDCWithRetry(YBTable, String, YugabyteDBConnectorConfig)},
+   * this overload does not create a client per attempt; it reuses the caller-provided client
+   * (whose lifecycle the caller manages) to avoid a TLS handshake per table. This is intended for
+   * short-lived bootstrap validation, where the caller already holds a healthy client and the
+   * retries are best-effort. It does not re-resolve the master leader between attempts, so it is
+   * not a substitute for the fresh-client overload used by the streaming and snapshot sources.
+   * @param ybClient an existing client to reuse (caller manages its lifecycle)
+   * @param table the {@link YBTable} instance of the table
+   * @param tableId the UUID of the table for which we need the tablets to poll for
+   * @param connectorConfig the configs used by the connector
+   * @return an RPC response containing the list of tablets to poll for
+   * @throws Exception when there are error after trying {@link YugabyteDBConnectorConfig#maxConnectorRetries()} times
+   */
+  public static GetTabletListToPollForCDCResponse getTabletListToPollForCDCWithRetry(
+      YBClient ybClient, YBTable table, String tableId,
+      YugabyteDBConnectorConfig connectorConfig) throws Exception {
+    int retryCount = 0;
+    Exception exception = null;
+    GetTabletListToPollForCDCResponse resp = null;
+
+    while (retryCount <= connectorConfig.maxConnectorRetries()) {
+      try {
+        resp = ybClient.getTabletListToPollForCdc(table, connectorConfig.streamId(), tableId);
+
+        if (resp.getTabletCheckpointPairListSize() == 0) {
+          throw new RuntimeException("Received an empty tablet list for table " + tableId);
+        }
+
+        return resp;
+      } catch (Exception e) {
+        retryCount++;
+        exception = e;
+        if (retryCount > connectorConfig.maxConnectorRetries()) {
+          LOGGER.error("Too many errors while trying to get the tablet list to poll, all the {} retries failed ", connectorConfig.maxConnectorRetries());
+          throw e;
+        }
+
+        LOGGER.warn("Error while trying to get the tablet list to poll for CDC; will attempt retry {} of {} after {} milli-seconds. Exception: {}",
+                             retryCount, connectorConfig.maxConnectorRetries(), connectorConfig.connectorRetryDelayMs(), e);
+
+        try {
+          final Metronome retryMetronome = Metronome.parker(Duration.ofMillis(connectorConfig.connectorRetryDelayMs()), Clock.SYSTEM);
+          retryMetronome.pause();
+        } catch (InterruptedException ie) {
+          LOGGER.warn("Connector retry sleep interrupted by exception: {}", ie);
+          Thread.currentThread().interrupt();
+        }
+      }
+    }
+
+    if (exception != null) {
+      throw exception;
+    }
+
+    return resp;
   }
 
   /**

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBgRPCConnector.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBgRPCConnector.java
@@ -164,8 +164,10 @@ public class YugabyteDBgRPCConnector extends RelationalBaseSourceConnector {
         boolean sendBeforeImage = false;
         boolean enableExplicitCheckpointing = false;
         try {
-            sendBeforeImage = YBClientUtils.isBeforeImageEnabled(this.yugabyteDBConnectorConfig);
-            enableExplicitCheckpointing = YBClientUtils.isExplicitCheckpointingEnabled(this.yugabyteDBConnectorConfig);
+            // Fetch stream info once and reuse for both checks, avoiding redundant RPCs.
+            CDCStreamInfo streamInfo = YBClientUtils.getStreamInfo(this.yugabyteDBConnectorConfig);
+            sendBeforeImage = YBClientUtils.isBeforeImageEnabled(streamInfo);
+            enableExplicitCheckpointing = YBClientUtils.isExplicitCheckpointingEnabled(streamInfo);
             LOGGER.info("Before image status: {}", sendBeforeImage);
             LOGGER.info("Explicit checkpointing enabled: {}", enableExplicitCheckpointing);
         } catch (Exception e) {
@@ -366,7 +368,9 @@ public class YugabyteDBgRPCConnector extends RelationalBaseSourceConnector {
                 throw new DebeziumException(errorMessage);
             }
 
-            this.tableIds = YBClientUtils.fetchTableList(ybClient, this.yugabyteDBConnectorConfig);
+            // Pass the already-fetched stream info to avoid per-table getDBStreamInfo RPCs.
+            this.tableIds = YBClientUtils.fetchTableList(ybClient, this.yugabyteDBConnectorConfig,
+                    getStreamInfoResp);
 
             if (tableIds == null || tableIds.isEmpty()) {
                 throw new DebeziumException("The tables provided in table.include.list do not exist");
@@ -376,8 +380,9 @@ public class YugabyteDBgRPCConnector extends RelationalBaseSourceConnector {
             try {
                 for (String tableId : tableIds) {
                     YBTable table = ybClient.openTableByUUID(tableId);
-                    GetTabletListToPollForCDCResponse resp = YBClientUtils.getTabletListToPollForCDCWithRetry(table,
-                            tableId, yugabyteDBConnectorConfig);
+                    // Reuse existing YBClient to avoid per-table TLS handshakes.
+                    GetTabletListToPollForCDCResponse resp = YBClientUtils.getTabletListToPollForCDCWithRetry(
+                            ybClient, table, tableId, yugabyteDBConnectorConfig);
                     List<HashPartition> partitions = new ArrayList<>();
                     LOGGER.info("TabletCheckpointPair list size for table {}: {}", tableId, resp.getTabletCheckpointPairListSize());
                     for (TabletCheckpointPair pair : resp.getTabletCheckpointPairList()) {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBgRPCConnector.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBgRPCConnector.java
@@ -166,8 +166,10 @@ public class YugabyteDBgRPCConnector extends RelationalBaseSourceConnector {
         boolean sendBeforeImage = false;
         boolean enableExplicitCheckpointing = false;
         try {
-            sendBeforeImage = YBClientUtils.isBeforeImageEnabled(this.yugabyteDBConnectorConfig);
-            enableExplicitCheckpointing = YBClientUtils.isExplicitCheckpointingEnabled(this.yugabyteDBConnectorConfig);
+            // Fetch stream info once and reuse for both checks, avoiding redundant RPCs.
+            CDCStreamInfo streamInfo = YBClientUtils.getStreamInfo(this.yugabyteDBConnectorConfig);
+            sendBeforeImage = YBClientUtils.isBeforeImageEnabled(streamInfo);
+            enableExplicitCheckpointing = YBClientUtils.isExplicitCheckpointingEnabled(streamInfo);
             LOGGER.info("Before image status: {}", sendBeforeImage);
             LOGGER.info("Explicit checkpointing enabled: {}", enableExplicitCheckpointing);
         } catch (Exception e) {
@@ -379,7 +381,9 @@ public class YugabyteDBgRPCConnector extends RelationalBaseSourceConnector {
                 throw new DebeziumException(errorMessage);
             }
 
-            this.tableIds = YBClientUtils.fetchTableList(ybClient, this.yugabyteDBConnectorConfig);
+            // Pass the already-fetched stream info to avoid per-table getDBStreamInfo RPCs.
+            this.tableIds = YBClientUtils.fetchTableList(ybClient, this.yugabyteDBConnectorConfig,
+                    getStreamInfoResp);
 
             if (tableIds == null || tableIds.isEmpty()) {
                 throw new DebeziumException("The tables provided in table.include.list do not exist");
@@ -389,8 +393,9 @@ public class YugabyteDBgRPCConnector extends RelationalBaseSourceConnector {
             try {
                 for (String tableId : tableIds) {
                     YBTable table = ybClient.openTableByUUID(tableId);
-                    GetTabletListToPollForCDCResponse resp = YBClientUtils.getTabletListToPollForCDCWithRetry(table,
-                            tableId, yugabyteDBConnectorConfig);
+                    // Reuse existing YBClient to avoid per-table TLS handshakes.
+                    GetTabletListToPollForCDCResponse resp = YBClientUtils.getTabletListToPollForCDCWithRetry(
+                            ybClient, table, tableId, yugabyteDBConnectorConfig);
                     List<HashPartition> partitions = new ArrayList<>();
                     LOGGER.info("TabletCheckpointPair list size for table {}: {}", tableId, resp.getTabletCheckpointPairListSize());
                     for (TabletCheckpointPair pair : resp.getTabletCheckpointPairList()) {


### PR DESCRIPTION
## Problem
Connector validation in validateTServerConnection() makes a large number of redundant RPCs and creates unnecessary YBClient connections. On CDC streams with many tables, this causes validation to be significantly slower than necessary.

## Changes
 - `fetchTableList()` : New overload accepts a pre-fetched GetDBStreamInfoResponse for stream membership checks. The caller in validateTServerConnection() already has this response; previously it was re-fetched per table in the loop. Old signature preserved as a delegate.
 - `isBeforeImageEnabled() / isExplicitCheckpointingEnabled()`:  New overloads accept a pre-fetched CDCStreamInfo. taskConfigs() now calls getStreamInfo() once and reuses the result instead of fetching it twice.
 - `isYSQLStream()`: Results cached in a ConcurrentHashMap keyed by stream ID. The YugabyteDBConnectorConfig constructor calls this twice (once in super(), once for the field); the second call is now a cache hit.
 - `getTabletListToPollForCDCWithRetry()`:  New overload accepts an existing YBClient so the caller can reuse an open connection instead of creating a new one (with TLShandshake) per table. Used in validateTServerConnection(). The original signature used by streaming and snapshot sources is unchanged.

## Impact

 For a connector on a stream with T matched tables and N total tables in the stream:

   | | Before | After |
   |---|--------|-------|
   | `getDBStreamInfo` RPCs | 2 + N | 2 |
   | `getStreamInfo` calls | 2 | 1 |
   | `isYSQLStream` RPCs | 4 | 2 |
   | YBClient connections created | 4 + T | 2 |


 All changes are backward-compatible — new overloads only, no changes to existing method behavior.