### PR TITLE
[DBZ][yugabyte/yugabyte-db#32752] Add per-tablet heartbeat support to the gRPC connector

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
@@ -240,6 +240,8 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
 
                                     tabletSafeTime.put(part.getId(), response.getResp().getSafeHybridTime());
 
+                                    maybeEmitTabletHeartbeat(part, offsetContext);
+
                                     LOGGER.debug("The final opid for tablet {} is {}", part.getTabletId(), finalOpid);
                                 }
                             }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
@@ -155,6 +155,8 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
                             curTabletId = entry.getValue();
                             YBPartition part = new YBPartition(entry.getKey(), tabletId, false);
 
+                            maybeEmitTabletHeartbeat(part, offsetContext);
+
                             OpId cp = offsetContext.lsn(part);
 
                             YBTable table = tableIdToTable.get(entry.getKey());
@@ -239,8 +241,6 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
                                     offsetContext.updateWalSegmentIndex(part, response.getWalSegmentIndex());
 
                                     tabletSafeTime.put(part.getId(), response.getResp().getSafeHybridTime());
-
-                                    maybeEmitTabletHeartbeat(part, offsetContext);
 
                                     LOGGER.debug("The final opid for tablet {} is {}", part.getTabletId(), finalOpid);
                                 }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBEventDispatcher.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBEventDispatcher.java
@@ -33,6 +33,7 @@ import io.debezium.pipeline.spi.Partition;
 import io.debezium.util.SchemaNameAdjuster;
 
 import java.util.EnumSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -179,6 +180,24 @@ public class YugabyteDBEventDispatcher<T extends DataCollectionId> extends Event
 
     private void enqueueTransactionMessage(SourceRecord record) throws InterruptedException {
         queue.enqueue(new DataChangeEvent(record));
+    }
+
+    public void dispatchHeartbeatEvent(YBPartition partition, Map<String, ?> offset) throws InterruptedException {
+        heartbeat.forcedBeat(partition.getSourcePartition(), offset, this::enqueueHeartbeat);
+    }
+
+    private void enqueueHeartbeat(SourceRecord record) throws InterruptedException {
+        queue.enqueue(new DataChangeEvent(record));
+    }
+
+    @Override
+    public void close() {
+        try {
+            heartbeat.close();
+        }
+        finally {
+            super.close();
+        }
     }
 
     private void enqueueLogicalDecodingMessage(SourceRecord record) throws InterruptedException {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -62,7 +62,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
     private final YugabyteDBSchema schema;
     private final SnapshotProgressListener snapshotProgressListener;
     private final YugabyteDBTaskContext taskContext;
-    private final EventDispatcher<YBPartition,TableId> dispatcher;
+    private final YugabyteDBEventDispatcher<TableId> dispatcher;
     protected final Clock clock;
     private final Snapshotter snapshotter;
     private final YugabyteDBConnection connection;
@@ -394,10 +394,8 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
     }
 
     /**
-     * Emit a heartbeat for the given tablet if the heartbeat interval has elapsed since its last one.
-     * A snapshot can run for a long time and a single heartbeat at completion would be lost if the
-     * task died before it was flushed, so tablets are paced through the snapshot the same way they
-     * are while streaming.
+     * Emit a heartbeat for the tablet if its interval has elapsed. A snapshot can run for a long time
+     * and a single beat at completion would be lost if the task died before it was flushed.
      */
     private void maybeEmitSnapshotHeartbeat(YBPartition part, YugabyteDBOffsetContext offsetContext) {
         if (!dispatcher.heartbeatsEnabled()) {
@@ -411,7 +409,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
         }
 
         try {
-            dispatcher.alwaysDispatchHeartbeatEvent(part, offsetContext);
+            dispatcher.dispatchHeartbeatEvent(part, offsetContext.getOffset(part));
             tabletToLastSnapshotHeartbeatMs.put(part.getId(), currentTimeMs);
         }
         catch (InterruptedException e) {
@@ -525,7 +523,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                     if (dispatcher.heartbeatsEnabled()) {
                         for (Pair<String, String> tablet : tableToTabletForSnapshot) {
                             YBPartition hbPartition = new YBPartition(tablet.getKey(), tablet.getValue(), true);
-                            dispatcher.alwaysDispatchHeartbeatEvent(hbPartition, previousOffset);
+                            dispatcher.dispatchHeartbeatEvent(hbPartition, previousOffset.getOffset(hbPartition));
                         }
                     }
                     return SnapshotResult.completed(previousOffset);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -82,6 +82,10 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
     protected List<HashPartition> partitionRanges;
 
     private boolean snapshotComplete = false;
+
+    // Per-tablet last heartbeat emit time (ms), to pace heartbeats through a long snapshot.
+    private final Map<String, Long> tabletToLastSnapshotHeartbeatMs = new HashMap<>();
+    private final long heartbeatIntervalMs;
     private Map<String, Long> lastGetChangesTime;
     private final String LAST_SNAPSHOT_RECORD_KEY = "LAST_SNAPSHOT_RECORD";
 
@@ -102,6 +106,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
         this.snapshotter = snapshotter;
         this.connection = connection;
         this.snapshotProgressListener = snapshotProgressListener;
+        this.heartbeatIntervalMs = connectorConfig.getHeartbeatInterval().toMillis();
 
         AsyncYBClient asyncClient = new AsyncYBClient.AsyncYBClientBuilder(connectorConfig.masterAddresses())
             .defaultAdminOperationTimeoutMs(connectorConfig.adminOperationTimeoutMs())
@@ -388,6 +393,32 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
       }
     }
 
