### PR TITLE
[DBZ][yugabyte/yugabyte-db#30831] Use max_index_in_sort_window while sending GetChnages rpcs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <version.kafka>3.9.2</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.2.13</version.logback>
-        <version.ybclient>0.8.111-20260312.173733-1</version.ybclient>
+        <version.ybclient>0.8.122-20260819.111006-1</version.ybclient>
         <version.gson>2.13.2</version.gson>
 
         <!--

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
@@ -192,7 +192,8 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
                                             table, streamId, tabletId, cp.getTerm(), cp.getIndex(), cp.getKey(),
                                             cp.getWrite_id(), cp.getTime(), schemaNeeded.get(tabletId),
                                             taskContext.shouldEnableExplicitCheckpointing() ? tabletToExplicitCheckpoint.get(part.getId()) : null,
-                                            tabletSafeTime.getOrDefault(part.getId(), -1L), offsetContext.getWalSegmentIndex(part));
+                                            tabletSafeTime.getOrDefault(part.getId(), -1L), offsetContext.getWalSegmentIndex(part),
+                                            null /* getchangesRespMaxSizeBytes */, offsetContext.getMaxIndexInSortWindow(part));
                                 } catch (CDCErrorException cdcException) {
                                     // Check if exception indicates a tablet split.
                                     if (cdcException.getCDCError().getCode() == CdcService.CDCErrorPB.Code.TABLET_SPLIT) {
@@ -239,6 +240,7 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
                                             response.getResp().getSafeHybridTime());
                                     offsetContext.updateWalPosition(part, finalOpid);
                                     offsetContext.updateWalSegmentIndex(part, response.getWalSegmentIndex());
+                                    offsetContext.updateMaxIndexInSortWindow(part, response.getMaxIndexInSortWindow());
 
                                     tabletSafeTime.put(part.getId(), response.getResp().getSafeHybridTime());
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -50,6 +50,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
     private IncrementalSnapshotContext<TableId> incrementalSnapshotContext;
     private YugabyteDBConnectorConfig connectorConfig;
     private final Map<String, Integer> tabletWalSegmentIndex;
+    private final Map<String, Long> tabletMaxIndexInSortWindow;
 
     private YugabyteDBOffsetContext(YugabyteDBConnectorConfig connectorConfig,
                                     YugabyteDBTransactionContext transactionContext,
@@ -60,6 +61,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
         this.incrementalSnapshotContext = incrementalSnapshotContext;
         this.connectorConfig = connectorConfig;
         this.tabletWalSegmentIndex = new ConcurrentHashMap<>();
+        this.tabletMaxIndexInSortWindow = new ConcurrentHashMap<>();
     }
 
     public YugabyteDBOffsetContext(Offsets<YBPartition, YugabyteDBOffsetContext> previousOffsets,
@@ -80,6 +82,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
         this.incrementalSnapshotContext = new SignalBasedIncrementalSnapshotContext<>();
         this.connectorConfig = config;
         this.tabletWalSegmentIndex = new ConcurrentHashMap<>();
+        this.tabletMaxIndexInSortWindow = new ConcurrentHashMap<>();
     }
 
     /**
@@ -91,6 +94,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
         this.tabletSourceInfo = sourceInfoMap;
         this.fromLsn = new ConcurrentHashMap<>();
         this.tabletWalSegmentIndex = new ConcurrentHashMap<>();
+        this.tabletMaxIndexInSortWindow = new ConcurrentHashMap<>();
         this.transactionContext = new YugabyteDBTransactionContext();
     }
 
@@ -193,6 +197,14 @@ public class YugabyteDBOffsetContext implements OffsetContext {
 
     public Integer getWalSegmentIndex(YBPartition partition) {
         return this.tabletWalSegmentIndex.getOrDefault(partition.getId(), 0);
+    }
+
+    public void updateMaxIndexInSortWindow(YBPartition partition, long maxIndexInSortWindow) {
+        this.tabletMaxIndexInSortWindow.put(partition.getId(), maxIndexInSortWindow);
+    }
+
+    public Long getMaxIndexInSortWindow(YBPartition partition) {
+        return this.tabletMaxIndexInSortWindow.getOrDefault(partition.getId(), 0L);
     }
 
     /**

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -510,7 +510,8 @@ public class YugabyteDBStreamingChangeEventSource implements
                                                 explicitCheckpoint.getTerm(), explicitCheckpoint.getIndex());
                                     setCheckpointWithGetChanges(syncClient, tableIdToTable.get(part.getTableId()), part,
                                             cp, explicitCheckpoint, schemaNeeded.get(part.getId()),
-                                            tabletSafeTime.get(part.getId()), offsetContext.getWalSegmentIndex(part));
+                                            tabletSafeTime.get(part.getId()), offsetContext.getWalSegmentIndex(part),
+                                            offsetContext.getMaxIndexInSortWindow(part));
 
                                     LOGGER.info("Handling tablet split for enqueued tablet {} as we have now received the commit callback",
                                             part.getTabletId());
@@ -563,7 +564,8 @@ public class YugabyteDBStreamingChangeEventSource implements
                                         table, streamId, tabletId, cp.getTerm(), cp.getIndex(), cp.getKey(),
                                         cp.getWrite_id(), cp.getTime(), schemaNeeded.get(part.getId()),
                                         explicitCheckpoint,
-                                        tabletSafeTime.getOrDefault(part.getId(), cp.getTime()), offsetContext.getWalSegmentIndex(part));
+                                        tabletSafeTime.getOrDefault(part.getId(), cp.getTime()), offsetContext.getWalSegmentIndex(part),
+                                        null /* getchangesRespMaxSizeBytes */, offsetContext.getMaxIndexInSortWindow(part));
 
                                 // Test only.
                                 if (TEST_TRACK_EXPLICIT_CHECKPOINTS) {
@@ -823,6 +825,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                                     response.getResp().getSafeHybridTime());
                             offsetContext.updateWalPosition(part, finalOpid);
                             offsetContext.updateWalSegmentIndex(part, response.getResp().getWalSegmentIndex());
