### PR TITLE
Fail fast on CHECKPOINT_TOO_OLD (GC'd WAL) instead of retrying GetChanges

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
@@ -280,6 +280,14 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
                     // The connector should ideally be stopped if this kind of state is reached.
                     throw new DebeziumException(ae);
                 } catch (Exception e) {
+                    // A checkpoint below the WAL retention floor can never be served, no matter
+                    // how often the request is retried - fail the task immediately instead of
+                    // masking the permanent failure behind the retry loop.
+                    if (isCheckpointTooOldFailure(e)) {
+                        LOGGER.error("WAL on the server has been garbage collected past the checkpoint for tablet {}; retries cannot succeed, failing the task", curTabletId, e);
+                        throw e;
+                    }
+
                     ++retryCount;
                     // If the retry limit is exceeded, log an error with a description and throw the exception.
                     if (retryCount > connectorConfig.maxConnectorRetries()) {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -844,6 +844,14 @@ public class YugabyteDBStreamingChangeEventSource implements
                         retryCount = 0;
                     }
                 } catch (Exception e) {
+                    // A checkpoint below the WAL retention floor can never be served, no matter
+                    // how often the request is retried - fail the task immediately instead of
+                    // masking the permanent failure behind the retry loop.
+                    if (isCheckpointTooOldFailure(e)) {
+                        LOGGER.error("WAL on the server has been garbage collected past the checkpoint for tablet {}; retries cannot succeed, failing the task", curTabletId, e);
+                        throw e;
+                    }
+
                     ++retryCount;
                     // If the retry limit is exceeded, log an error with a description and throw the exception.
                     if (retryCount > connectorConfig.maxConnectorRetries()) {
@@ -865,6 +873,45 @@ public class YugabyteDBStreamingChangeEventSource implements
                 }
             }
         }
