### PR TITLE
[DBZ][yugabyte/yugabyte-db#32752] Skip record position update on empty transaction COMMIT

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
@@ -344,8 +344,11 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
                         beginCountForTablet.merge(part.getId(), 1, Integer::sum);
                     } else if (message.getOperation() == ReplicationMessage.Operation.COMMIT) {
                         LOGGER.debug("LSN in case of COMMIT is " + lsn);
-                        offsetContext.updateRecordPosition(part, lsn, lastCompletelyProcessedLsn, message.getRawCommitTime(),
-                                String.valueOf(message.getTransactionId()), null, message.getRecordTime(), message.getXreplOriginId());
+                        Integer recordsInBlock = recordsInTransactionalBlock.get(part.getId());
+                        if (recordsInBlock == null || recordsInBlock != 0) {
+                            offsetContext.updateRecordPosition(part, lsn, lastCompletelyProcessedLsn, message.getRawCommitTime(),
+                                    String.valueOf(message.getTransactionId()), null, message.getRecordTime(), message.getXreplOriginId());
+                        }
 
                         if (recordsInTransactionalBlock.containsKey(part.getId())) {
                             if (recordsInTransactionalBlock.get(part.getId()) == 0) {
@@ -375,8 +378,11 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
                     beginCountForTablet.merge(part.getId(), 1, Integer::sum);
                 } else if (message.getOperation() == ReplicationMessage.Operation.COMMIT) {
                     LOGGER.debug("LSN in case of COMMIT is " + lsn);
-                    offsetContext.updateRecordPosition(part, lsn, lastCompletelyProcessedLsn, message.getRawCommitTime(),
-                            String.valueOf(message.getTransactionId()), null, message.getRecordTime(), message.getXreplOriginId());
+                    Integer recordsInBlock = recordsInTransactionalBlock.get(part.getId());
+                    if (recordsInBlock == null || recordsInBlock != 0) {
+                        offsetContext.updateRecordPosition(part, lsn, lastCompletelyProcessedLsn, message.getRawCommitTime(),
+                                String.valueOf(message.getTransactionId()), null, message.getRecordTime(), message.getXreplOriginId());
+                    }
                     dispatcher.dispatchTransactionCommittedEvent(part, offsetContext);
 
                     if (recordsInTransactionalBlock.containsKey(part.getId())) {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -658,8 +658,11 @@ public class YugabyteDBStreamingChangeEventSource implements
                                             }
                                             if (message.getOperation() == Operation.COMMIT) {
                                                 LOGGER.debug("LSN in case of COMMIT is " + lsn);
-                                                offsetContext.updateRecordPosition(part, lsn, lastCompletelyProcessedLsn, message.getRawCommitTime(),
-                                                        String.valueOf(message.getTransactionId()), null, message.getRecordTime(), message.getXreplOriginId());
+                                                Integer recordsInBlock = recordsInTransactionalBlock.get(part.getId());
+                                                if (recordsInBlock == null || recordsInBlock != 0) {
+                                                    offsetContext.updateRecordPosition(part, lsn, lastCompletelyProcessedLsn, message.getRawCommitTime(),
+                                                            String.valueOf(message.getTransactionId()), null, message.getRecordTime(), message.getXreplOriginId());
+                                                }
 
                                                 if (recordsInTransactionalBlock.containsKey(part.getId())) {
                                                     if (recordsInTransactionalBlock.get(part.getId()) == 0) {
@@ -687,8 +690,11 @@ public class YugabyteDBStreamingChangeEventSource implements
                                             beginCountForTablet.merge(part.getId(), 1, Integer::sum);
                                         } else if (message.getOperation() == Operation.COMMIT) {
                                             LOGGER.debug("LSN in case of COMMIT is " + lsn);
-                                            offsetContext.updateRecordPosition(part, lsn, lastCompletelyProcessedLsn, message.getRawCommitTime(),
-                                                    String.valueOf(message.getTransactionId()), null, message.getRecordTime(), message.getXreplOriginId());
+                                            Integer recordsInBlock = recordsInTransactionalBlock.get(part.getId());
+                                            if (recordsInBlock == null || recordsInBlock != 0) {
+                                                offsetContext.updateRecordPosition(part, lsn, lastCompletelyProcessedLsn, message.getRawCommitTime(),
+                                                        String.valueOf(message.getTransactionId()), null, message.getRecordTime(), message.getXreplOriginId());
+                                            }
                                             dispatcher.dispatchTransactionCommittedEvent(part, offsetContext);
 
                                             if (recordsInTransactionalBlock.containsKey(part.getId())) {


### PR DESCRIPTION
## Problem

The CDC stream delivers BEGIN and COMMIT markers for a transaction even when no change records for the tablet arrive between them; the connector already tracks and logs this case ("Records in the transactional block ... are 0"). On every COMMIT, both streaming sources unconditionally advance the tablet's last seen record position, including for these empty blocks.

An empty block emits nothing to Kafka, so the position it advances to can never be acknowledged. Under EXPLICIT checkpointing the tablet's last seen position ends up ahead of its explicit checkpoint with nothing in flight to close the gap. That stalls the two mechanisms gated on the tablet having nothing outstanding: the empty-poll self advance (#246) stops firing, so the checkpoint of a tablet that goes quiet after an empty commit freezes and pins WAL and intents retention, and after a tablet split the parent's checkpoint can no longer reach the split point, so the wait-list release for the children stalls with it.

Today the whole per-task offset map masks this most of the time: every record carries every tablet's position, so any sibling's acknowledgement also confirms the empty-commit position. It surfaces when the entire task is quiet, and becomes deterministic with per-tablet offsets (#413), which remove the masking entirely. This change is extracted unchanged out of #413 so it can be reviewed and land on its own; #413 depends on it for the empty-commit case.

## Solution

On COMMIT, advance the record position only when the transactional block carried at least one record for the tablet. A block with no tracked BEGIN keeps today's behavior. Applied to both transactional branches of `YugabyteDBStreamingChangeEventSource` and `YugabyteDBConsistentStreamingSource` (four sites). Everything else about COMMIT handling, the transaction committed event dispatch, block bookkeeping, and logging, is unchanged.

## Testing

- `YugabyteDBExplicitCheckpointingTest` (2/2) and `YugabyteDBTransactionMetadataTest` (6/6) pass on this branch (docker, yugabytedb/yugabyte:latest). Between them they cover explicit checkpoint propagation to the server through `commitOffset` and the transactional BEGIN/COMMIT bookkeeping around all four guarded sites with non-empty blocks.
- The hunks are byte-identical to what #413 previously carried, verified by diffing the two files between this branch and the #413 head at extraction time.