### PR TITLE
[DBZ][yugabyte/yugabyte-db#31129] Upgrade dependencies

### DIFF
--- a/.github/scripts/install_prerequisites.sh
+++ b/.github/scripts/install_prerequisites.sh
@@ -17,8 +17,8 @@ set -exo pipefail
 . /etc/os-release
 
 if [[ "${ID_LIKE:-}" == *rhel* ]]; then
-  sudo yum -y -q install java-11-openjdk-devel
-  sudo alternatives --set java java-11-openjdk.x86_64
+  sudo yum -y -q install java-21-openjdk-devel
+  sudo alternatives --set java java-21-openjdk.x86_64
 else
   echo "OS not supported"
   exit 1

--- a/.github/workflows/basic-test-workflow.yml
+++ b/.github/workflows/basic-test-workflow.yml
@@ -22,6 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 21
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -37,11 +37,11 @@ jobs:
       - name: Checkout Action
         uses: actions/checkout@v4
       
-      - name: Set up Java 11
+      - name: Set up Java 21
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 21
 
       - name: Clean targets
         run: mvn release:clean

--- a/.github/workflows/build-sanity.yml
+++ b/.github/workflows/build-sanity.yml
@@ -13,6 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 21
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/sanity-workflow.yml
+++ b/.github/workflows/sanity-workflow.yml
@@ -15,6 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 21
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,14 @@ COPY --chown=kafka:kafka target/debezium-connector-yugabytedb-*.jar $KAFKA_CONNE
 # Set the TLS version to be used by Kafka processes
 ENV KAFKA_OPTS="-Djdk.tls.client.protocols=TLSv1.2"
 
-# Add the required jar files to be packaged with the base connector
-RUN cd $KAFKA_CONNECT_YB_DIR && curl -sLo kafka-connect-jdbc-10.6.5.jar https://github.com/yugabyte/kafka-connect-jdbc/releases/download/10.6.5-CUSTOM/kafka-connect-jdbc-10.6.5.jar
-RUN cd $KAFKA_CONNECT_YB_DIR && curl -sLo jdbc-yugabytedb-42.3.5-yb-1.jar https://repo1.maven.org/maven2/com/yugabyte/jdbc-yugabytedb/42.3.5-yb-1/jdbc-yugabytedb-42.3.5-yb-1.jar
-RUN cd $KAFKA_CONNECT_YB_DIR && curl -sLo mysql-connector-j-9.2.0.jar https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/9.2.0/mysql-connector-j-9.2.0.jar
-RUN cd $KAFKA_CONNECT_YB_DIR && curl -sLo postgresql-42.7.7.jar https://repo1.maven.org/maven2/org/postgresql/postgresql/42.7.7/postgresql-42.7.7.jar
+# Add the required jar files to be packaged with the base connector.
+RUN cd $KAFKA_CONNECT_YB_DIR && curl -sfLo kafka-connect-jdbc-10.6.5.jar https://github.com/yugabyte/kafka-connect-jdbc/releases/download/10.6.5-CUSTOM/kafka-connect-jdbc-10.6.5.jar
+RUN cd $KAFKA_CONNECT_YB_DIR && curl -sfLo jdbc-yugabytedb-42.3.5-yb-1.jar https://repo1.maven.org/maven2/com/yugabyte/jdbc-yugabytedb/42.3.5-yb-1/jdbc-yugabytedb-42.3.5-yb-1.jar
+RUN cd $KAFKA_CONNECT_YB_DIR && curl -sfLo mysql-connector-j-9.2.0.jar https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/9.2.0/mysql-connector-j-9.2.0.jar
+RUN cd $KAFKA_CONNECT_YB_DIR && curl -sfLo postgresql-42.7.7.jar https://repo1.maven.org/maven2/org/postgresql/postgresql/42.7.7/postgresql-42.7.7.jar
 
 # Add JMX Prometheus agent and metrics pattern file to expose metrics
-RUN mkdir -p $KAFKA_HOME/etc && cd $KAFKA_HOME/etc && curl -so jmx_prometheus_javaagent-1.3.3.jar https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/1.3.3/jmx_prometheus_javaagent-1.3.3.jar
+RUN mkdir -p $KAFKA_HOME/etc && cd $KAFKA_HOME/etc && curl -sfo jmx_prometheus_javaagent-1.0.1.jar https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/1.0.1/jmx_prometheus_javaagent-1.0.1.jar
 
 ADD metrics.yml /etc/jmx-exporter/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 # On your terminal, run the following to build the image:
 # mvn clean package -Dquick
 
-FROM debezium/connect:1.9.5.Final
+FROM yugabyte/debezium-connect-base:latest
 
 # Create the directories for the connectors to be placed into
 ENV KAFKA_CONNECT_YB_DIR=$KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-yugabytedb
 RUN mkdir $KAFKA_CONNECT_YB_DIR && cd $KAFKA_CONNECT_YB_DIR
 
 # Copy the Debezium Connector for YugabyteDB
-COPY target/debezium-connector-yugabytedb-*.jar $KAFKA_CONNECT_YB_DIR/
+COPY --chown=kafka:kafka target/debezium-connector-yugabytedb-*.jar $KAFKA_CONNECT_YB_DIR/
 
 # Set the TLS version to be used by Kafka processes
 ENV KAFKA_OPTS="-Djdk.tls.client.protocols=TLSv1.2"
@@ -16,13 +16,12 @@ ENV KAFKA_OPTS="-Djdk.tls.client.protocols=TLSv1.2"
 # Add the required jar files to be packaged with the base connector
 RUN cd $KAFKA_CONNECT_YB_DIR && curl -sLo kafka-connect-jdbc-10.6.5.jar https://github.com/yugabyte/kafka-connect-jdbc/releases/download/10.6.5-CUSTOM/kafka-connect-jdbc-10.6.5.jar
 RUN cd $KAFKA_CONNECT_YB_DIR && curl -sLo jdbc-yugabytedb-42.3.5-yb-1.jar https://repo1.maven.org/maven2/com/yugabyte/jdbc-yugabytedb/42.3.5-yb-1/jdbc-yugabytedb-42.3.5-yb-1.jar
-RUN cd $KAFKA_CONNECT_YB_DIR && curl -sLo mysql-connector-java-8.0.30.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.30/mysql-connector-java-8.0.30.jar
-RUN cd $KAFKA_CONNECT_YB_DIR && curl -sLo postgresql-42.5.1.jar https://repo1.maven.org/maven2/org/postgresql/postgresql/42.5.1/postgresql-42.5.1.jar
+RUN cd $KAFKA_CONNECT_YB_DIR && curl -sLo mysql-connector-j-9.2.0.jar https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/9.2.0/mysql-connector-j-9.2.0.jar
+RUN cd $KAFKA_CONNECT_YB_DIR && curl -sLo postgresql-42.7.7.jar https://repo1.maven.org/maven2/org/postgresql/postgresql/42.7.7/postgresql-42.7.7.jar
 
-# Add Jmx agent and metrics pattern file to expose the metrics info
-RUN mkdir /kafka/etc && cd /kafka/etc && curl -so jmx_prometheus_javaagent-0.17.2.jar https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.17.2/jmx_prometheus_javaagent-0.17.2.jar
+# Add JMX Prometheus agent and metrics pattern file to expose metrics
+RUN mkdir -p $KAFKA_HOME/etc && cd $KAFKA_HOME/etc && curl -so jmx_prometheus_javaagent-1.3.3.jar https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/1.3.3/jmx_prometheus_javaagent-1.3.3.jar
 
 ADD metrics.yml /etc/jmx-exporter/
 
 ENV CLASSPATH=$KAFKA_HOME
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # On your terminal, run the following to build the image:
 # mvn clean package -Dquick
 
-FROM yugabyte/debezium-connect-base:latest
+FROM quay.io/yugabyte/debezium-connect-base:latest
 
 # Create the directories for the connectors to be placed into
 ENV KAFKA_CONNECT_YB_DIR=$KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-yugabytedb

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Kafka Connect can also be run standalone as a single process, although doing so 
 
 The YugabyteDB connector can also be used as a library without Kafka or Kafka Connect, enabling applications and services to directly connect to a YugabyteDB database and obtain the ordered change events. This approach requires the application to record the progress of the connector so that upon restart the connect can continue where it left off. Therefore, this may be a useful approach for less critical use cases. For production use cases, we highly recommend using this connector with Kafka and Kafka Connect.
 
+## Prerequisites
+
+- **JDK 21** is required to build the project. The compiled bytecode targets Java 17.
+
 ## Building the connector jar
 
 1. Navigate inside the repository.

--- a/base_source_image/Dockerfile
+++ b/base_source_image/Dockerfile
@@ -19,7 +19,7 @@
 #   - Avro, Guava, logredactor, and the transitive deps Confluent requires
 #     (commons-codec, commons-compress, re2j, minimal-json, snakeyaml, etc.)
 #   - Debezium 1.9 kafka-connect-start.sh fetched at build time from the
-#     upstream debezium/container-images repo
+#     upstream debezium/container-images repo.
 #
 # Where this image fits
 # ---------------------

--- a/base_source_image/Dockerfile
+++ b/base_source_image/Dockerfile
@@ -1,0 +1,125 @@
+# YugabyteDB Debezium Connect Base Image
+#
+# Provides a Kafka Connect runtime with Confluent serialization libraries.
+# Based on Rapid Fort hardened Azul Zulu JDK 21 on Ubuntu 22.04 (Jammy).
+#
+# Build (from repo root):
+#   docker build -f base_source_image/Dockerfile -t yugabyte/debezium-connect-base:latest .
+
+FROM eclipse-temurin:21-jre-jammy
+
+LABEL maintainer="yugabyte" \
+      debezium.version="1.9.5.Final"
+
+#
+# Set the Debezium version, Kafka version, and Scala version (needed for download URL).
+#
+ARG DEBEZIUM_VERSION=1.9
+ARG KAFKA_VERSION=3.9.2
+ARG SCALA_VERSION=2.13
+
+#
+# Kafka home and plugin directories
+#
+ENV KAFKA_HOME=/opt/kafka \
+    KAFKA_DATA=/opt/kafka/data
+ENV KAFKA_CONNECT_PLUGINS_DIR=$KAFKA_HOME/connect \
+    KAFKA_CONNECT_PLUGINS=$KAFKA_HOME/new-connector-plugins \
+    CONNECT_PLUGIN_PATH=$KAFKA_HOME/connect \
+    KAFKA_VERSION=${KAFKA_VERSION} \
+    SCALA_VERSION=${SCALA_VERSION}
+
+#
+# Install minimal packages (curl needed for healthchecks and JAR downloads)
+#
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl \
+        iproute2 \
+    && rm -rf /var/lib/apt/lists/*
+
+#
+# Create a user and home directory for Kafka
+#
+USER root
+
+RUN groupadd -r kafka -g 1001 && \
+    useradd -u 1001 -r -g kafka -m -d $KAFKA_HOME -s /sbin/nologin -c "Kafka user" kafka && \
+    chmod -R 755 $KAFKA_HOME
+
+#
+# Download and install Apache Kafka
+#
+RUN mkdir -p /tmp/kafka-download && \
+    curl -fsSL \
+      "https://dlcdn.apache.org/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" \
+      -o /tmp/kafka-download/kafka.tgz || \
+    curl -fsSL \
+      "https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" \
+      -o /tmp/kafka-download/kafka.tgz && \
+    tar -xzf /tmp/kafka-download/kafka.tgz -C /tmp/kafka-download && \
+    cp -r /tmp/kafka-download/kafka_${SCALA_VERSION}-${KAFKA_VERSION}/* $KAFKA_HOME/ && \
+    rm -rf /tmp/kafka-download
+
+#
+# Create connector plugin directories:
+#   - KAFKA_CONNECT_PLUGINS_DIR: where Kafka Connect discovers plugins at runtime
+#   - KAFKA_CONNECT_PLUGINS: staging volume; entrypoint copies from here into connector-plugins
+#   - connector-plugins: actual plugin path set in connect-distributed.properties
+#
+RUN mkdir -p "$KAFKA_CONNECT_PLUGINS_DIR" "$KAFKA_CONNECT_PLUGINS" "$KAFKA_HOME/connector-plugins" "$KAFKA_DATA"
+
+#
+# Confluent serialization libraries (for Avro / Schema Registry support)
+# Confluent 7.9.x aligns with Kafka 3.9.x
+#
+ARG CONFLUENT_VERSION=7.9.0
+ARG AVRO_VERSION=1.12.0
+
+RUN cd $KAFKA_HOME/libs && \
+    curl -sfLO "https://packages.confluent.io/maven/io/confluent/kafka-connect-avro-converter/${CONFLUENT_VERSION}/kafka-connect-avro-converter-${CONFLUENT_VERSION}.jar" && \
+    curl -sfLO "https://packages.confluent.io/maven/io/confluent/kafka-connect-avro-data/${CONFLUENT_VERSION}/kafka-connect-avro-data-${CONFLUENT_VERSION}.jar" && \
+    curl -sfLO "https://packages.confluent.io/maven/io/confluent/kafka-avro-serializer/${CONFLUENT_VERSION}/kafka-avro-serializer-${CONFLUENT_VERSION}.jar" && \
+    curl -sfLO "https://packages.confluent.io/maven/io/confluent/kafka-schema-serializer/${CONFLUENT_VERSION}/kafka-schema-serializer-${CONFLUENT_VERSION}.jar" && \
+    curl -sfLO "https://packages.confluent.io/maven/io/confluent/kafka-schema-registry-client/${CONFLUENT_VERSION}/kafka-schema-registry-client-${CONFLUENT_VERSION}.jar" && \
+    curl -sfLO "https://packages.confluent.io/maven/io/confluent/common-config/${CONFLUENT_VERSION}/common-config-${CONFLUENT_VERSION}.jar" && \
+    curl -sfLO "https://packages.confluent.io/maven/io/confluent/common-utils/${CONFLUENT_VERSION}/common-utils-${CONFLUENT_VERSION}.jar" && \
+    curl -sfLO "https://repo1.maven.org/maven2/org/apache/avro/avro/${AVRO_VERSION}/avro-${AVRO_VERSION}.jar" && \
+    curl -sfLO "https://repo1.maven.org/maven2/com/google/guava/guava/33.4.0-jre/guava-33.4.0-jre.jar"
+
+#
+# Download the kafka-connect start script from upstream (handles CONNECT_* env var
+# mapping, JMX setup, and launches connect-distributed.sh)
+#
+RUN mkdir /scripts
+RUN curl -fsSL https://raw.githubusercontent.com/debezium/container-images/main/connect-base/${DEBEZIUM_VERSION}/docker-entrypoint.sh -o /scripts/kafka-connect-start.sh
+
+#
+# Preserve original config (entrypoint restores from here on startup)
+#
+RUN mkdir $KAFKA_HOME/config.orig && \
+    mv $KAFKA_HOME/config/* $KAFKA_HOME/config.orig && \
+    chown -R 1001:kafka $KAFKA_HOME/config.orig
+
+# Remove unnecessary files (sources, javadoc, scaladoc JARs)
+RUN rm -f $KAFKA_HOME/libs/*-{sources,javadoc,scaladoc}.jar*
+
+#
+# Allow random UID to use Kafka
+#
+RUN chmod -R g+w,o+w $KAFKA_HOME && \
+    chown -R 1001:kafka $KAFKA_HOME
+
+WORKDIR $KAFKA_HOME
+
+EXPOSE 8083
+VOLUME ["${KAFKA_HOME}/config", "${KAFKA_CONNECT_PLUGINS_DIR}"]
+
+#
+# Copy entrypoint script and switch user
+#
+COPY base_source_image/docker-entrypoint.sh /
+RUN chmod 755 /docker-entrypoint.sh && chmod -R 755 /scripts
+USER kafka
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["kafka-connect"]

--- a/base_source_image/Dockerfile
+++ b/base_source_image/Dockerfile
@@ -1,10 +1,60 @@
+# =============================================================================
 # YugabyteDB Debezium Connect Base Image
+# =============================================================================
 #
-# Provides a Kafka Connect runtime with Confluent serialization libraries.
-# Based on Rapid Fort hardened Azul Zulu JDK 21 on Ubuntu 22.04 (Jammy).
+# Purpose
+# -------
+# Provides a Kafka Connect runtime with Confluent serialization libraries,
+# replacing the upstream `debezium/connect:1.9.5.Final` image. Rolling our
+# own base lets us pin JDK 21, Kafka 3.9.2, Ubuntu 22.04 (Jammy), and a
+# non-root `kafka` user (UID 1001), and patch CVEs on our own cadence.
 #
-# Build (from repo root):
-#   docker build -f base_source_image/Dockerfile -t yugabyte/debezium-connect-base:latest .
+# Image contents
+# --------------
+#   - Eclipse Temurin JDK 21 (JRE) on Ubuntu 22.04
+#   - Apache Kafka ${KAFKA_VERSION} (Scala ${SCALA_VERSION})
+#   - Confluent serialization libs ${CONFLUENT_VERSION}
+#     (avro-converter, avro-data, avro-serializer, schema-serializer,
+#      schema-converter, schema-registry-client, common-config, common-utils)
+#   - Avro, Guava, logredactor, and the transitive deps Confluent requires
+#     (commons-codec, commons-compress, re2j, minimal-json, snakeyaml, etc.)
+#   - Debezium 1.9 kafka-connect-start.sh fetched at build time from the
+#     upstream debezium/container-images repo
+#
+# Where this image fits
+# ---------------------
+#   eclipse-temurin:21-jre-jammy            (public base)
+#         |
+#         v
+#   quay.io/yugabyte/debezium-connect-base  (this Dockerfile)
+#         |
+#         v
+#   quay.io/yugabyte/debezium-connector     (top-level Dockerfile, layers
+#                                            the YugabyteDB connector jar)
+#
+# When to rebuild
+# ---------------
+# Rebuild and push this image only when its contents change, e.g.:
+#   - Kafka, Confluent, JDK, or Ubuntu version bump
+#   - New jar added to $KAFKA_HOME/libs
+#   - System package change (apt-get line)
+#   - Security patch
+# The connector jar itself does NOT require rebuilding the base — the
+# top-level Dockerfile only COPYs the connector jar on top.
+#
+# Build and push (from repo root)
+# -------------------------------
+#   docker build -f base_source_image/Dockerfile \
+#       -t quay.io/yugabyte/debezium-connect-base:latest .
+#   docker push quay.io/yugabyte/debezium-connect-base:latest
+#
+# Local smoke test
+# --------------------------------------------------------
+#   docker run --rm --entrypoint sh \
+#       quay.io/yugabyte/debezium-connect-base:latest \
+#       -c 'ls $KAFKA_HOME/libs | grep -E "kafka-connect-avro|avro-|guava-"'
+#
+# =============================================================================
 
 FROM eclipse-temurin:21-jre-jammy
 
@@ -94,7 +144,9 @@ RUN cd $KAFKA_HOME/libs && \
     curl -sfLO "https://repo1.maven.org/maven2/com/google/re2j/re2j/1.6/re2j-1.6.jar" && \
     curl -sfLO "https://repo1.maven.org/maven2/org/yaml/snakeyaml/2.0/snakeyaml-2.0.jar" && \
     curl -sfLO "https://repo1.maven.org/maven2/io/confluent/logredactor/1.0.12/logredactor-1.0.12.jar" && \
-    curl -sfLO "https://repo1.maven.org/maven2/io/confluent/logredactor-metrics/1.0.12/logredactor-metrics-1.0.12.jar"
+    curl -sfLO "https://repo1.maven.org/maven2/io/confluent/logredactor-metrics/1.0.12/logredactor-metrics-1.0.12.jar" && \
+    curl -sfLO "https://repo1.maven.org/maven2/commons-codec/commons-codec/1.16.1/commons-codec-1.16.1.jar" && \
+    curl -sfLO "https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.26.1/commons-compress-1.26.1.jar"
 
 #
 # Download the kafka-connect start script from upstream (handles CONNECT_* env var

--- a/base_source_image/Dockerfile
+++ b/base_source_image/Dockerfile
@@ -64,10 +64,9 @@ RUN mkdir -p /tmp/kafka-download && \
 #
 # Create connector plugin directories:
 #   - KAFKA_CONNECT_PLUGINS_DIR: where Kafka Connect discovers plugins at runtime
-#   - KAFKA_CONNECT_PLUGINS: staging volume; entrypoint copies from here into connector-plugins
-#   - connector-plugins: actual plugin path set in connect-distributed.properties
+#   - KAFKA_CONNECT_PLUGINS: staging volume; entrypoint copies from here into KAFKA_CONNECT_PLUGINS_DIR
 #
-RUN mkdir -p "$KAFKA_CONNECT_PLUGINS_DIR" "$KAFKA_CONNECT_PLUGINS" "$KAFKA_HOME/connector-plugins" "$KAFKA_DATA"
+RUN mkdir -p "$KAFKA_CONNECT_PLUGINS_DIR" "$KAFKA_CONNECT_PLUGINS" "$KAFKA_DATA"
 
 #
 # Confluent serialization libraries (for Avro / Schema Registry support)
@@ -81,11 +80,21 @@ RUN cd $KAFKA_HOME/libs && \
     curl -sfLO "https://packages.confluent.io/maven/io/confluent/kafka-connect-avro-data/${CONFLUENT_VERSION}/kafka-connect-avro-data-${CONFLUENT_VERSION}.jar" && \
     curl -sfLO "https://packages.confluent.io/maven/io/confluent/kafka-avro-serializer/${CONFLUENT_VERSION}/kafka-avro-serializer-${CONFLUENT_VERSION}.jar" && \
     curl -sfLO "https://packages.confluent.io/maven/io/confluent/kafka-schema-serializer/${CONFLUENT_VERSION}/kafka-schema-serializer-${CONFLUENT_VERSION}.jar" && \
+    curl -sfLO "https://packages.confluent.io/maven/io/confluent/kafka-schema-converter/${CONFLUENT_VERSION}/kafka-schema-converter-${CONFLUENT_VERSION}.jar" && \
     curl -sfLO "https://packages.confluent.io/maven/io/confluent/kafka-schema-registry-client/${CONFLUENT_VERSION}/kafka-schema-registry-client-${CONFLUENT_VERSION}.jar" && \
     curl -sfLO "https://packages.confluent.io/maven/io/confluent/common-config/${CONFLUENT_VERSION}/common-config-${CONFLUENT_VERSION}.jar" && \
     curl -sfLO "https://packages.confluent.io/maven/io/confluent/common-utils/${CONFLUENT_VERSION}/common-utils-${CONFLUENT_VERSION}.jar" && \
     curl -sfLO "https://repo1.maven.org/maven2/org/apache/avro/avro/${AVRO_VERSION}/avro-${AVRO_VERSION}.jar" && \
-    curl -sfLO "https://repo1.maven.org/maven2/com/google/guava/guava/33.4.0-jre/guava-33.4.0-jre.jar"
+    curl -sfLO "https://repo1.maven.org/maven2/com/google/guava/guava/33.4.0-jre/guava-33.4.0-jre.jar" && \
+    curl -sfLO "https://repo1.maven.org/maven2/com/google/guava/failureaccess/1.0.2/failureaccess-1.0.2.jar" && \
+    curl -sfLO "https://repo1.maven.org/maven2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar" && \
+    curl -sfLO "https://repo1.maven.org/maven2/org/checkerframework/checker-qual/3.43.0/checker-qual-3.43.0.jar" && \
+    curl -sfLO "https://repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/3.0.0/j2objc-annotations-3.0.0.jar" && \
+    curl -sfLO "https://repo1.maven.org/maven2/com/eclipsesource/minimal-json/minimal-json/0.9.5/minimal-json-0.9.5.jar" && \
+    curl -sfLO "https://repo1.maven.org/maven2/com/google/re2j/re2j/1.6/re2j-1.6.jar" && \
+    curl -sfLO "https://repo1.maven.org/maven2/org/yaml/snakeyaml/2.0/snakeyaml-2.0.jar" && \
+    curl -sfLO "https://repo1.maven.org/maven2/io/confluent/logredactor/1.0.12/logredactor-1.0.12.jar" && \
+    curl -sfLO "https://repo1.maven.org/maven2/io/confluent/logredactor-metrics/1.0.12/logredactor-metrics-1.0.12.jar"
 
 #
 # Download the kafka-connect start script from upstream (handles CONNECT_* env var
@@ -113,7 +122,11 @@ RUN chmod -R g+w,o+w $KAFKA_HOME && \
 WORKDIR $KAFKA_HOME
 
 EXPOSE 8083
-VOLUME ["${KAFKA_HOME}/config", "${KAFKA_CONNECT_PLUGINS_DIR}"]
+# NOTE: $KAFKA_CONNECT_PLUGINS_DIR is intentionally NOT declared as a VOLUME here.
+# The classic Docker builder discards modifications to VOLUME paths made by RUN
+# commands in child images, which broke fabric8 docker-maven-plugin builds that
+# curl additional connector jars into the plugin dir.
+VOLUME ["${KAFKA_HOME}/config"]
 
 #
 # Copy entrypoint script and switch user

--- a/base_source_image/docker-entrypoint.sh
+++ b/base_source_image/docker-entrypoint.sh
@@ -30,15 +30,14 @@ case $1 in
     kafka-connect)
         shift
         # Set the directory with debezium connectors in config file
-        echo "plugin.path=$KAFKA_HOME/connector-plugins" >> $KAFKA_HOME/config/connect-distributed.properties
+        echo "plugin.path=$KAFKA_CONNECT_PLUGINS_DIR" >> $KAFKA_HOME/config/connect-distributed.properties
 
         # If volume with plugins is not empty then use the contents of volume with plugins as connector plugins. Otherwise use default set of plugins
         if find $KAFKA_CONNECT_PLUGINS -mindepth 1 -maxdepth 1 | read; then
-            rm -rf $KAFKA_HOME/connector-plugins/*;
             ls ${KAFKA_CONNECT_PLUGINS}
-            cp -R ${KAFKA_CONNECT_PLUGINS}/* $KAFKA_HOME/connector-plugins/
+            cp -R ${KAFKA_CONNECT_PLUGINS}/* $KAFKA_CONNECT_PLUGINS_DIR/
         fi
-        export CONNECT_PLUGIN_PATH=$KAFKA_HOME/connector-plugins
+        export CONNECT_PLUGIN_PATH=$KAFKA_CONNECT_PLUGINS_DIR
         if [ -z "$1" ]; then
             exec /scripts/kafka-connect-start.sh start
         else

--- a/base_source_image/docker-entrypoint.sh
+++ b/base_source_image/docker-entrypoint.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Exit immediately if a *pipeline* returns a non-zero status. (Add -x for command tracing)
+set -e
+
+# Copy config files if not provided in volume
+cp -rn $KAFKA_HOME/config.orig/* $KAFKA_HOME/config
+
+case $1 in
+    zookeeper)
+        shift
+        # Change the Zookeeper snapshot directory in zookeeper.properties file
+        sed -i "s|dataDir=.*|dataDir=${ZK_DATA}|" $KAFKA_HOME/config/zookeeper.properties
+        if [ -z "$1" ]; then
+            exec $KAFKA_HOME/bin/zookeeper-server-start.sh $KAFKA_HOME/config/zookeeper.properties
+        else
+            echo "Zookeeper can not have any arguments"
+        fi
+        ;;
+    kafka)
+        shift
+        # Set the directory where the logs for kafka will be stored
+        sed -i "s|log.dirs=.*|log.dirs=${KAFKA_DATA}|" $KAFKA_HOME/config/server.properties
+        if [ -z "$1" ]; then
+            exec $KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties
+        else
+            exec $KAFKA_HOME/bin/kafka-server-start.sh "$@"
+        fi
+        ;;
+    kafka-connect)
+        shift
+        # Set the directory with debezium connectors in config file
+        echo "plugin.path=$KAFKA_HOME/connector-plugins" >> $KAFKA_HOME/config/connect-distributed.properties
+
+        # If volume with plugins is not empty then use the contents of volume with plugins as connector plugins. Otherwise use default set of plugins
+        if find $KAFKA_CONNECT_PLUGINS -mindepth 1 -maxdepth 1 | read; then
+            rm -rf $KAFKA_HOME/connector-plugins/*;
+            ls ${KAFKA_CONNECT_PLUGINS}
+            cp -R ${KAFKA_CONNECT_PLUGINS}/* $KAFKA_HOME/connector-plugins/
+        fi
+        export CONNECT_PLUGIN_PATH=$KAFKA_HOME/connector-plugins
+        if [ -z "$1" ]; then
+            exec /scripts/kafka-connect-start.sh start
+        else
+            exec /scripts/kafka-connect-start.sh "$@"
+        fi
+        ;;
+    *)
+        echo "First argument must be either zookeeper, kafka or kafka-connect."
+        exit 1
+        ;;
+esac

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,10 @@
         <version.fabric8.plugin>0.48.1</version.fabric8.plugin>
         <version.jackson>2.19.0</version.jackson>
 
-        <!-- Compile -->
+        <!-- Compile: build requires JDK 21, output targets Java 17 -->
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Enforce JDK 21 for building -->

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <version.surefire.plugin>3.5.5</version.surefire.plugin>
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
         <version.compiler.plugin>3.13.0</version.compiler.plugin>
-        <version.shade.plugin>3.6.0</version.shade.plugin>
+        <version.shade.plugin>3.6.1</version.shade.plugin>
         <version.release.plugin>3.0.0-M5</version.release.plugin>
         <version.site.plugin>3.7.1</version.site.plugin>
         <version.resources.plugin>3.1.0</version.resources.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -545,6 +545,21 @@
                         <artifactId>junit-jupiter-engine</artifactId>
                         <version>${version.junit}</version>
                     </dependency>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-launcher</artifactId>
+                        <version>${version.junit}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-engine</artifactId>
+                        <version>${version.junit}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-commons</artifactId>
+                        <version>${version.junit}</version>
+                    </dependency>
                 </dependencies>
             </plugin>
             <!--
@@ -556,6 +571,28 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>${version.failsafe.plugin}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>${version.junit}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-launcher</artifactId>
+                        <version>${version.junit}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-engine</artifactId>
+                        <version>${version.junit}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-commons</artifactId>
+                        <version>${version.junit}</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <id>integration-test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,14 @@
 
 	<dependencyManagement>
 		<dependencies>
+			<!-- Override Netty modules pinned to 4.1.73 by debezium-bom:1.9.5 -->
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-bom</artifactId>
+				<version>4.1.128.Final</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
 			<dependency>
             	<groupId>io.debezium</groupId>
             	<artifactId>debezium-bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,34 +21,34 @@
         <version.debezium>1.9.5.Final</version.debezium>
 
         <!-- Plugins -->
-        <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
+        <version.surefire.plugin>3.5.5</version.surefire.plugin>
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
-        <version.compiler.plugin>3.8.1</version.compiler.plugin>
+        <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <version.shade.plugin>3.6.0</version.shade.plugin>
         <version.release.plugin>3.0.0-M5</version.release.plugin>
         <version.site.plugin>3.7.1</version.site.plugin>
         <version.resources.plugin>3.1.0</version.resources.plugin>
-        <version.docker.maven.plugin>0.40.2</version.docker.maven.plugin>
+        <version.docker.maven.plugin>0.48.1</version.docker.maven.plugin>
         <version.protoc.maven.plugin>3.11.4</version.protoc.maven.plugin>
-        <version.fabric8.plugin>0.40.2</version.fabric8.plugin>
+        <version.fabric8.plugin>0.48.1</version.fabric8.plugin>
         <version.jackson>2.19.0</version.jackson>
 
         <!-- Compile -->
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <!-- Enforce JDK 11 for building (handled via JBoss parent POM)-->
-        <jdk.min.version>11</jdk.min.version>
+        <!-- Enforce JDK 21 for building -->
+        <jdk.min.version>21</jdk.min.version>
 
         <!-- Dependency Versions -->
-        <version.postgresql.driver>42.7.2</version.postgresql.driver>
+        <version.postgresql.driver>42.7.7</version.postgresql.driver>
         <version.com.google.protobuf>4.30.2</version.com.google.protobuf>
-        <version.kafka>3.7.0</version.kafka>
+        <version.kafka>3.9.2</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
-        <version.logback>1.4.0</version.logback>
+        <version.logback>1.2.13</version.logback>
         <version.ybclient>0.8.111-20260312.173733-1</version.ybclient>
-        <version.gson>2.8.9</version.gson>
+        <version.gson>2.13.2</version.gson>
 
         <!--
           Specify the properties that will be used for setting up the integration tests' Docker container.
@@ -59,7 +59,7 @@
         <protobuf.output.directory>${project.basedir}/generated-sources</protobuf.output.directory>
 
         <!-- Test -->
-        <version.junit>5.9.2</version.junit>
+        <version.junit>6.0.3</version.junit>
 
         <!-- Deploy -->
         <version.s3.wagon>0.1.3</version.s3.wagon>
@@ -210,7 +210,7 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>5.0.1</version>
+            <version>7.0.2</version>
         </dependency>
 
 		<!-- Building -->
@@ -257,6 +257,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <version>${version.logback}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -274,6 +275,7 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
+            <version>4.3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -284,6 +286,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-avro-converter</artifactId>
+            <version>7.0.16</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -314,14 +317,14 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.20.0</version>
             <scope>compile</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/io.netty/netty-all -->
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.115.Final</version>
+            <version>4.1.128.Final</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.stumbleupon/async -->
         <dependency>
@@ -333,12 +336,12 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.79</version>
+            <version>1.82</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>RELEASE</version>
+            <version>${version.junit}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/debezium/connector/yugabytedb/consistent/Message.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/consistent/Message.java
@@ -168,7 +168,7 @@ public class Message implements Comparable<Message> {
 
     /**
      * Return a BigInteger equal to the unsigned value of the argument.
-     * Code taken from <a href="https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/master/src/java.base/share/classes/java/lang/Long.java#L241">Long.java</a>
+     * Code taken from <a href="https://github.com/openjdk/jdk21/blob/master/src/java.base/share/classes/java/lang/Long.java#L241">Long.java</a>
      */
     protected static BigInteger toUnsignedBigInteger(long i) {
         if (i >= 0L)

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBBeforeImageTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBBeforeImageTest.java
@@ -1,6 +1,6 @@
 package io.debezium.connector.yugabytedb;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCQLTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBCQLTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 

--- a/src/test/java/io/debezium/connector/yugabytedb/consistent/YugabyteDBStreamConsistencyTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/consistent/YugabyteDBStreamConsistencyTest.java
@@ -1,7 +1,6 @@
 package io.debezium.connector.yugabytedb.consistent;
 
-import static org.junit.Assert.*;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -325,7 +324,7 @@ public class YugabyteDBStreamConsistencyTest extends YugabyteDBContainerTestBase
         for (int i = 0; i < recordsToAssert.size(); ++i) {
             Struct value = (Struct) recordsToAssert.get(i).value();
             long serial = value.getStruct("after").getStruct("serial_no").getInt32("value");
-            assertEquals("Failed to verify serial number, expected: " + expectedSerial + " received: " + serial + " at index " + i + " with record " + recordsToAssert.get(i), expectedSerial, serial);
+            assertEquals(expectedSerial, serial, "Failed to verify serial number, expected: " + expectedSerial + " received: " + serial + " at index " + i + " with record " + recordsToAssert.get(i));
 
             ++expectedSerial;
         }
@@ -400,7 +399,7 @@ public class YugabyteDBStreamConsistencyTest extends YugabyteDBContainerTestBase
             Struct value = (Struct) recordsToAssert.get(i).value();
             long id = value.getStruct("after").getStruct("id").getInt32("value");
 
-            assertEquals("Expected id " + expectedId + " but got id " + id + " at index " + i, expectedId, id);
+            assertEquals(expectedId, id, "Expected id " + expectedId + " but got id " + id + " at index " + i);
             ++expectedId;
         }
     }