+    /**
+     * Emit a heartbeat for the given tablet if the heartbeat interval has elapsed since its last one.
+     * A snapshot can run for a long time and a single heartbeat at completion would be lost if the
+     * task died before it was flushed, so tablets are paced through the snapshot the same way they
+     * are while streaming.
+     */
+    private void maybeEmitSnapshotHeartbeat(YBPartition part, YugabyteDBOffsetContext offsetContext) {
+        if (!dispatcher.heartbeatsEnabled()) {
+            return;
+        }
+
+        long currentTimeMs = clock.currentTimeInMillis();
+        Long lastHeartbeatMs = tabletToLastSnapshotHeartbeatMs.putIfAbsent(part.getId(), currentTimeMs);
+        if (lastHeartbeatMs == null || currentTimeMs - lastHeartbeatMs < heartbeatIntervalMs) {
+            return;
+        }
+
+        try {
+            dispatcher.alwaysDispatchHeartbeatEvent(part, offsetContext);
+            tabletToLastSnapshotHeartbeatMs.put(part.getId(), currentTimeMs);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
     protected SnapshotResult<YugabyteDBOffsetContext> doExecute(ChangeEventSourceContext context, YBPartition partition, YugabyteDBOffsetContext previousOffset,
                                                                 SnapshotContext<YBPartition, YugabyteDBOffsetContext> snapshotContext,
                                                                 SnapshottingTask snapshottingTask)
@@ -482,6 +513,8 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
 
                 String tabletId = tableIdToTabletId.getValue();
                 YBPartition part = new YBPartition(tableUUID, tabletId, true /* colocated */);
+
+                maybeEmitSnapshotHeartbeat(part, previousOffset);
 
                  // Check if snapshot is completed here, if it is, then break out of the loop
                 if (snapshotCompletedTablets.size() == tableToTabletForSnapshot.size()) {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -487,6 +487,14 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                 if (snapshotCompletedTablets.size() == tableToTabletForSnapshot.size()) {
                     LOGGER.info("Snapshot completed for all the tablets");
                     this.snapshotComplete = true;
+                    // Emit one heartbeat per tablet at snapshot completion so each tablet's checkpoint is
+                    // flushed at the snapshot boundary.
+                    if (dispatcher.heartbeatsEnabled()) {
+                        for (Pair<String, String> tablet : tableToTabletForSnapshot) {
+                            YBPartition hbPartition = new YBPartition(tablet.getKey(), tablet.getValue(), true);
+                            dispatcher.alwaysDispatchHeartbeatEvent(hbPartition, previousOffset);
+                        }
+                    }
                     return SnapshotResult.completed(previousOffset);
                 }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -882,7 +882,7 @@ public class YugabyteDBStreamingChangeEventSource implements
         return explicitCheckpoint;
     }
 
-    private void maybeEmitTabletHeartbeat(YBPartition part, YugabyteDBOffsetContext offsetContext) {
+    protected void maybeEmitTabletHeartbeat(YBPartition part, YugabyteDBOffsetContext offsetContext) {
         if (!dispatcher.heartbeatsEnabled()) {
             return;
         }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -483,6 +483,12 @@ public class YugabyteDBStreamingChangeEventSource implements
                             curTabletId = entry.getValue();
                             YBPartition part = new YBPartition(entry.getKey() /* tableId */, tabletId, false /* colocated */);
 
+                            // Give every tablet its chance to beat before anything can skip it. A tablet
+                            // waiting on a split callback, or one whose GetChanges keeps failing, is never
+                            // reached later in this pass and would otherwise go silent exactly when its
+                            // checkpoint needs to keep moving.
+                            maybeEmitTabletHeartbeat(part, offsetContext);
+
                             OpId cp = offsetContext.lsn(part);
 
                             if (taskContext.shouldEnableExplicitCheckpointing()
@@ -824,8 +830,6 @@ public class YugabyteDBStreamingChangeEventSource implements
                                     tabletToExplicitCheckpoint.put(part.getId(), finalOpid.toCdcSdkCheckpoint());
                                 }
                             }
-
-                            maybeEmitTabletHeartbeat(part, offsetContext);
 
                             LOGGER.debug("The final opid for tablet {} is {}", part.getId(), finalOpid);
                         }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -896,7 +896,7 @@ public class YugabyteDBStreamingChangeEventSource implements
             return;
         }
         try {
-            dispatcher.dispatchHeartbeatEvent(part, offsetContext.getOffset());
+            dispatcher.dispatchHeartbeatEvent(part, offsetContext.getOffset(part));
             tabletToLastHeartbeatMs.put(part.getId(), currentTimeMs);
         }
         catch (InterruptedException e) {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -96,6 +96,10 @@ public class YugabyteDBStreamingChangeEventSource implements
 
     protected Map<String, CdcSdkCheckpoint> tabletToExplicitCheckpoint;
 
+    // Per-tablet last heartbeat emit time (ms), to pace per-tablet heartbeats.
+    protected final Map<String, Long> tabletToLastHeartbeatMs = new ConcurrentHashMap<>();
+    protected final long heartbeatIntervalMs;
+
     protected final Filters filters;
 
     // This timer is used to log the offset map periodically.
@@ -133,6 +137,7 @@ public class YugabyteDBStreamingChangeEventSource implements
         yugabyteDBTypeRegistry = taskContext.schema().getTypeRegistry();
         this.queue = queue;
         this.tabletToExplicitCheckpoint = new ConcurrentHashMap<>();
+        this.heartbeatIntervalMs = connectorConfig.getHeartbeatInterval().toMillis();
         this.splitTabletsWaitingForCallback = new HashSet<>();
         this.filters = new Filters(connectorConfig);
         this.partitionRanges = new ArrayList<>();
@@ -820,6 +825,8 @@ public class YugabyteDBStreamingChangeEventSource implements
                                 }
                             }
 
+                            maybeEmitTabletHeartbeat(part, offsetContext);
+
                             LOGGER.debug("The final opid for tablet {} is {}", part.getId(), finalOpid);
                         }
                         // Reset the retry count, because if flow reached at this point, it means that the connection
@@ -873,6 +880,24 @@ public class YugabyteDBStreamingChangeEventSource implements
         }
 
         return explicitCheckpoint;
