### PR TITLE
[DBZ][yugabyte/yugabyte-db#32629] CDCSDK: Support the yb_grpc replication slot plugin

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -403,6 +403,23 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
             public boolean supportsTruncate() {
                 return false;
             }
+        },
+        // Plugin name for gRPC CDC streams created via the PostgreSQL replication-slot syntax.
+        YB_GRPC("yb_grpc") {
+            @Override
+            public MessageDecoder messageDecoder(MessageDecoderContext config) {
+                return new YbProtoMessageDecoder();
+            }
+
+            @Override
+            public String getPostgresPluginName() {
+                return getValue();
+            }
+
+            @Override
+            public boolean supportsTruncate() {
+                return false;
+            }
         };
 
         private final String decoderName;
@@ -773,7 +790,7 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
             .withDefault(DEFAULT_PLUGIN_NAME)
             .withDescription("The name of the Postgres logical decoding plugin installed on the server. " +
                     "Supported values are '" + LogicalDecoder.YBOUTPUT.getValue()
-                    + "'. " +
+                    + "' and '" + LogicalDecoder.YB_GRPC.getValue() + "'. " +
                     "Defaults to '" + LogicalDecoder.YBOUTPUT.getValue() + "'.");
 
     public static final Field SLOT_NAME = Field.create("slot.name")
@@ -786,7 +803,7 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
             .withValidation(YugabyteDBConnectorConfig::validateReplicationSlotName)
             .withDescription("The name of the YSQL logical decoding slot created for streaming changes from a plugin." +
                     "Defaults to 'debezium");
-    
+
     public static final Field DROP_SLOT_ON_STOP = Field.create("slot.drop.on.stop")
             .withDisplayName("Drop slot on stop")
             .withType(Type.BOOLEAN)
@@ -1913,7 +1930,7 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
                 LOGGER.warn(
                         String.format("Error while trying to %s filtered publication. Will retry, attempt %d out of %d",
                                 isUpdate ? "update" : "create", retryCount, maxAttempts));
-                    
+
                 pauseBetweenRetries(config.getLong(RETRY_DELAY_MS));
             }
         }
@@ -1931,7 +1948,7 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
                 LOGGER.trace("Ignoring table {} as it's not included in the filter configuration", tableId);
                 continue;
             }
-            
+
             LOGGER.trace("Adding table {} to the list of captured tables", tableId);
             capturedTables.add(tableId);
         }

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBPublicationReplicationTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBPublicationReplicationTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Unit tests to verify that connector works well with Publication and Replication slots.
  * The minimum service version required for these tests to work is 2.20.2
- * 
+ *
  * @author Sumukh Phalgaonkar (sumukh.phalgaonkar@yugabyte.com)
  */
 public class YugabyteDBPublicationReplicationTest extends YugabyteDBContainerTestBase {
@@ -92,7 +92,7 @@ public class YugabyteDBPublicationReplicationTest extends YugabyteDBContainerTes
         TestHelper.execute(String.format(TestHelper.createPublicationForTableStatement, "pub", "t1"));
         TestHelper.execute(TestHelper.createReplicationSlotStatement);
 
-        Configuration.Builder configBuilder = TestHelper.getConfigBuilderWithPublication("yugabyte", "pub", "test_replication_slot"); 
+        Configuration.Builder configBuilder = TestHelper.getConfigBuilderWithPublication("yugabyte", "pub", "test_replication_slot");
         startEngine(configBuilder);
         final long recordsCount = 1;
 
@@ -107,6 +107,26 @@ public class YugabyteDBPublicationReplicationTest extends YugabyteDBContainerTes
     }
 
     @Test
+    public void testYbGrpcPluginReplicationStreamingConsumption() throws Exception {
+      TestHelper.execute(String.format(TestHelper.createPublicationForTableStatement, PUB_NAME, "t1"));
+      TestHelper.execute("SELECT pg_create_logical_replication_slot('" + SLOT_NAME + "', 'yb_grpc');");
+
+      Configuration.Builder configBuilder = TestHelper.getConfigBuilderWithPublication("yugabyte", PUB_NAME, SLOT_NAME);
+      configBuilder.with(YugabyteDBConnectorConfig.PLUGIN_NAME, YugabyteDBConnectorConfig.LogicalDecoder.YB_GRPC.getValue());
+      startEngine(configBuilder);
+      final long recordsCount = 1;
+
+      awaitUntilConnectorIsReady();
+
+      // Introducing sleep to ensure that we insert the records after bootstrap is completed.
+      Thread.sleep(30000);
+
+      insertRecords(recordsCount);
+
+      verifyPrimaryKeyOnly(recordsCount);
+    }
+
+    @Test
     public void testPublicationReplicationSnapshotConsumption() throws Exception {
         TestHelper.execute("CREATE TABLE IF NOT EXISTS t2_snapshot (id int primary key);");
         TestHelper.execute(String.format(TestHelper.createPublicationForTableStatement, "pub", "t2_snapshot"));
@@ -116,7 +136,8 @@ public class YugabyteDBPublicationReplicationTest extends YugabyteDBContainerTes
         final int recordsCount = 1000;
         TestHelper.executeBulk(insertStatement, recordsCount);
 
-        Configuration.Builder configBuilder = TestHelper.getConfigBuilderWithPublication("yugabyte", "pub", "test_replication_slot"); 
+        Configuration.Builder configBuilder =
+            TestHelper.getConfigBuilderWithPublication("yugabyte", "pub", "test_replication_slot");
         configBuilder.with(YugabyteDBConnectorConfig.SNAPSHOT_MODE, YugabyteDBConnectorConfig.SnapshotMode.INITIAL.getValue());
         startEngine(configBuilder);
 
@@ -566,8 +587,6 @@ public class YugabyteDBPublicationReplicationTest extends YugabyteDBContainerTes
         }).get();
     }
 
-    
-
     private void verifyPrimaryKeyOnly(long recordsCount) {
         List<SourceRecord> records = new ArrayList<>();
         waitAndFailIfCannotConsume(records, recordsCount);
@@ -577,7 +596,7 @@ public class YugabyteDBPublicationReplicationTest extends YugabyteDBContainerTes
             assertValueField(records.get(i), "after/id/value", i);
         }
     }
-    
+
     private boolean dropReplicationSlot() throws Exception {
         try (YugabyteDBConnection ybConnection = TestHelper.create();
              Connection connection = ybConnection.connection()) {


### PR DESCRIPTION
#### Problem
gRPC CDC streams created via the PostgreSQL replication-slot syntax
(CREATE_REPLICATION_SLOT ... LOGICAL yb_grpc) carry the plugin name
`yb_grpc`. The connector rejected such streams at config-validation time
because LogicalDecoder had no matching constant:
```
  java.lang.IllegalArgumentException: No enum constant io.debezium.connector.
  yugabytedb.YugabyteDBConnectorConfig.LogicalDecoder.YB_GRPC
```

#### Solution
This PR adds a YB_GRPC("yb_grpc") value to the LogicalDecoder enum. These streams
are consumed by the gRPC connector and produce yb-proto records, so it
uses the same YbProtoMessageDecoder as YBOUTPUT. Also listed yb_grpc in the
plugin.name field description.

#### Test Plan
Added YugabyteDBPublicationReplicationTest#testYbGrpcPluginReplicationStreamingConsumption for verifying the change.