### PR TITLE
Add SERVICE_LOAD plugin discovery support

### DIFF
--- a/src/main/resources/META-INF/services/org.apache.kafka.connect.source.SourceConnector
+++ b/src/main/resources/META-INF/services/org.apache.kafka.connect.source.SourceConnector
@@ -1,0 +1,1 @@
+io.debezium.connector.yugabytedb.YugabyteDBgRPCConnector


### PR DESCRIPTION
When Kafka-Connect is set up with `plugin.discovery=SERVICE_LOAD`, then the yugabyte connector is never found. This PR adds support for it.

For documentation about plugin discovery and service loading, see:
- https://docs.confluent.io/platform/current/installation/configuration/connect/index.html#plugin-discovery
- https://cwiki.apache.org/confluence/spaces/KAFKA/pages/240881354/KIP-898+Modernize+Connect+plugin+discovery
- https://kafka.apache.org/42/kafka-connect/connector-development-guide/#connector-example

I haven't been able to build this locally because I cannot download one of the dependencies:
```
mvn clean package -Dquick
[INFO] Scanning for projects...
[INFO]
[INFO] -------------< io.debezium:debezium-connector-yugabytedb >--------------
[INFO] Building YugabyteDB Source Connector dz.1.9.5.yb.grpc.2026.1-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
Downloading from maven.yugabyte.repo: s3://repository.yugabyte.com/maven/org/yb/yb-client/0.8.111-SNAPSHOT/yb-client-0.8.111-20260312.173733-1.pom
[ERROR] The AWS Access Key Id you provided does not exist in our records. (Service: Amazon S3; Status Code: 403; Error Code: InvalidAccessKeyId; Request ID: 2CJP8K1AA49YT6S8; S3 Extended Request ID: G2hL6zXcUgQZjSLrcpqlXdzWLllH0J7Wn0SrFcdT2YLlx9Xncm7nYc7fwkuE76K5w80CsYNYhvALTgMJk6DhpqZOoZKmUXnZ; Proxy: null)
[WARNING] s3://repository.yugabyte.com/maven - Connection refused
[INFO] Logged off - repository.yugabyte.com
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  3.014 s
[INFO] Finished at: 2026-08-07T15:13:25+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project debezium-connector-yugabytedb: Could not collect dependencies for project io.debezium:debezium-connector-yugabytedb:jar:dz.1.9.5.yb.grpc.2026.1-SNAPSHOT
[ERROR] Failed to read artifact descriptor for org.yb:yb-client:jar:0.8.111-20260312.173733-1
[ERROR] 	Caused by: The following artifacts could not be resolved: org.yb:yb-client:pom:0.8.111-20260312.173733-1 (absent): Could not transfer artifact org.yb:yb-client:pom:0.8.111-20260312.173733-1 from/to maven.yugabyte.repo (s3://repository.yugabyte.com/maven): Could not connect to repository
[ERROR] Failed to read artifact descriptor for org.yb:yb-client:jar:tests:0.8.111-20260312.173733-1
[ERROR] 	Caused by: The following artifacts could not be resolved: org.yb:yb-client:pom:0.8.111-20260312.173733-1 (absent): org.yb:yb-client:pom:0.8.111-20260312.173733-1 failed to transfer from s3://repository.yugabyte.com/maven during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of maven.yugabyte.repo has elapsed or updates are forced. Original error: Could not transfer artifact org.yb:yb-client:pom:0.8.111-20260312.173733-1 from/to maven.yugabyte.repo (s3://repository.yugabyte.com/maven): Could not connect to repository
[ERROR]
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
```