+    }
+
+    private void maybeEmitTabletHeartbeat(YBPartition part, YugabyteDBOffsetContext offsetContext) {
+        if (!dispatcher.heartbeatsEnabled()) {
+            return;
+        }
+        long currentTimeMs = clock.currentTimeInMillis();
+        Long lastHeartbeatMs = tabletToLastHeartbeatMs.putIfAbsent(part.getId(), currentTimeMs);
+        if (lastHeartbeatMs == null || currentTimeMs - lastHeartbeatMs < heartbeatIntervalMs) {
+            return;
+        }
+        try {
+            dispatcher.dispatchHeartbeatEvent(part, offsetContext.getOffset());
+            tabletToLastHeartbeatMs.put(part.getId(), currentTimeMs);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     /**

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBHeartbeatTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBHeartbeatTest.java
@@ -173,4 +173,66 @@ public class YugabyteDBHeartbeatTest extends YugabyteDBContainerTestBase {
 
         engine.stop();
     }
+
+    private static Set<String> distinctTablets(List<SourceRecord> records) {
+        Set<String> tablets = new HashSet<>();
+        for (SourceRecord r : records) {
+            Map<String, ?> offset = r.sourceOffset();
+            if (offset == null) {
+                continue;
+            }
+            for (String key : offset.keySet()) {
+                if ("transaction_id".equals(key)) {
+                    continue;
+                }
+                int dot = key.lastIndexOf('.');
+                tablets.add(dot < 0 ? key : key.substring(dot + 1));
+            }
+        }
+        return tablets;
+    }
+
+    @Test
+    public void snapshotCompletionEmitsHeartbeatPerTablet() throws Exception {
+        TestHelper.execute("CREATE TABLE t1 (id INT PRIMARY KEY, name TEXT) SPLIT INTO 3 TABLETS;");
+        for (int i = 1; i <= 30; ++i) {
+            TestHelper.execute("INSERT INTO t1 VALUES (" + i + ", 'snap" + i + "');");
+        }
+        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", false /* before image */,
+                true /* explicit checkpointing */, false, false);
+        Configuration config = TestHelper.getConfigBuilder("public.t1", dbStreamId)
+                .with(EmbeddedEngine.ENGINE_NAME, "heartbeat-snapshot-test")
+                .with(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG,
+                        Testing.Files.createTestingFile("heartbeat-snapshot-offsets.txt").getAbsolutePath())
+                .with(EmbeddedEngine.OFFSET_FLUSH_INTERVAL_MS, 0)
+                .with(EmbeddedEngine.CONNECTOR_CLASS, YugabyteDBgRPCConnector.class)
+                .with("heartbeat.interval.ms", 600000)
+                .with("snapshot.mode", "initial")
+                .build();
+
+        runEngine(config);
+        awaitUntilConnectorIsReady();
+
+        // All 30 pre-inserted rows are delivered by the snapshot.
+        Awaitility.await().atMost(Duration.ofSeconds(60)).until(() -> snapshotOf(".t1").size() >= 30);
+        long lastSnapshotIndex = snapshotOf(".t1").stream()
+                .mapToLong(YugabyteDBHeartbeatTest::tabletMaxIndex).max().orElse(-1);
+        assertTrue(lastSnapshotIndex > 0, "expected snapshot offsets to be captured");
+
+        int tabletCount = distinctTablets(new ArrayList<>(captured)).size();
+        Awaitility.await().atMost(Duration.ofSeconds(60)).until(() -> heartbeats().size() >= tabletCount);
+
+        List<SourceRecord> hbs = heartbeats();
+        LOGGER.info("snapshot-completion heartbeats={} tabletCount={}", hbs.size(), tabletCount);
+        assertEquals(tabletCount, hbs.size(),
+                "expected exactly one snapshot-completion heartbeat per tablet (" + tabletCount
+                        + " tablets), got " + hbs.size());
+
+        long maxHeartbeatIndex = hbs.stream().mapToLong(YugabyteDBHeartbeatTest::tabletMaxIndex).max().orElse(-1);
+        assertTrue(maxHeartbeatIndex >= lastSnapshotIndex,
+                "snapshot-completion heartbeat checkpoint index " + maxHeartbeatIndex
+                        + " should be at least the last snapshot record index " + lastSnapshotIndex);
+
+        engine.stop();
+    }
 }

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBHeartbeatTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBHeartbeatTest.java
@@ -21,6 +21,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
+import org.yb.client.GetCheckpointResponse;
+import org.yb.client.YBClient;
+import org.yb.client.YBTable;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -85,6 +89,10 @@ public class YugabyteDBHeartbeatTest extends YugabyteDBContainerTestBase {
         return new ArrayList<>(captured).stream()
                 .filter(r -> r.topic() != null && r.topic().endsWith(suffix))
                 .collect(Collectors.toList());
+    }
+
+    private List<SourceRecord> dataRecords() {
+        return snapshotOf(".t1");
     }
 
     private List<SourceRecord> heartbeats() {
@@ -232,6 +240,155 @@ public class YugabyteDBHeartbeatTest extends YugabyteDBContainerTestBase {
         assertTrue(maxHeartbeatIndex >= lastSnapshotIndex,
                 "snapshot-completion heartbeat checkpoint index " + maxHeartbeatIndex
                         + " should be at least the last snapshot record index " + lastSnapshotIndex);
+
+        engine.stop();
+    }
+
+    private static long serverCheckpointIndex(YBClient client, YBTable table, String streamId, String tabletId)
+            throws Exception {
+        GetCheckpointResponse response = client.getCheckpoint(table, streamId, tabletId);
+        return response.getIndex();
+    }
+
+    @Test
+    public void heartbeatsAdvanceExplicitCheckpointOnServerWhileRecordsAreFiltered() throws Exception {
+        TestHelper.execute("CREATE TABLE t1 (id INT PRIMARY KEY, name TEXT) SPLIT INTO 2 TABLETS;");
+        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", false /* before image */,
+                true /* explicit checkpointing */, false, false);
+        Configuration config = TestHelper.getConfigBuilder("public.t1", dbStreamId)
+                .with(EmbeddedEngine.ENGINE_NAME, "heartbeat-server-checkpoint-test")
+                .with(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG,
+                        Testing.Files.createTestingFile("heartbeat-server-checkpoint.txt").getAbsolutePath())
+                .with(EmbeddedEngine.OFFSET_FLUSH_INTERVAL_MS, 0)
+                .with("heartbeat.interval.ms", 5000)
+                .with("skipped.operations", "u")
+                .with(EmbeddedEngine.CONNECTOR_CLASS, YugabyteDBgRPCConnector.class)
+                .build();
+
+        runEngine(config);
+        awaitUntilConnectorIsReady();
+
+        for (int i = 0; i < 50; ++i) {
+            TestHelper.execute("INSERT INTO t1 VALUES (" + i + ", 'inserted');");
+        }
+        Awaitility.await().atMost(Duration.ofSeconds(60)).until(() -> dataRecords().size() >= 40);
+
+        YBClient ybClient = TestHelper.getYbClient(getMasterAddress());
+        try {
+            YBTable table = TestHelper.getYbTable(ybClient, "t1");
+            Set<String> tablets = ybClient.getTabletUUIDs(table);
+
+            Map<String, Long> before = new HashMap<>();
+            for (String tabletId : tablets) {
+                before.put(tabletId, serverCheckpointIndex(ybClient, table, dbStreamId, tabletId));
+            }
+
+            // Every further change is an update, which the filter drops before it can be produced,
+            // so nothing but a heartbeat can carry these tablets' checkpoints forward.
+            for (int round = 0; round < 5; ++round) {
+                TestHelper.execute("UPDATE t1 SET name = 'filtered-" + round + "';");
+                TestHelper.waitFor(Duration.ofSeconds(3));
+            }
+
+            Awaitility.await().atMost(Duration.ofSeconds(90)).until(() -> {
+                for (String tabletId : tablets) {
+                    if (serverCheckpointIndex(ybClient, table, dbStreamId, tabletId) <= before.get(tabletId)) {
+                        return false;
+                    }
+                }
+                return true;
+            });
+        }
+        finally {
+            ybClient.close();
+        }
+
+        engine.stop();
+    }
+
+    @Test
+    public void heartbeatsFlowForATabletWhoseEveryRecordIsFiltered() throws Exception {
+        // Range sharded with a split point so all writes land in one tablet; the other tablet never
+        // has a record of its own, and the written tablet has all of its changes filtered away.
+        TestHelper.execute("CREATE TABLE t1 (id INT, name TEXT, PRIMARY KEY (id ASC)) SPLIT AT VALUES ((5000));");
+        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", false /* before image */,
+                true /* explicit checkpointing */, false, false);
+        Configuration config = TestHelper.getConfigBuilder("public.t1", dbStreamId)
+                .with(EmbeddedEngine.ENGINE_NAME, "heartbeat-filtered-tablet-test")
+                .with(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG,
+                        Testing.Files.createTestingFile("heartbeat-filtered-tablet.txt").getAbsolutePath())
+                .with(EmbeddedEngine.OFFSET_FLUSH_INTERVAL_MS, 0)
+                .with("heartbeat.interval.ms", 5000)
+                .with("skipped.operations", "u")
+                .with(EmbeddedEngine.CONNECTOR_CLASS, YugabyteDBgRPCConnector.class)
+                .build();
+
+        runEngine(config);
+        awaitUntilConnectorIsReady();
+
+        for (int i = 0; i < 30; ++i) {
+            TestHelper.execute("INSERT INTO t1 VALUES (" + i + ", 'below-split');");
+        }
+        Awaitility.await().atMost(Duration.ofSeconds(60)).until(() -> dataRecords().size() >= 20);
+
+        long heartbeatsBefore = heartbeats().size();
+        for (int round = 0; round < 5; ++round) {
+            TestHelper.execute("UPDATE t1 SET name = 'filtered-" + round + "' WHERE id < 5000;");
+            TestHelper.waitFor(Duration.ofSeconds(3));
+        }
+
+        // Heartbeats must keep flowing for both tablets: the one whose records were all filtered and
+        // the one that never had any.
+        Awaitility.await().atMost(Duration.ofSeconds(90))
+                .until(() -> heartbeats().size() - heartbeatsBefore >= 2);
+        Set<String> heartbeatTablets = distinctTablets(heartbeats());
+        assertEquals(2, heartbeatTablets.size(),
+                "expected heartbeats for both tablets, saw: " + heartbeatTablets);
+
+        engine.stop();
+    }
+
+    @Test
+    public void heartbeatsFlowWhenEverySnapshotRecordIsFiltered() throws Exception {
+        TestHelper.execute("CREATE TABLE t1 (id INT PRIMARY KEY, name TEXT) SPLIT INTO 3 TABLETS;");
+        for (int i = 0; i < 60; ++i) {
+            TestHelper.execute("INSERT INTO t1 VALUES (" + i + ", 'pre-existing');");
+        }
+
+        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", false /* before image */,
+                true /* explicit checkpointing */, true, true);
+        Configuration config = TestHelper.getConfigBuilder("public.t1", dbStreamId)
+                .with(EmbeddedEngine.ENGINE_NAME, "heartbeat-filtered-snapshot-test")
+                .with(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG,
+                        Testing.Files.createTestingFile("heartbeat-filtered-snapshot.txt").getAbsolutePath())
+                .with(EmbeddedEngine.OFFSET_FLUSH_INTERVAL_MS, 0)
+                .with("heartbeat.interval.ms", 5000)
+                .with("snapshot.mode", "initial")
+                // Snapshot rows are read events, so filtering them leaves the snapshot with nothing
+                // to produce for any tablet.
+                .with("skipped.operations", "r")
+                .with(EmbeddedEngine.CONNECTOR_CLASS, YugabyteDBgRPCConnector.class)
+                .build();
+
+        runEngine(config);
+        awaitUntilConnectorIsReady();
+
+        YBClient ybClient = TestHelper.getYbClient(getMasterAddress());
+        try {
+            YBTable table = TestHelper.getYbTable(ybClient, "t1");
+            Set<String> tablets = ybClient.getTabletUUIDs(table);
+
+            // No snapshot record reaches Kafka, so only heartbeats can report progress; one per
+            // tablet has to arrive by the time the snapshot boundary is crossed.
+            Awaitility.await().atMost(Duration.ofSeconds(120))
+                    .until(() -> distinctTablets(heartbeats()).size() >= tablets.size());
+
+            assertTrue(dataRecords().isEmpty(),
+                    "expected every snapshot record to be filtered, saw " + dataRecords().size());
+        }
+        finally {
+            ybClient.close();
+        }
 
         engine.stop();
     }

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBHeartbeatTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBHeartbeatTest.java
@@ -1,0 +1,176 @@
+package io.debezium.connector.yugabytedb;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
+import io.debezium.embedded.EmbeddedEngine;
+import io.debezium.engine.spi.OffsetCommitPolicy;
+import io.debezium.util.LoggingContext;
+import io.debezium.util.Testing;
+import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies the per-tablet timer heartbeat: with updates filtered out (skipped.operations=u), the tablet
+ * keeps advancing its checkpoint, the heartbeats carry an offset past the last delivered insert, and
+ * streaming still resumes for later inserts.
+ */
+public class YugabyteDBHeartbeatTest extends YugabyteDBContainerTestBase {
+    private static final Logger LOGGER = LoggerFactory.getLogger(YugabyteDBHeartbeatTest.class);
+    private final List<SourceRecord> captured = Collections.synchronizedList(new ArrayList<>());
+
+    @BeforeAll
+    public static void beforeAll() throws SQLException {
+        initializeYBContainer();
+        TestHelper.dropAllSchemas();
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        captured.clear();
+    }
+
+    @AfterEach
+    public void afterEach() throws Exception {
+        stopConnector();
+        TestHelper.executeDDL("drop_tables_and_databases.ddl");
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        shutdownYBContainer();
+    }
+
+    private void runEngine(Configuration config) {
+        CountDownLatch latch = new CountDownLatch(1);
+        engine = EmbeddedEngine.create()
+                .using(config)
+                .using(OffsetCommitPolicy.always())
+                .notifying((records, committer) -> {
+                    for (SourceRecord record : records) {
+                        committer.markProcessed(record);
+                        captured.add(record);
+                    }
+                    committer.markBatchFinished();
+                })
+                .using(this.getClass().getClassLoader())
+                .using((success, message, error) -> {
+                    if (error != null) {
+                        LOGGER.error("Engine error", error);
+                    }
+                    latch.countDown();
+                })
+                .build();
+        ExecutorService exec = Executors.newFixedThreadPool(1);
+        exec.execute(() -> {
+            LoggingContext.forConnector(getClass().getSimpleName(), "", "engine");
+            engine.run();
+        });
+    }
+
+    private List<SourceRecord> snapshotOf(String suffix) {
+        return new ArrayList<>(captured).stream()
+                .filter(r -> r.topic() != null && r.topic().endsWith(suffix))
+                .collect(Collectors.toList());
+    }
+
+    private List<SourceRecord> heartbeats() {
+        return new ArrayList<>(captured).stream()
+                .filter(r -> r.topic() != null && r.topic().startsWith("__debezium-heartbeat"))
+                .collect(Collectors.toList());
+    }
+
+    // Highest tablet checkpoint index found in a record's sourceOffset. Offset values are OpId
+    // strings "term:index:key:write_id:time"; index is the second field.
+    private static long tabletMaxIndex(SourceRecord record) {
+        long max = -1;
+        Map<String, ?> offset = record.sourceOffset();
+        if (offset == null) {
+            return max;
+        }
+        for (Map.Entry<String, ?> e : offset.entrySet()) {
+            if ("transaction_id".equals(e.getKey()) || !(e.getValue() instanceof String)) {
+                continue;
+            }
+            String[] parts = ((String) e.getValue()).split(":");
+            if (parts.length >= 2) {
+                try {
+                    max = Math.max(max, Long.parseLong(parts[1].trim()));
+                }
+                catch (NumberFormatException ignored) {
+                }
+            }
+        }
+        return max;
+    }
+
+    @Test
+    public void heartbeatCarriesCheckpointPastFilteredUpdatesAndStreamingResumes() throws Exception {
+        TestHelper.execute("CREATE TABLE t1 (id INT PRIMARY KEY, name TEXT);");
+        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", false /* before image */,
+                true /* explicit checkpointing */, false, false);
+        Configuration config = TestHelper.getConfigBuilder("public.t1", dbStreamId)
+                .with(EmbeddedEngine.ENGINE_NAME, "heartbeat-test")
+                .with(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG,
+                        Testing.Files.createTestingFile("heartbeat-offsets.txt").getAbsolutePath())
+                .with(EmbeddedEngine.OFFSET_FLUSH_INTERVAL_MS, 0)
+                .with(EmbeddedEngine.CONNECTOR_CLASS, YugabyteDBgRPCConnector.class)
+                .with("heartbeat.interval.ms", 10000)
+                .with("skipped.operations", "u")
+                .build();
+
+        runEngine(config);
+        awaitUntilConnectorIsReady();
+
+        // 10 inserts are delivered (op=c).
+        for (int i = 1; i <= 10; ++i) {
+            TestHelper.execute("INSERT INTO t1 VALUES (" + i + ", 'ins" + i + "');");
+        }
+        Awaitility.await().atMost(Duration.ofSeconds(30)).until(() -> snapshotOf(".t1").size() >= 10);
+        long lastInsertIndex = snapshotOf(".t1").stream().mapToLong(YugabyteDBHeartbeatTest::tabletMaxIndex).max().orElse(-1);
+        assertTrue(lastInsertIndex > 0, "expected insert offsets to be captured");
+
+        long heartbeatsBeforeIdle = heartbeats().size();
+
+        // 10 updates are filtered out (op=u) but still advance the tablet position.
+        for (int i = 1; i <= 10; ++i) {
+            TestHelper.execute("UPDATE t1 SET name = 'upd" + i + "' WHERE id = " + i + ";");
+        }
+
+        // Idle for ~65s: with a 10s interval, only heartbeats should flow.
+        TestHelper.waitFor(Duration.ofSeconds(65));
+
+        List<SourceRecord> hbs = heartbeats();
+        long duringIdle = hbs.size() - heartbeatsBeforeIdle;
+        assertTrue(duringIdle >= 5,
+                "expected >=5 heartbeats over ~65s at 10s interval, got " + duringIdle);
+
+        long maxHeartbeatIndex = hbs.stream().mapToLong(YugabyteDBHeartbeatTest::tabletMaxIndex).max().orElse(-1);
+        assertTrue(maxHeartbeatIndex > lastInsertIndex,
+                "heartbeat checkpoint index " + maxHeartbeatIndex
+                        + " should be past the last delivered insert index " + lastInsertIndex
+                        + " (filtered updates must advance the checkpoint)");
+
+        // Streaming still works after the filtered/idle stretch: later inserts are delivered.
+        long dataBeforeResume = snapshotOf(".t1").size();
+        for (int i = 11; i <= 15; ++i) {
+            TestHelper.execute("INSERT INTO t1 VALUES (" + i + ", 'ins" + i + "');");
+        }
+        Awaitility.await().atMost(Duration.ofSeconds(30)).until(() -> snapshotOf(".t1").size() >= dataBeforeResume + 5);
+
+        engine.stop();
+    }
+}

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBHeartbeatTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBHeartbeatTest.java
@@ -153,6 +153,11 @@ public class YugabyteDBHeartbeatTest extends YugabyteDBContainerTestBase {
 
         long heartbeatsBeforeIdle = heartbeats().size();
 
+        YBClient ybClient = TestHelper.getYbClient(getMasterAddress());
+        YBTable table = TestHelper.getYbTable(ybClient, "t1");
+        String tabletId = ybClient.getTabletUUIDs(table).iterator().next();
+        long checkpointBeforeIdle = serverCheckpointIndex(ybClient, table, dbStreamId, tabletId);
+
         // 10 updates are filtered out (op=u) but still advance the tablet position.
         for (int i = 1; i <= 10; ++i) {
             TestHelper.execute("UPDATE t1 SET name = 'upd" + i + "' WHERE id = " + i + ";");
@@ -171,6 +176,12 @@ public class YugabyteDBHeartbeatTest extends YugabyteDBContainerTestBase {
                 "heartbeat checkpoint index " + maxHeartbeatIndex
                         + " should be past the last delivered insert index " + lastInsertIndex
                         + " (filtered updates must advance the checkpoint)");
+
+        // Carrying the position on the record is only half of it: the acknowledged heartbeat has to
+        // reach the server, so cdc_state must have moved past where it was before the idle window.
+        Awaitility.await().atMost(Duration.ofSeconds(60)).until(
+                () -> serverCheckpointIndex(ybClient, table, dbStreamId, tabletId) > checkpointBeforeIdle);
+        ybClient.close();
 
         // Streaming still works after the filtered/idle stretch: later inserts are delivered.
         long dataBeforeResume = snapshotOf(".t1").size();
@@ -241,58 +252,15 @@ public class YugabyteDBHeartbeatTest extends YugabyteDBContainerTestBase {
                 "snapshot-completion heartbeat checkpoint index " + maxHeartbeatIndex
                         + " should be at least the last snapshot record index " + lastSnapshotIndex);
 
-        engine.stop();
-    }
-
-    private static long serverCheckpointIndex(YBClient client, YBTable table, String streamId, String tabletId)
-            throws Exception {
-        GetCheckpointResponse response = client.getCheckpoint(table, streamId, tabletId);
-        return response.getIndex();
-    }
-
-    @Test
-    public void heartbeatsAdvanceExplicitCheckpointOnServerWhileRecordsAreFiltered() throws Exception {
-        TestHelper.execute("CREATE TABLE t1 (id INT PRIMARY KEY, name TEXT) SPLIT INTO 2 TABLETS;");
-        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", false /* before image */,
-                true /* explicit checkpointing */, false, false);
-        Configuration config = TestHelper.getConfigBuilder("public.t1", dbStreamId)
-                .with(EmbeddedEngine.ENGINE_NAME, "heartbeat-server-checkpoint-test")
-                .with(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG,
-                        Testing.Files.createTestingFile("heartbeat-server-checkpoint.txt").getAbsolutePath())
-                .with(EmbeddedEngine.OFFSET_FLUSH_INTERVAL_MS, 0)
-                .with("heartbeat.interval.ms", 5000)
-                .with("skipped.operations", "u")
-                .with(EmbeddedEngine.CONNECTOR_CLASS, YugabyteDBgRPCConnector.class)
-                .build();
-
-        runEngine(config);
-        awaitUntilConnectorIsReady();
-
-        for (int i = 0; i < 50; ++i) {
-            TestHelper.execute("INSERT INTO t1 VALUES (" + i + ", 'inserted');");
-        }
-        Awaitility.await().atMost(Duration.ofSeconds(60)).until(() -> dataRecords().size() >= 40);
-
+        // The snapshot boundary beat has to land in cdc_state, otherwise the checkpoint the snapshot
+        // reached is lost the moment streaming takes over.
         YBClient ybClient = TestHelper.getYbClient(getMasterAddress());
         try {
             YBTable table = TestHelper.getYbTable(ybClient, "t1");
             Set<String> tablets = ybClient.getTabletUUIDs(table);
-
-            Map<String, Long> before = new HashMap<>();
-            for (String tabletId : tablets) {
-                before.put(tabletId, serverCheckpointIndex(ybClient, table, dbStreamId, tabletId));
-            }
-
-            // Every further change is an update, which the filter drops before it can be produced,
-            // so nothing but a heartbeat can carry these tablets' checkpoints forward.
-            for (int round = 0; round < 5; ++round) {
-                TestHelper.execute("UPDATE t1 SET name = 'filtered-" + round + "';");
-                TestHelper.waitFor(Duration.ofSeconds(3));
-            }
-
             Awaitility.await().atMost(Duration.ofSeconds(90)).until(() -> {
                 for (String tabletId : tablets) {
-                    if (serverCheckpointIndex(ybClient, table, dbStreamId, tabletId) <= before.get(tabletId)) {
+                    if (serverCheckpointIndex(ybClient, table, dbStreamId, tabletId) <= 0) {
                         return false;
                     }
                 }
@@ -306,11 +274,24 @@ public class YugabyteDBHeartbeatTest extends YugabyteDBContainerTestBase {
         engine.stop();
     }
 
+    private static long serverCheckpointIndex(YBClient client, YBTable table, String streamId, String tabletId)
+            throws Exception {
+        GetCheckpointResponse response = client.getCheckpoint(table, streamId, tabletId);
+        return response.getIndex();
+    }
+
+
     @Test
-    public void heartbeatsFlowForATabletWhoseEveryRecordIsFiltered() throws Exception {
-        // Range sharded with a split point so all writes land in one tablet; the other tablet never
-        // has a record of its own, and the written tablet has all of its changes filtered away.
+    public void heartbeatsAdvanceATabletWhoseEveryRecordIsFiltered() throws Exception {
+        // Range sharded with a split point, seeded on both sides before the stream exists. The
+        // connector never snapshots, so the only records it ever sees are the updates below, every one
+        // of which the filter drops: both tablets have WAL of their own and nothing shippable.
         TestHelper.execute("CREATE TABLE t1 (id INT, name TEXT, PRIMARY KEY (id ASC)) SPLIT AT VALUES ((5000));");
+        for (int i = 0; i < 30; ++i) {
+            TestHelper.execute("INSERT INTO t1 VALUES (" + i + ", 'pre-existing');");
+            TestHelper.execute("INSERT INTO t1 VALUES (" + (6000 + i) + ", 'pre-existing');");
+        }
+
         String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", false /* before image */,
                 true /* explicit checkpointing */, false, false);
         Configuration config = TestHelper.getConfigBuilder("public.t1", dbStreamId)
@@ -326,24 +307,43 @@ public class YugabyteDBHeartbeatTest extends YugabyteDBContainerTestBase {
         runEngine(config);
         awaitUntilConnectorIsReady();
 
-        for (int i = 0; i < 30; ++i) {
-            TestHelper.execute("INSERT INTO t1 VALUES (" + i + ", 'below-split');");
-        }
-        Awaitility.await().atMost(Duration.ofSeconds(60)).until(() -> dataRecords().size() >= 20);
+        YBClient ybClient = TestHelper.getYbClient(getMasterAddress());
+        try {
+            YBTable table = TestHelper.getYbTable(ybClient, "t1");
+            Set<String> tablets = ybClient.getTabletUUIDs(table);
+            assertEquals(2, tablets.size(), "expected the split point to produce two tablets");
 
-        long heartbeatsBefore = heartbeats().size();
-        for (int round = 0; round < 5; ++round) {
-            TestHelper.execute("UPDATE t1 SET name = 'filtered-" + round + "' WHERE id < 5000;");
-            TestHelper.waitFor(Duration.ofSeconds(3));
-        }
+            Map<String, Long> before = new HashMap<>();
+            for (String tabletId : tablets) {
+                before.put(tabletId, serverCheckpointIndex(ybClient, table, dbStreamId, tabletId));
+            }
 
-        // Heartbeats must keep flowing for both tablets: the one whose records were all filtered and
-        // the one that never had any.
-        Awaitility.await().atMost(Duration.ofSeconds(90))
-                .until(() -> heartbeats().size() - heartbeatsBefore >= 2);
-        Set<String> heartbeatTablets = distinctTablets(heartbeats());
-        assertEquals(2, heartbeatTablets.size(),
-                "expected heartbeats for both tablets, saw: " + heartbeatTablets);
+            for (int round = 0; round < 5; ++round) {
+                TestHelper.execute("UPDATE t1 SET name = 'filtered-" + round + "';");
+                TestHelper.waitFor(Duration.ofSeconds(3));
+            }
+
+            assertTrue(dataRecords().isEmpty(),
+                    "expected every record to be filtered, saw " + dataRecords().size());
+
+            // Heartbeats have to reach both tablets: the one whose every record was filtered and the
+            // one that never had a record at all.
+            Awaitility.await().atMost(Duration.ofSeconds(90))
+                    .until(() -> distinctTablets(heartbeats()).size() >= 2);
+
+            // Emitting a heartbeat is not enough; the checkpoint has to move on the server.
+            Awaitility.await().atMost(Duration.ofSeconds(90)).until(() -> {
+                for (String tabletId : tablets) {
+                    if (serverCheckpointIndex(ybClient, table, dbStreamId, tabletId) <= before.get(tabletId)) {
+                        return false;
+                    }
+                }
+                return true;
+            });
+        }
+        finally {
+            ybClient.close();
+        }
 
         engine.stop();
     }
@@ -385,10 +385,91 @@ public class YugabyteDBHeartbeatTest extends YugabyteDBContainerTestBase {
 
             assertTrue(dataRecords().isEmpty(),
                     "expected every snapshot record to be filtered, saw " + dataRecords().size());
+
+            // Nothing was produced from the snapshot, so only the heartbeats can have moved these
+            // tablets off the position the stream started from.
+            Awaitility.await().atMost(Duration.ofSeconds(90)).until(() -> {
+                for (String tabletId : tablets) {
+                    if (serverCheckpointIndex(ybClient, table, dbStreamId, tabletId) <= 0) {
+                        return false;
+                    }
+                }
+                return true;
+            });
         }
         finally {
             ybClient.close();
         }
+
+        engine.stop();
+    }
+
+    @Test
+    public void heartbeatOffsetCarriesOnlyItsOwnTablet() throws Exception {
+        TestHelper.execute("CREATE TABLE t1 (id INT PRIMARY KEY, name TEXT) SPLIT INTO 3 TABLETS;");
+        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", false /* before image */,
+                true /* explicit checkpointing */, false, false);
+        Configuration config = TestHelper.getConfigBuilder("public.t1", dbStreamId)
+                .with(EmbeddedEngine.ENGINE_NAME, "heartbeat-own-tablet-test")
+                .with(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG,
+                        Testing.Files.createTestingFile("heartbeat-own-tablet.txt").getAbsolutePath())
+                .with(EmbeddedEngine.OFFSET_FLUSH_INTERVAL_MS, 0)
+                .with("heartbeat.interval.ms", 5000)
+                .with(EmbeddedEngine.CONNECTOR_CLASS, YugabyteDBgRPCConnector.class)
+                .build();
+
+        runEngine(config);
+        awaitUntilConnectorIsReady();
+
+        for (int i = 0; i < 60; ++i) {
+            TestHelper.execute("INSERT INTO t1 VALUES (" + i + ", " + i + "::text);");
+        }
+        Awaitility.await().atMost(Duration.ofSeconds(60)).until(() -> dataRecords().size() >= 40);
+
+        // Every tablet has to appear across the heartbeats. Since a heartbeat carries only its own
+        // tablet, that can only happen if each tablet emitted one for itself.
+        Awaitility.await().atMost(Duration.ofSeconds(90))
+                .until(() -> distinctTablets(heartbeats()).size() >= 3);
+
+        for (SourceRecord heartbeat : heartbeats()) {
+            Set<String> tablets = heartbeat.sourceOffset().keySet().stream()
+                    .filter(k -> !k.equals("transaction_id"))
+                    .collect(Collectors.toSet());
+            assertEquals(1, tablets.size(),
+                    "heartbeat offset must reference exactly one tablet, got: " + heartbeat.sourceOffset());
+        }
+
+        engine.stop();
+    }
+
+    @Test
+    public void heartbeatsAreOffByDefault() throws Exception {
+        TestHelper.execute("CREATE TABLE t1 (id INT PRIMARY KEY, name TEXT) SPLIT INTO 2 TABLETS;");
+        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1", false /* before image */,
+                true /* explicit checkpointing */, false, false);
+        // No heartbeat.interval.ms: the upstream default of 0 must leave heartbeats disabled.
+        Configuration config = TestHelper.getConfigBuilder("public.t1", dbStreamId)
+                .with(EmbeddedEngine.ENGINE_NAME, "heartbeat-default-off-test")
+                .with(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG,
+                        Testing.Files.createTestingFile("heartbeat-default-off.txt").getAbsolutePath())
+                .with(EmbeddedEngine.OFFSET_FLUSH_INTERVAL_MS, 0)
+                .with(EmbeddedEngine.CONNECTOR_CLASS, YugabyteDBgRPCConnector.class)
+                .build();
+
+        runEngine(config);
+        awaitUntilConnectorIsReady();
+
+        for (int i = 0; i < 20; ++i) {
+            TestHelper.execute("INSERT INTO t1 VALUES (" + i + ", 'row" + i + "');");
+        }
+        Awaitility.await().atMost(Duration.ofSeconds(60)).until(() -> dataRecords().size() >= 20);
+
+        // Idle long enough that any accidental non-zero default would have fired several times.
+        TestHelper.waitFor(Duration.ofSeconds(20));
+
+        assertTrue(heartbeats().isEmpty(),
+                "heartbeats must stay disabled unless heartbeat.interval.ms is set, got "
+                        + heartbeats().size());
 
         engine.stop();
     }


### PR DESCRIPTION
## Problem

The gRPC connector never emits heartbeats. `YugabyteDBEventDispatcher` builds a heartbeat instance from the factory, but nothing ever fires it (there is a leftover `// TODO: Add heartbeat event processing here` in `dispatchDataChangeEvent`), so `heartbeat.interval.ms` has no effect on the gRPC path.

Because a single task polls many tablets, a tablet whose recent changes never reach Kafka, all dropped by `skipped.operations` or an SMT, or simply idle relative to the stream, stops advancing its explicit checkpoint. The server then retains that tablet's WAL and intents, which grow until retention limits are hit and can eventually fail the task. The worst shapes are a tablet parked on the split wait-list and a tablet whose `GetChanges` keeps failing: both stop being reached by the polling loop, so they go silent exactly when their checkpoint most needs to keep moving. The same applies during the initial snapshot: a long snapshot whose records are filtered never acknowledges anything, so a crash restarts the scan from the beginning.

## Solution

Emit a heartbeat per tablet, paced by a per-tablet timer, at the start of each tablet's turn in the polling loop, in both streaming sources and through the snapshot. Every tablet keeps advancing regardless of activity, and each heartbeat carries only its own tablet's checkpoint.

- `YugabyteDBStreamingChangeEventSource`
  - Added `maybeEmitTabletHeartbeat(part, offsetContext)`, called at the top of each per-tablet pass, before the split wait-list skip and before `GetChanges`. A tablet waiting on a split callback or failing its calls is never reached later in the pass, so beating first keeps parked and erroring tablets advancing. Pacing is per tablet via a `tabletToLastHeartbeatMs` map; there is no "is the tablet behind" condition, so idle, filtered, and active tablets all advance uniformly.
  - Added `heartbeatIntervalMs`, derived from `connectorConfig.getHeartbeatInterval()`.
- `YugabyteDBConsistentStreamingSource`
  - Calls the same helper at the top of its own per-tablet pass. The consistent source overrides the polling loop, so heartbeats had never fired under `transaction.ordering`.
- `YugabyteDBSnapshotChangeEventSource`
  - Added `maybeEmitSnapshotHeartbeat(part, previousOffset)`, per-tablet paced beats through the snapshot. Acked beats feed the explicit checkpoint that the next snapshot `GetChanges` ships, so the snapshot paging key keeps advancing in `cdc_state` and a mid-snapshot crash resumes from the last persisted key instead of rescanning the tablet. This matters most when every snapshot record is filtered, where no data record ever acknowledges anything.
  - Kept the completion burst: one beat per tablet when all tablets finish, flushing each tablet's snapshot-final checkpoint at the boundary.
  - The dispatcher field is now `YugabyteDBEventDispatcher<TableId>` (the constructor already receives that type), making the offset-map overload reachable.
- `YugabyteDBEventDispatcher`
  - Added `dispatchHeartbeatEvent(YBPartition, Map offset)`, which calls `Heartbeat.forcedBeat` keyed to the tablet's source partition. The base `dispatchHeartbeatEvent` relies on `HeartbeatImpl`'s single task-wide timer, which would let only one tablet beat per interval; `forcedBeat` plus the per-tablet timer above gives each tablet its own cadence. Heartbeats share the record queue, so a beat can never overtake a data record and confirm past it.
  - Added a `close()` override that closes the dispatcher's heartbeat instance, releasing its resources (including the JDBC connection when a heartbeat action query is configured).
- `YugabyteDBOffsetContext`
  - Added `getOffset(YBPartition)`, an offset naming only the given tablet. Every heartbeat (streaming, snapshot pacing, completion burst) carries just its own tablet's checkpoint, so a beat for one tablet can never confirm a sibling past records that were not acknowledged. The method is identical to the one introduced by #413, so the two PRs merge cleanly in either order.

Under explicit checkpointing, an acked heartbeat advances that tablet's checkpoint through the existing `commit()` -> `commitOffset()` -> `GetChanges` -> `cdc_state` path, which is what releases the retained WAL.

Heartbeats stay opt-in: `heartbeat.interval.ms` keeps the upstream default of `0` (disabled), and a test now pins that default. Set a positive value to enable. Note that the heartbeat topic must exist or be creatable; on clusters with topic auto-creation disabled, pre-create `__debezium-heartbeat.<topic.prefix>` before enabling.

## Testing

All docker-based, in `YugabyteDBHeartbeatTest`. Every scenario test verifies the checkpoint on the server through `YBClient.getCheckpoint` (`cdc_state`), not only that heartbeat records appear.

- `heartbeatCarriesCheckpointPastFilteredUpdatesAndStreamingResumes`: single tablet, `heartbeat.interval.ms=10000`, `skipped.operations=u`. Inserts 10 rows (delivered), applies 10 updates (filtered), idles ~65s. Asserts at least 5 beats arrive during the idle window, the beat checkpoint is past the last delivered insert, the server checkpoint moved past its pre-idle value, and later inserts still stream through.
- `snapshotCompletionEmitsHeartbeatPerTablet`: 3-tablet table populated before the connector starts, so rows flow through the initial snapshot. The interval is set large enough that the streaming timer cannot fire, so any heartbeat can only be the completion burst. Asserts all 30 rows are delivered, exactly one beat per tablet, each carrying at least the last snapshot position, and a server checkpoint set for every tablet.
- `heartbeatsAdvanceATabletWhoseEveryRecordIsFiltered`: range table split at 5000, seeded on both sides before the stream exists (no snapshot), then only updates, all dropped by `skipped.operations=u`. Asserts zero data records were produced, beats flow for both tablets, and both tablets' server checkpoints advance past their baselines.
- `heartbeatsFlowWhenEverySnapshotRecordIsFiltered`: `snapshot.mode=initial` with `skipped.operations=r`, so every snapshot record is dropped. Asserts per-tablet beats, zero data records, and a server checkpoint set for every tablet.
- `heartbeatOffsetCarriesOnlyItsOwnTablet`: 3-tablet table; waits until all three tablets appear across the beats, then asserts every heartbeat's offset references exactly one tablet.
- `heartbeatsAreOffByDefault`: no `heartbeat.interval.ms` configured; streams rows, idles, asserts zero heartbeat records. Pins the opt-in default.
- Manual end-to-end on a real cluster: range-split table with 3 tablets, one deliberately idle, `heartbeat.interval.ms=10000`, Kafka Connect with snapshot plus streaming for 10 minutes. All three tablets, including the idle one, produced a heartbeat on the `__debezium-heartbeat` topic every ~10s. This run predates the per-tablet offset change, so its beats still carried the whole map; the single-tablet payload is covered by `heartbeatOffsetCarriesOnlyItsOwnTablet`.