@@ -480,7 +479,7 @@ public class YugabyteDBStreamConsistencyTest extends YugabyteDBContainerTestBase
             Struct value = (Struct) recordsToAssert.get(i).value();
             long serialNo = value.getStruct("after").getStruct("serial_no").getInt32("value");
 
-            assertEquals("Expected serial " + expectedSerial + " but got serial " + serialNo + " at index " + i, expectedSerial, serialNo);
+            assertEquals(expectedSerial, serialNo, "Expected serial " + expectedSerial + " but got serial " + serialNo + " at index " + i);
             ++expectedSerial;
         }
     }
@@ -555,7 +554,7 @@ public class YugabyteDBStreamConsistencyTest extends YugabyteDBContainerTestBase
             Struct value = (Struct) recordsToAssert.get(i).value();
             long id = value.getStruct("after").getStruct("id").getInt32("value");
 
-            assertEquals("Expected id " + expectedId + " but got id " + id + " at index " + i, expectedId, id);
+            assertEquals(expectedId, id, "Expected id " + expectedId + " but got id " + id + " at index " + i);
             ++expectedId;
         }
     }
@@ -631,7 +630,7 @@ public class YugabyteDBStreamConsistencyTest extends YugabyteDBContainerTestBase
         for (int i = 0; i < recordsToAssert.size(); ++i) {
             Struct value = (Struct) recordsToAssert.get(i).value();
             long serial = value.getStruct("after").getStruct("serial_no").getInt32("value");
-            assertEquals("Failed to verify serial number, expected: " + expectedSerial + " received: " + serial, expectedSerial, serial);
+            assertEquals(expectedSerial, serial, "Failed to verify serial number, expected: " + expectedSerial + " received: " + serial);
 
             ++expectedSerial;
         }
