### PR TITLE
[DBZ][yugabyte/yugabyte-db#31129] Followup for Upgrade dependencies changes

### DIFF
--- a/base_source_image/Dockerfile
+++ b/base_source_image/Dockerfile
@@ -149,6 +149,18 @@ RUN cd $KAFKA_HOME/libs && \
     curl -sfLO "https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.26.1/commons-compress-1.26.1.jar"
 
 #
+# Debezium 3.x SMTs placed on the system classpath so they're discoverable by Kafka Connect
+# across all plugins.
+#
+ARG DEBEZIUM_SMT_VERSION=3.5.1.Final
+RUN cd $KAFKA_HOME/libs && \
+    curl -sfLO "https://repo1.maven.org/maven2/io/debezium/debezium-connect-plugins/${DEBEZIUM_SMT_VERSION}/debezium-connect-plugins-${DEBEZIUM_SMT_VERSION}.jar" && \
+    curl -sfLO "https://repo1.maven.org/maven2/io/debezium/debezium-connector-common/${DEBEZIUM_SMT_VERSION}/debezium-connector-common-${DEBEZIUM_SMT_VERSION}.jar" && \
+    curl -sfLO "https://repo1.maven.org/maven2/io/debezium/debezium-config/${DEBEZIUM_SMT_VERSION}/debezium-config-${DEBEZIUM_SMT_VERSION}.jar" && \
+    curl -sfLO "https://repo1.maven.org/maven2/io/debezium/debezium-util/${DEBEZIUM_SMT_VERSION}/debezium-util-${DEBEZIUM_SMT_VERSION}.jar" && \
+    curl -sfLO "https://repo1.maven.org/maven2/io/debezium/debezium-api/${DEBEZIUM_SMT_VERSION}/debezium-api-${DEBEZIUM_SMT_VERSION}.jar"
+
+#
 # Download the kafka-connect start script from upstream (handles CONNECT_* env var
 # mapping, JMX setup, and launches connect-distributed.sh)
 #
@@ -161,6 +173,15 @@ RUN curl -fsSL https://raw.githubusercontent.com/debezium/container-images/main/
 RUN mkdir $KAFKA_HOME/config.orig && \
     mv $KAFKA_HOME/config/* $KAFKA_HOME/config.orig && \
     chown -R 1001:kafka $KAFKA_HOME/config.orig
+
+# Pin stdout appender threshold to INFO (matches upstream debezium/connect).
+# Stops PUT /admin/loggers->DEBUG from flooding stdout and stalling the connector,
+# while still letting WARN/ERROR through.
+RUN for f in $KAFKA_HOME/config.orig/log4j.properties $KAFKA_HOME/config.orig/connect-log4j.properties; do \
+        if [ -f "$f" ] && ! grep -q '^log4j.appender.stdout.threshold' "$f"; then \
+            sed -i '/^log4j.appender.stdout=org.apache.log4j.ConsoleAppender/a log4j.appender.stdout.threshold=INFO' "$f"; \
+        fi; \
+    done
 
 # Remove unnecessary files (sources, javadoc, scaladoc JARs)
 RUN rm -f $KAFKA_HOME/libs/*-{sources,javadoc,scaladoc}.jar*

--- a/base_source_image/Dockerfile
+++ b/base_source_image/Dockerfile
@@ -148,12 +148,13 @@ RUN cd $KAFKA_HOME/libs && \
     curl -sfLO "https://repo1.maven.org/maven2/commons-codec/commons-codec/1.16.1/commons-codec-1.16.1.jar" && \
     curl -sfLO "https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.26.1/commons-compress-1.26.1.jar"
 
-#
-# Debezium 3.x SMTs placed on the system classpath so they're discoverable by Kafka Connect
-# across all plugins.
-#
+# Debezium 3.x SMTs in their own plugin dir (isolated PluginClassLoader). SMTs are
+# still globally discoverable (Connect's transform lookup spans plugins), and the
+# isolation prevents CloudEventsConverter's ServiceLoader scan from colliding with
+# the YB connector's shaded 1.9.5 CloudEventsProvider SPI.
 ARG DEBEZIUM_SMT_VERSION=3.5.1.Final
-RUN cd $KAFKA_HOME/libs && \
+RUN mkdir -p $KAFKA_CONNECT_PLUGINS_DIR/debezium-smts && \
+    cd $KAFKA_CONNECT_PLUGINS_DIR/debezium-smts && \
     curl -sfLO "https://repo1.maven.org/maven2/io/debezium/debezium-connect-plugins/${DEBEZIUM_SMT_VERSION}/debezium-connect-plugins-${DEBEZIUM_SMT_VERSION}.jar" && \
     curl -sfLO "https://repo1.maven.org/maven2/io/debezium/debezium-connector-common/${DEBEZIUM_SMT_VERSION}/debezium-connector-common-${DEBEZIUM_SMT_VERSION}.jar" && \
     curl -sfLO "https://repo1.maven.org/maven2/io/debezium/debezium-config/${DEBEZIUM_SMT_VERSION}/debezium-config-${DEBEZIUM_SMT_VERSION}.jar" && \


### PR DESCRIPTION
## Problem
Two latent issues surfaced after the dependency-upgrade PR landed:

Logger flood on the new base image. Kafka Connect's runtime logger API (PUT /admin/loggers/<ns> -> DEBUG) is honoured by Kafka 3.9.2. Our custom base used Kafka's default log4j.properties, which has no threshold on the stdout appender, while upstream debezium/connect:1.9.5.Final pinned log4j.appender.stdout.threshold=INFO. Without that threshold, switching a hot-path logger to DEBUG at runtime can dump millions of lines/min to stdout and stall the connector under load.

Debezium SMTs (io.debezium.transforms.ByLogicalTableRouter, etc.) were unreachable. The shaded connector jar strips them via <minimizeJar>true</minimizeJar>. The upstream debezium/connect:1.9.5.Final base used to make them available implicitly by shipping per-Debezium-connector plugin subdirs (db2, mongodb, mysql, …), each carrying its own debezium-core-1.9.5.Final.jar; our slimmer custom base no longer inherits that.

## Solution
Two minimal changes to base_source_image/Dockerfile. The connector code, framework version (debezium:1.9.5.Final), and yb-client are untouched.

Pin stdout appender threshold to INFO, matching upstream. The threshold drops sub-INFO records at the appender even when an individual logger is set to DEBUG via the Connect runtime API. WARN/ERROR still pass through, so the connector's user-visible messages continue to appear; only the DEBUG flood is suppressed.

Bundle a minimal Debezium 3.x SMT dep set as its own plugin at /opt/kafka/connect/debezium-smts/ (not on the system classpath). Five small jars: debezium-connect-plugins, debezium-connector-common, debezium-config, debezium-util, debezium-api, all 3.5.1.Final, make ByLogicalTableRouter and friends discoverable: Kafka Connect's transform lookup is cross-plugin, so any connector can reference them by FQN. We deliberately use the modern 3.x split rather than re-introducing the full debezium-core:1.9.5.Final jar.

The SMT jars run in their own isolated PluginClassLoader, so any internal ServiceLoader scan they do (e.g. CloudEventsConverter.<clinit> looking for CloudEventsProvider impls) is scoped to that classloader and doesn't reach the YB connector plugin's META-INF/services/io.debezium.converters.spi.CloudEventsProvider entry. This avoids the ServiceConfigurationError: ... not a subtype cross-classloader SPI mismatch that putting the 3.x jars on the system classpath would trigger against our shaded 1.9.5 SPI.