### PR TITLE
Add connector name tag to JMX metrics

### DIFF
--- a/metrics.yml
+++ b/metrics.yml
@@ -113,7 +113,26 @@ rules:
       context: "$2"
       table: "$4"
 
-  - pattern: "debezium.([^:]+)<type=connector-metrics, server=([^,]+), task=([^,]+), context=([^,]+), partition=([^>]+)>([^:]+)"
+  - pattern: "debezium.([^:]+)<type=connector-metrics, server=([^,]+), task=([^,]+), context=([^,]+), partition=([^,>]+), connector=([^>]+)>([^:]+)"
+    name: "debezium_metrics_$7"
+    labels:
+      plugin: "$1"
+      name: "$2"
+      context: "$4"
+      task: "$3"
+      partition: "$5"
+      connector: "$6"
+
+  - pattern: "debezium.([^:]+)<type=connector-metrics, server=([^,]+), task=([^,]+), context=([^,]+), connector=([^>]+)>([^:]+)"
+    name: "debezium_metrics_$6"
+    labels:
+      plugin: "$1"
+      name: "$2"
+      context: "$4"
+      task: "$3"
+      connector: "$5"
+
+  - pattern: "debezium.([^:]+)<type=connector-metrics, server=([^,]+), task=([^,]+), context=([^,]+), partition=([^,>]+)>([^:]+)"
     name: "debezium_metrics_$6"
     labels:
       plugin: "$1"
@@ -122,7 +141,7 @@ rules:
       task: "$3"
       partition: "$5"
 
-  - pattern: "debezium.([^:]+)<type=connector-metrics, server=([^,]+), task=([^,]+), context=([^>]+)>([^:]+)"
+  - pattern: "debezium.([^:]+)<type=connector-metrics, server=([^,]+), task=([^,]+), context=([^,>]+)>([^:]+)"
     name: "debezium_metrics_$5"
     labels:
       plugin: "$1"

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -56,6 +57,7 @@ import io.debezium.relational.RelationalTableFilters;
 import io.debezium.relational.TableId;
 import io.debezium.relational.Tables.TableFilter;
 import io.debezium.util.Clock;
+import io.debezium.util.Collect;
 import io.debezium.util.Metronome;
 import io.debezium.util.Strings;
 
@@ -616,6 +618,8 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
     public static final int DEFAULT_MBEAN_REGISTRATION_RETRIES = 12;
     public static final long DEFAULT_MBEAN_REGISTRATION_RETRY_DELAY_MS = 5_000;
     public static final long DEFAULT_LAST_CALLBACK_TIMEOUT_MS = 3 * 60 * 1000;