@@ -782,7 +781,7 @@ public class YugabyteDBStreamConsistencyTest extends YugabyteDBContainerTestBase
             Struct value = (Struct) recordsToAssert.get(i).value();
             long serialNo = value.getStruct("after").getStruct("serial_no").getInt32("value");
 
-            assertEquals("Expected serial " + expected + " but got serial " + serialNo + " at index " + i, expected, serialNo);
+            assertEquals(expected, serialNo, "Expected serial " + expected + " but got serial " + serialNo + " at index " + i);
             ++expected;
         }
     }


### PR DESCRIPTION
## Problem
The connector was tied to a stack that had aged out and accumulated risk:

1. **Outdated runtime.** The Docker image used `debezium/connect:1.9.5.Final`, which is built on JDK 11 and ships older Confluent serialization libraries. We had no control over its CVE patch cadence or its base OS.

2. **Outdated dependencies.** Kafka was pinned to 3.7.0, JUnit to 5.9.x, Avro converter to a Confluent 7.x line several releases behind, postgresql JDBC to 42.7.2, BouncyCastle to 1.79, etc. Several of these had outstanding CVEs or were transitively forcing older versions (e.g. Netty 4.1.73 via `debezium-bom:1.9.5`).

3. **Outdated build JDK.** The project compiled on JDK 11. HikariCP 7, newer Confluent libraries, and the modern test toolchain require JDK 17+, blocking any further dependency hygiene.

