### PR TITLE
[DBZ][yugabyte/yugabyte-db#32888] CDCSDK: Removing check of using slot name in config if available for a stream

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -1770,27 +1770,6 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
             return true;
         }
 
-        try (YBClient ybClient = YBClientUtils.getYbClient(config)) {
-            GetDBStreamInfoResponse getDBStreamInfoResponse = ybClient.getDBStreamInfo(streamId);
-            ListCDCStreamsResponse resp = ybClient.listCDCStreams(null, getDBStreamInfoResponse.getNamespaceId(), null);
-            for (CDCStreamInfo stream : resp.getStreams()) {
-                if (stream.getStreamId().equals(streamId)) {
-                    String slotName = stream.getCdcsdkYsqlReplicationSlotName();
-                    if (slotName == null || slotName.isEmpty()) {
-                        return false;
-                    } else {
-                        String errorFormat = "Stream ID %s is associated with replication slot %s. Please use slot name in the config instead of Stream ID.";
-                        String errorMessage = String.format(errorFormat, streamId, slotName);
-                        LOGGER.error(errorMessage);
-                        throw new DebeziumException(errorMessage);
-                    }
-                }
-            }
-        } catch (Exception e) {
-            LOGGER.error("Exception while making RPC calls to server");
-            throw new DebeziumException(e);
-        }
-
         return false;
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -28,10 +28,6 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.common.config.ConfigValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.yb.client.CDCStreamInfo;
-import org.yb.client.GetDBStreamInfoResponse;
-import org.yb.client.ListCDCStreamsResponse;
-import org.yb.client.YBClient;
 
 import io.debezium.DebeziumException;
 import io.debezium.config.ConfigDefinition;
@@ -1766,11 +1762,7 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
         String streamId = config.getString(YugabyteDBConnectorConfig.STREAM_ID);
 
         // For CQL tables as well as for the config not using Publication/Replication streamId will be non null
-        if (streamId == null || streamId.isEmpty()) {
-            return true;
-        }
-
-        return false;
+        return Strings.isNullOrEmpty(streamId);
     }
 
     /**

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBPublicationReplicationTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBPublicationReplicationTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.*;
 import org.yb.client.GetDBStreamInfoResponse;
 import org.yb.client.YBClient;
 
-import io.debezium.DebeziumException;
 import io.debezium.config.Configuration;
 import io.debezium.connector.yugabytedb.transforms.YBExtractNewRecordState;
 import io.debezium.transforms.ExtractNewRecordStateConfigDefinition;
@@ -170,7 +169,7 @@ public class YugabyteDBPublicationReplicationTest extends YugabyteDBContainerTes
     }
 
     @Test
-    public void oldConfigStreamIDShouldNotBePartOfReplicationSlot() throws Exception {
+    public void testConfigWithStreamIdShouldNotUsePublication() throws Exception {
         TestHelper.execute(TestHelper.createReplicationSlotStatement);
         TestHelper.execute(String.format(TestHelper.createPublicationForTableStatement, "pub", "t1"));
         String streamId = TestHelper.getStreamIdFromSlot("test_replication_slot");
@@ -180,13 +179,9 @@ public class YugabyteDBPublicationReplicationTest extends YugabyteDBContainerTes
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder("yugabyte", "public.t1", streamId);
         Configuration config = configBuilder.build();
 
-        DebeziumException exception = assertThrows(DebeziumException.class, ()->YugabyteDBConnectorConfig.shouldUsePublication(config));
-
-        String errorMessage = String.format(
-         "Stream ID %s is associated with replication slot %s. Please use slot name in the config instead of Stream ID.",
-                streamId, "test_replication_slot");
-        assertTrue(exception.getMessage().contains(errorMessage));
-
+        // Even if the stream ID is associated with a replication slot, a config specifying the
+        // stream ID directly should keep the old behaviour and not use the publication path.
+        assertFalse(YugabyteDBConnectorConfig.shouldUsePublication(config));
     }
 
     @Test


### PR DESCRIPTION
#### Problem
The issue occurred when `shouldUsePublication()` in `YugabyteDBConnectorConfig.java` threw an exception mentioning that the gRPC stream created via yb-admin cmd have a slot_name and so connector config should use slot_name instead of stream_id.
This function essentially checks that if the stream_id is provided in connector config, then such stream should not have the slot name. If such stream have the slot_name, the user should provide slot_name instead of stream_id for consuming records.
This worked previously from gRPC streams because they never had slot name. However with changes in https://github.com/yugabyte/yugabyte-db/commit/1cbc75d9f0cec24394608319719cfb8e073431f0, the gRPC streams are now given the slot names.

#### Solution
This condition is essentially invalid now and is now being removed via this PR. User can keep using stream_id for getting the records.

#### Test Plan
Modified test `YugabyteDBPublicationReplicationTest#oldConfigStreamIDShouldNotBePartOfReplicationSlot` so as to work with changed behaviour. Thus, changed the test name too to `testConfigWithStreamIdShouldNotUsePublication`.