+                            offsetContext.updateMaxIndexInSortWindow(part, response.getResp().getMaxIndexInSortWindow());
 
                             tabletSafeTime.put(part.getId(), response.getResp().getSafeHybridTime());
 
@@ -920,20 +923,22 @@ public class YugabyteDBStreamingChangeEventSource implements
      * @param schemaNeeded whether we need schema in the response
      * @param tabletSafeTime
      * @param walSegmentIndex
+     * @param maxIndexInSortWindow
      * @throws Exception if we receive any other error than the one for tablet split upon calling
      * GetChanges
      */
     protected void setCheckpointWithGetChanges(YBClient syncClient, YBTable ybTable, YBPartition partition,
                                                OpId fromOpId, CdcSdkCheckpoint explicitCheckpoint,
                                                boolean schemaNeeded, long tabletSafeTime,
-                                               int walSegmentIndex) throws Exception {
+                                               int walSegmentIndex, long maxIndexInSortWindow) throws Exception {
         try {
             // This will throw an error saying tablet split detected as we are calling GetChanges again on the
             // same checkpoint - handle the error and move ahead.
             GetChangesResponse resp = syncClient.getChangesCDCSDK(
               ybTable, connectorConfig.streamId(), partition.getTabletId(), fromOpId.getTerm(),
               fromOpId.getIndex(), fromOpId.getKey(), fromOpId.getWrite_id(), fromOpId.getTime(),
-              schemaNeeded, explicitCheckpoint, tabletSafeTime, walSegmentIndex);
+              schemaNeeded, explicitCheckpoint, tabletSafeTime, walSegmentIndex,
+              null /* getchangesRespMaxSizeBytes */, maxIndexInSortWindow);
 
             // We do not update the tablet safetime we get from the response at this
             // point because the previous GetChanges call is supposed to throw


### PR DESCRIPTION
#### Problem

The diff https://phorge.dev.yugabyte.com/D56990  added a new field called `max_index_in_sort_window` to the GetChangesRequest and GetChangesResponse protos to solve a CDC data loss problem. However the gRPC connector cannot use these fields directly. Hence this PR.


#### Solution

This PR updates the yb-client version to `0.8.122-20260819.111006-1` so that we can use the new field in GetChanges rpcs. The usage of the field `max_index_in_sort_window` is identical to that of `wal_segment_index`. This means that for every tablet, the value of `max_index_in_sort_window` from the previous GetChanges response is passed on to the next request. The first request goes in with the default value 0.


#### Testing

No UT could be written since this field comes into action only when we have out of order applies in the WAL. There is no deterministic way to produce this in a UT.
The existing UTs in `YugabyteDBDatatypesTest` were run to ensure that there is no regression. 