4. **Mixed JUnit 4 / 5 usage in tests.** Test files imported `org.junit.Assert` and used JUnit 4 `assertEquals(message, expected, actual)` signatures, which break under JUnit 5 / 6.

These accumulated until any single dependency bump cascaded into multiple runtime failures.

## Solution
Coordinated upgrade of the build toolchain, runtime image, and dependency versions, with the connector framework (`debezium:1.9.5.Final`) intentionally held constant to avoid behavioral changes to the connector itself.

- **Build / target JDK split.** `mvn` builds on **JDK 21** but produces **Java 17 bytecode** (`maven.compiler.release=17`). Customers on JDK 17+ run the same jar; the developer/CI toolchain moves forward.

- **Custom Connect base image.** Replaced `debezium/connect:1.9.5.Final` with `quay.io/yugabyte/debezium-connect-base:latest`, built from `base_source_image/Dockerfile` on `eclipse-temurin:21-jre-jammy`. This gives us ownership of the JDK 21 runtime, Kafka 3.9.2, Confluent 7.9.0 serialization libs, non-root user (UID 1001), and CVE patch cadence.

- **Dependency bumps** in `pom.xml`: Kafka 3.7.0 → 3.9.2, JUnit 5.9.2 → 6.0.3, postgresql 42.7.2 → 42.7.7, HikariCP 5.0.1 → 7.0.2, commons-lang3 3.12.0 → 3.20.0, netty 4.1.115 → 4.1.128, bouncycastle 1.79 → 1.82, gson 2.8.9 → 2.13.2, plus Maven plugin bumps (shade 3.6.1, surefire 3.5.5, docker-maven-plugin 0.48.1, etc.). Added a Netty BOM override to defeat the `debezium-bom:1.9.5` pin of Netty 4.1.73. Pinned logback to 1.2.13 (kept SLF4J 1.7.x compatibility).

