### PR TITLE
Add test for slot restart time move forward

### DIFF
--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBPublicationReplicationTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBPublicationReplicationTest.java
@@ -532,6 +532,59 @@ public class YugabyteDBPublicationReplicationTest extends YugabyteDBContainerTes
         assertTombstone(changeRecords.get(3));
     }
 
+    @Test
+    public void testHistoryRetentionBarrierMovesForward() throws Exception {
+        TestHelper.execute(String.format(TestHelper.createPublicationForTableStatement, PUB_NAME, "t1"));
+        TestHelper.execute(TestHelper.createReplicationSlotStatement);
+
+        startEngine(getPublicationConfig());
+        final long recordsCount = 10;
+
+        awaitUntilConnectorIsReady();
+
+        Thread.sleep(30000);
+
+        insertRecords(recordsCount);
+
+        List<SourceRecord> records = new ArrayList<>();
+        waitAndFailIfCannotConsume(records, recordsCount);
+
+        Struct value = (Struct) records.get(records.size() - 1).value();
+        Struct source = value.getStruct("source");
+        long lastCommitTime = source.getInt64("commit_time");
+        long commitMicros = lastCommitTime >> SourceInfo.HT_BITS_FOR_LOGICAL_COMPONENT;
+
+        try {
+            Awaitility.await()
+                .atMost(Duration.ofSeconds(30))
+                .pollInterval(Duration.ofSeconds(5))
+                .until(() -> {
+                    try (YugabyteDBConnection conn = TestHelper.create();
+                         Connection connection = conn.connection();
+                         Statement stmt = connection.createStatement()) {
+                        ResultSet rs = stmt.executeQuery(
+                            "SELECT yb_restart_time FROM pg_replication_slots "
+                            + "WHERE slot_name = 'test_replication_slot';");
+                        if (rs.next()) {
+                            java.sql.Timestamp ts = rs.getTimestamp("yb_restart_time");
+                            if (ts == null) {
+                                return false;
+                            }
+                            java.time.Instant restartInstant = ts.toInstant();
+                            long restartMicros = restartInstant.getEpochSecond() * 1_000_000
+                                + restartInstant.getNano() / 1_000;
+                            LOGGER.info("yb_restart_time micros: {} commitMicros: {}",
+                                restartMicros, commitMicros);
+                            return restartMicros >= commitMicros;
+                        }
+                        return false;
+                    }
+                });
+        } catch (ConditionTimeoutException e) {
+            fail("History retention barrier did not advance to the last commit time within 30 seconds", e);
+        }
+    }
+
     // ---- Helpers ----
 
     private Configuration.Builder getPublicationConfig() throws Exception {

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBPublicationReplicationTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBPublicationReplicationTest.java
@@ -533,7 +533,7 @@ public class YugabyteDBPublicationReplicationTest extends YugabyteDBContainerTes
     }
 
     @Test
-    public void testHistoryRetentionBarrierMovesForward() throws Exception {
+    public void testSlotRestartTimeMovesForward() throws Exception {
         TestHelper.execute(String.format(TestHelper.createPublicationForTableStatement, PUB_NAME, "t1"));
         TestHelper.execute(TestHelper.createReplicationSlotStatement);
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBPublicationReplicationTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBPublicationReplicationTest.java
@@ -581,7 +581,7 @@ public class YugabyteDBPublicationReplicationTest extends YugabyteDBContainerTes
                     }
                 });
         } catch (ConditionTimeoutException e) {
-            fail("History retention barrier did not advance to the last commit time within 30 seconds", e);
+            fail("Slot restart time did not advance to the last commit time within 30 seconds", e);
         }
     }
 


### PR DESCRIPTION
- Implemented a new test to verify that the slot restart time advances correctly after inserting records.
- The test checks the `yb_restart_time` from the replication slot to ensure it meets the expected commit time.