+
+    private static final String KAFKA_CONNECT_NAME = "name";
 
     @Override
     public JdbcConfiguration getJdbcConfig() {
@@ -2051,6 +2055,23 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
     @Override
     public String getConnectorName() {
         return Module.name();
+    }
+
+    /**
+     * Returns metric tags identifying this connector instance. {@link #getLogicalName()} is only the
+     * topic prefix, which every connector reading from the same database shares, whereas the name
+     * Kafka Connect assigned to the connector is unique within a worker.
+     *
+     * @return a single {@code connector} tag, or an empty map when the configuration carries no
+     *         {@code name} property
+     */
+    public Map<String, String> getConnectorMetricTags() {
+        return resolveConnectorMetricTags(getConfig());
+    }
+
+    static Map<String, String> resolveConnectorMetricTags(Configuration config) {
+        String connectorName = config.getString(KAFKA_CONNECT_NAME, "");
+        return connectorName.isEmpty() ? Collections.emptyMap() : Collect.linkMapOf("connector", connectorName);
     }
 
     public ConnectionFactory getConnectionFactory() {

--- a/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBMetrics.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBMetrics.java
@@ -62,10 +62,12 @@ public class YugabyteDBMetrics {
     registrationRetryDelay = Duration.ofMillis(connectorConfig.mbeanRegistrationRetryDelayMs());
 
     if (multiPartitionMode) {
-      this.name = metricName(connectorType, Collect.linkMapOf(
+      Map<String, String> tags = Collect.linkMapOf(
               "server", connectorName,
               "task", connectorConfig.getTaskId(),
-              "context", contextName));
+              "context", contextName);
+      tags.putAll(connectorConfig.getConnectorMetricTags());
+      this.name = metricName(connectorType, tags);
     } else {
       this.name = metricName(connectorType, connectorName, contextName);
     }
@@ -91,12 +93,13 @@ public class YugabyteDBMetrics {
     registrationRetryDelay = Duration.ofMillis(connectorConfig.mbeanRegistrationRetryDelayMs());
     
     if (multiPartitionMode) {
-      LOGGER.info("Configuring a metric with connector type {} server {}, task ID {} and context {}",
-                  connectorType, connectorName, taskId, contextName);
-      this.name = metricName(connectorType, Collect.linkMapOf(
+      Map<String, String> tags = Collect.linkMapOf(
           "server", connectorName,
           "task", taskId,
-          "context", contextName));
+          "context", contextName);
+      tags.putAll(connectorConfig.getConnectorMetricTags());
+      LOGGER.info("Configuring a metric with connector type {} and tags {}", connectorType, tags);
+      this.name = metricName(connectorType, tags);
     } else {
       this.name = metricName(connectorType, connectorName, contextName);
     }

--- a/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBSnapshotTaskMetrics.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBSnapshotTaskMetrics.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.yugabytedb.metrics;
 
 import java.util.Collection;
+import java.util.Map;
 
 import io.debezium.connector.base.ChangeEventQueueMetrics;
 import io.debezium.connector.common.CdcSourceTaskContext;
@@ -29,13 +30,15 @@ public class YugabyteDBSnapshotTaskMetrics extends AbstractYugabyteDBTaskMetrics
                                          YugabyteDBConnectorConfig connectorConfig,
                                          String taskId) {
         super(taskContext, "snapshot", changeEventQueueMetrics, partitions,
-                (YBPartition partition) -> new YugabyteDBSnapshotPartitionMetrics(taskContext,
-                        Collect.linkMapOf(
-                                "server", taskContext.getConnectorName(),
-                                "task", taskId,
-                                "context", "snapshot",
-                                "partition", partition.getFullPartitionName()),
-                        metadataProvider), connectorConfig, taskId);
+                (YBPartition partition) -> {
+                    Map<String, String> tags = Collect.linkMapOf(
+                            "server", taskContext.getConnectorName(),
+                            "task", taskId,
+                            "context", "snapshot",
+                            "partition", partition.getFullPartitionName());
+                    tags.putAll(connectorConfig.getConnectorMetricTags());
+                    return new YugabyteDBSnapshotPartitionMetrics(taskContext, tags, metadataProvider);
+                }, connectorConfig, taskId);
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBStreamingTaskMetrics.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBStreamingTaskMetrics.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.yugabytedb.metrics;
 
 import java.util.Collection;
+import java.util.Map;
 
 import io.debezium.connector.base.ChangeEventQueueMetrics;
 import io.debezium.connector.common.CdcSourceTaskContext;
@@ -31,13 +32,15 @@ public class YugabyteDBStreamingTaskMetrics extends AbstractYugabyteDBTaskMetric
                                           YugabyteDBConnectorConfig connectorConfig,
                                           String taskId) {
         super(taskContext, "streaming", changeEventQueueMetrics, partitions,
-                (YBPartition partition) -> new YugabyteDBStreamingPartitionMetrics(taskContext,
-                    Collect.linkMapOf(
-                        "server", taskContext.getConnectorName(),
-                        "task", taskId,
-                        "context", "streaming",
-                        "partition", partition.getFullPartitionName()),
-                    metadataProvider), connectorConfig, taskId);
+                (YBPartition partition) -> {
+                    Map<String, String> tags = Collect.linkMapOf(
+                            "server", taskContext.getConnectorName(),
+                            "task", taskId,
+                            "context", "streaming",
+                            "partition", partition.getFullPartitionName());
+                    tags.putAll(connectorConfig.getConnectorMetricTags());
+                    return new YugabyteDBStreamingPartitionMetrics(taskContext, tags, metadataProvider);
+                }, connectorConfig, taskId);
         connectionMeter = new ConnectionMeter();
     }
 

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConfigTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBConfigTest.java
@@ -1,8 +1,16 @@
 package io.debezium.connector.yugabytedb;
 
+import java.lang.management.ManagementFactory;
 import java.sql.SQLException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -12,6 +20,7 @@ import io.debezium.config.Configuration;
 import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
 import io.debezium.connector.yugabytedb.common.YugabytedTestBase;
 import io.debezium.connector.yugabytedb.connection.ReplicationConnection;
+import io.debezium.util.Collect;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -144,6 +153,54 @@ public class YugabyteDBConfigTest extends YugabyteDBContainerTestBase {
 
         assertEquals(300, intervals[0]);
         assertEquals(300, intervals[1]);
+    }
+
+    @Test
+    public void shouldTagMetricsWithTheConnectorNameAfterTheExistingTags() {
+        Configuration config = TestHelper.defaultConfig().with("name", "globaldb-core-collections").build();
+
+        Map<String, String> tags = Collect.linkMapOf(
+                "server", "globaldb",
+                "task", "0",
+                "context", "streaming",
+                "partition", "000043000000300080000000000308a1.9e0f2c4b");
+        tags.putAll(YugabyteDBConnectorConfig.resolveConnectorMetricTags(config));
+
+        assertEquals("server, task, context, partition, connector", String.join(", ", tags.keySet()));
+        assertEquals("globaldb-core-collections", tags.get("connector"));
+    }
+
+    @Test
+    public void shouldNotTagMetricsWhenKafkaConnectSuppliedNoName() {
+        Configuration config = TestHelper.defaultConfig().build();
+
+        assertTrue(YugabyteDBConnectorConfig.resolveConnectorMetricTags(config).isEmpty());
+    }
+
+    @Test
+    public void shouldRegisterMBeansTaggedWithTheConnectorName() throws Exception {
+        TestHelper.dropAllSchemas();
+
+        TestHelper.executeDDL("yugabyte_create_tables.ddl");
+
+        String dbStreamId = TestHelper.getNewDbStreamId("yugabyte", "t1");
+
+        startEngine(TestHelper.getConfigBuilder("public.t1", dbStreamId));
+
+        awaitUntilConnectorIsReady();
+
+        MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+        ObjectName pattern = new ObjectName("debezium.yugabytedb:type=connector-metrics,*");
+
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(30))
+                .until(() -> !mBeanServer.queryNames(pattern, null).isEmpty());
+
+        Set<ObjectName> registeredBeans = mBeanServer.queryNames(pattern, null);
+        for (ObjectName registeredBean : registeredBeans) {
+            assertTrue(registeredBean.getKeyPropertyListString().endsWith(",connector=test-connector"),
+                    "MBean is not tagged with the connector name: " + registeredBean);
+        }
     }
 
     // This verifies that the connector should not be running if a wrong table.include.list is provided