- **JUnit 4 → 5 test migration.** Replaced `org.junit.Assert.*` imports with `org.junit.jupiter.api.Assertions.*` and flipped the `assertEquals` message argument from leading to trailing position across three test files.

- **CI workflows.** All four GitHub Actions workflows now install temurin Java 21; `install_prerequisites.sh` installs `java-21-openjdk-devel`.

### Changes Made
- `pom.xml` — version bumps, Netty BOM override, JUnit platform deps in surefire and failsafe plugins, compiler `source=21 release=17`, pinned versions for `logback-classic`, `awaitility`, `kafka-connect-avro-converter` that previously inherited from `debezium-bom`.
- `Dockerfile` — switched FROM to `quay.io/yugabyte/debezium-connect-base:latest`, bumped mysql/postgresql/jmx-exporter jar versions, added `--chown=kafka:kafka` for the non-root base user, added `-f` to curl steps so the build fails on 4xx/5xx instead of writing HTML error bodies to disk.
- `base_source_image/Dockerfile` (new) — self-built base image with Kafka 3.9.2, Confluent 7.9.0, Avro, Guava, logredactor and the full transitive closure those libs require (`commons-codec`, `commons-compress`, `re2j`, `minimal-json`, `snakeyaml`, `failureaccess`, `checker-qual`, etc.). Header comment documents purpose, contents, image layering chain, when to rebuild, and the build/push commands.
- `base_source_image/docker-entrypoint.sh` (new) — entrypoint that copies staged plugins into the runtime plugin dir and execs the upstream `kafka-connect-start.sh` (fetched at build time from `debezium/container-images/connect-base/1.9/`).
- `.github/workflows/*.yml` — explicit Java 21 setup step in all four workflows.
- `.github/scripts/install_prerequisites.sh` — RHEL install switched to `java-21-openjdk-devel`.
- `src/test/java/.../YugabyteDBBeforeImageTest.java`, `YugabyteDBCQLTest.java`, `YugabyteDBStreamConsistencyTest.java` — JUnit 4 → 5 assertion API migration.
- `src/main/java/.../consistent/Message.java` — javadoc link bumped from openjdk-jdk11 to openjdk/jdk21.
- `README.md` — documents JDK 21 build / JDK 17 runtime requirement.

## Test Plan
- `mvn clean package -Dquick` builds successfully on JDK 21 and produces a jar with Java 17 bytecode (verified `major_version=0x3D=61`).
- Base image builds cleanly via `docker build -f base_source_image/Dockerfile` with no curl failures; smoke test confirms all expected jars land in `$KAFKA_HOME/libs`.
- Connector image builds end-to-end via the fabric8 docker-maven-plugin.
- Existing connector test suite + QA tests