+    }
+
+    /**
+     * Checks whether the given exception indicates that the WAL required to serve the tablet's
+     * checkpoint has already been garbage collected on the server (CHECKPOINT_TOO_OLD). Once the
+     * server has GC'd past the checkpoint, no retry of GetChanges can ever succeed, so this
+     * failure must be treated as terminal.
+     * <p>
+     * The typed {@link CDCErrorException} is usually available on the cause chain: when the
+     * client's retry budget is exhausted, AsyncYBClient chains the last attempt's exception as
+     * the cause of the surfaced {@link NonRecoverableException}. Some exhaustion paths surface
+     * no cause though, in which case the failure can only be recognized by the server error
+     * text appended to the message.
+     *
+     * @param throwable the exception to classify
+     * @return true if the failure is a GC'd-WAL failure and retrying is pointless
+     */
+    protected static boolean isCheckpointTooOldFailure(Throwable throwable) {
+        for (Throwable t = throwable; t != null; t = t.getCause()) {
+            if (t instanceof CDCErrorException) {
+                CdcService.CDCErrorPB error = ((CDCErrorException) t).getCDCError();
+                if (error != null && error.getCode() == Code.CHECKPOINT_TOO_OLD) {
+                    return true;
+                }
+            }
+
+            // Backstop for client paths which do not attach the typed CDC error.
+            if (t instanceof YBException) {
+                String message = t.getMessage();
+                if (message != null && (message.contains("garbage collected") || message.contains("already GCed"))) {
+                    return true;
+                }
+            }
+
+            if (t.getCause() == t) {
+                break;
+            }
+        }
+        return false;
     }
 
     private void probeConnectionIfNeeded() throws SQLException {

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingErrorClassificationTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingErrorClassificationTest.java
@@ -1,0 +1,87 @@
+package io.debezium.connector.yugabytedb;
+
+import java.lang.reflect.Constructor;
+
+import org.junit.jupiter.api.Test;
+import org.yb.cdc.CdcService;
+import org.yb.cdc.CdcService.CDCErrorPB.Code;
+import org.yb.client.CDCErrorException;
+import org.yb.client.YBException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the terminal classification of GC'd-WAL (CHECKPOINT_TOO_OLD) GetChanges
+ * failures, see {@link YugabyteDBStreamingChangeEventSource#isCheckpointTooOldFailure(Throwable)}.
+ */
+public class YugabyteDBStreamingErrorClassificationTest {
+
+    // Message text as surfaced by AsyncYBClient when the retry budget is exhausted, with the
+    // last attempt's server error appended.
+    private static final String GCED_WAL_MESSAGE =
+            "Too many attempts: YRpc(method=GetChanges, service=yb.cdc.CDCService, "
+            + "tablet=5850030e94824b1a9b163b42583c865d, attempt=68, maxAttempts=1800, "
+            + "maxTimeoutMs=900000, elapsedTimeMs=879055). "
+            + "Server[7c590f5172fa471bb897c8df6596ef9f] NOT_FOUND[code 1]: "
+            + "The logs from index 69914790 have been garbage collected and cannot be read : "
+            + "Failed to read ops 69914791..74395351: op index 69914791 has been already GCed "
+            + "from log index cache, max_gced_op_index: 71300580";
+
+    @Test
+    public void shouldClassifyCheckpointTooOldCdcErrorAsTerminal() throws Exception {
+        assertTrue(YugabyteDBStreamingChangeEventSource.isCheckpointTooOldFailure(
+                cdcErrorException("checkpoint too old", Code.CHECKPOINT_TOO_OLD)));
+    }
+
+    @Test
+    public void shouldClassifyCheckpointTooOldCdcErrorOnCauseChainAsTerminal() throws Exception {
+        // AsyncYBClient chains the last attempt's CDCErrorException as the cause of the
+        // NonRecoverableException it surfaces once the retry budget is exhausted.
+        Exception wrapped = new RuntimeException("Too many attempts",
+                cdcErrorException("checkpoint too old", Code.CHECKPOINT_TOO_OLD));
+        assertTrue(YugabyteDBStreamingChangeEventSource.isCheckpointTooOldFailure(wrapped));
+    }
+
+    @Test
+    public void shouldClassifyGcedWalMessageWithoutCauseAsTerminal() {
+        // Some retry-exhaustion paths surface no cause, leaving only the message text.
+        assertTrue(YugabyteDBStreamingChangeEventSource.isCheckpointTooOldFailure(
+                ybException(GCED_WAL_MESSAGE)));
+    }
+
+    @Test
+    public void shouldNotClassifyOtherCdcErrorsAsTerminal() throws Exception {
+        assertFalse(YugabyteDBStreamingChangeEventSource.isCheckpointTooOldFailure(
+                cdcErrorException("tablet split detected", Code.TABLET_SPLIT)));
+        assertFalse(YugabyteDBStreamingChangeEventSource.isCheckpointTooOldFailure(
+                cdcErrorException("leader not ready", Code.LEADER_NOT_READY)));
+    }
+
+    @Test
+    public void shouldNotClassifyOtherYbClientFailuresAsTerminal() {
+        assertFalse(YugabyteDBStreamingChangeEventSource.isCheckpointTooOldFailure(
+                ybException("Too many attempts: YRpc(method=GetChanges, ...). TimedOut[code 15]")));
+        assertFalse(YugabyteDBStreamingChangeEventSource.isCheckpointTooOldFailure(
+                ybException(null)));
+    }
+
+    @Test
+    public void shouldNotClassifyNonYbClientExceptionsByMessageText() {
+        // The message backstop only applies to yb-client exceptions.
+        assertFalse(YugabyteDBStreamingChangeEventSource.isCheckpointTooOldFailure(
+                new RuntimeException(GCED_WAL_MESSAGE)));
+    }
+
+    private static YBException ybException(String message) {
+        return new YBException(message) {
+        };
+    }
+
+    private static CDCErrorException cdcErrorException(String message, Code code) throws Exception {
+        CdcService.CDCErrorPB error = CdcService.CDCErrorPB.newBuilder().setCode(code).buildPartial();
+        Constructor<CDCErrorException> constructor =
+                CDCErrorException.class.getDeclaredConstructor(String.class, CdcService.CDCErrorPB.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(message, error);
+    }
+}


### PR DESCRIPTION
## Problem

When a tablet's CDC checkpoint falls below the retained WAL floor, `GetChanges` fails permanently with `CHECKPOINT_TOO_OLD` (`NOT_FOUND: The logs from index N have been garbage collected and cannot be read ... already GCed from log index cache, max_gced_op_index: M`). Since `max_gced_op_index` only ever moves forward, no retry can succeed.

The generic retry loop in the poll loop still treats this as retriable: it retries `max.connector.retries` times (default 5), and each attempt burns the full `operation.timeout.ms` (default 900000 ms) inside the yb-client before the `NonRecoverableException` surfaces. With default settings, a permanently broken stream reports RUNNING for ~90 minutes before the task finally fails, delaying detection and remediation.

## Change

Classify the failure as terminal and rethrow immediately, letting the existing producer-throwable path fail the task on the first surfaced exception (one yb-client retry budget instead of `max.connector.retries + 1`):

- `isCheckpointTooOldFailure(Throwable)` walks the cause chain looking for a `CDCErrorException` whose `CDCErrorPB` code is `CHECKPOINT_TOO_OLD`. `AsyncYBClient` chains the last attempt's exception as the cause of the `NonRecoverableException` it throws when the retry budget is exhausted (`tooManyAttemptsOrTimeout`), so the typed code is available in the common path.
- A message-text backstop (`"garbage collected"` / `"already GCed"`, scoped to `YBException` subclasses only) covers the client paths that surface the exhaustion exception with a null cause.
- Applied to both `YugabyteDBStreamingChangeEventSource` and `YugabyteDBConsistentStreamingSource` poll loops.

Other error codes (e.g. `TABLET_SPLIT`, `LEADER_NOT_READY`) keep the existing retry behavior.

## Testing

- New container-free unit tests covering: typed `CHECKPOINT_TOO_OLD` directly and via the cause chain, the verbatim exhaustion message with no cause, and negatives (`TABLET_SPLIT` / `LEADER_NOT_READY`, timeout messages, null message, and GC'd-WAL text on a non-yb-client exception must NOT match).
- Validated on a live environment with several tablets wedged below the WAL floor: tasks now fail on the first surfaced exception with `WAL on the server has been garbage collected past the checkpoint for tablet ...; retries cannot succeed, failing the task` instead of looping through `will attempt retry N of 5` for ~90 minutes.

## Notes

The first ~15 minutes (one internal yb-client retry budget for the `GetChanges` RPC) is unavoidable from the connector side; the yb-client itself retries `CHECKPOINT_TOO_OLD` internally until `maxAttempts`/`maxTimeoutMs`. A client-side fix to stop retrying that code would compose with this change, but is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