### PR DESCRIPTION
## Problem

The `server` tag on the task- and partition-scoped MBeans this connector registers is the Debezium logical name, i.e. the topic prefix. That is a property of the source database rather than of the connector, so every connector configured against the same database registers with the same `server` tag.

When more than one such connector runs in a Kafka Connect worker, this has two consequences:

1. **Metrics cannot be attributed to a connector.** `MilliSecondsBehindSource` and the event counters are only distinguishable down to the tablet in the `partition` tag, so lag reads as a property of the whole database. Recovering which connector a tablet belongs to means resolving table and tablet UUIDs out of band.

2. **Task-scoped MBeans collide.** `AbstractYugabyteDBTaskMetrics` registers at `server=<prefix>, task=<id>, context=<context>` with no `partition` tag, which is identical across connectors. Only the first connector to register succeeds; the rest exhaust the retry loop in `YugabyteDBMetrics#register` and log `Failed to register metrics MBean, metrics will not be available`. The observable symptom is one set of queue metrics per worker instead of one per connector.

## Change

Adds the name Kafka Connect assigned to the connector as a `connector` tag on the task- and partition-scoped MBeans.

- `YugabyteDBConnectorConfig#getConnectorMetricTags()` returns a `connector` tag read from Connect's `name` property, or an empty map when the configuration carries no `name` at all. A separate accessor is used because `getConnectorName()` is already overridden to return `Module.name()`, and `getLogicalName()` is the topic prefix.
- Each construction site appends it with `tags.putAll(connectorConfig.getConnectorMetricTags())`: the multi-partition task-level tag maps in `YugabyteDBMetrics`, and the partition tag maps in `YugabyteDBStreamingTaskMetrics` and `YugabyteDBSnapshotTaskMetrics`.

Mutating the map returned by `Collect.linkMapOf` is how Debezium core adds tags beyond the fixed set: `io.debezium.metrics.Metrics` has done exactly this for its `custom.metric.tags` since 2.6, and `Collect` offers no ordered-map factory past four pairs. Order matters because `metricName` serialises the map by iteration order.

**The tag is appended after the existing tags**, so any `ObjectName` pattern anchored on the leading tags keeps matching. `metricName(connectorType, connectorName, contextName)` is left untouched. `AbstractYugabyteDBTaskMetrics` always requests multi-partition mode, so the single-partition path is unaffected by this change.

## Effect on MBean names

`name` is set by Kafka Connect and propagated to every task, and `EmbeddedEngine.ENGINE_NAME` is the required field `name`, so the embedded engine and Debezium Server supply it too. The tag is therefore present in every deployment, and MBean names change accordingly — worth a release note. The empty-map path only applies to a `Configuration` built by hand, as in the unit tests below.

Anything matching MBean names by pattern has to account for the extra tag. `metrics.yml` in this repo gets two rules for the tagged beans, and the existing `debezium` rules have their trailing capture groups constrained from `[^>]+` to `[^,>]+` so that a tagged bean cannot fall through to a rule that silently absorbs the tag into the preceding label.

## Testing

- `mvn test-compile` passes.
- Three tests in `YugabyteDBConfigTest`. Two follow the shape of the existing `resolveCdcPollIntervals` tests against a static resolver taking a `Configuration`: one pins the resulting tag order, since exporter configurations depend on the tag being last, and one covers the absent-name case. The third starts the connector and asserts that every registered `debezium.yugabytedb:type=connector-metrics,*` MBean carries the tag, which covers the construction sites rather than the resolver.
