### PR TITLE
Make failure-path error messages actionable

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YBClientUtils.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YBClientUtils.java
@@ -141,10 +141,19 @@ public class YBClientUtils {
               }
           }
       }
+      catch (DebeziumException e) {
+          // Already carries a specific, user-facing message (for example the table-not-in-stream
+          // error raised above); rethrow it as-is instead of nesting it inside another exception.
+          throw e;
+      }
       catch (Exception e) {
           // We are ultimately throwing this exception since this will be thrown while initializing 
           // the connector and at this point if this exception is thrown, we should not proceed 
           // forward with the connector.
+          // The context goes to the log rather than into the exception message so that the cause's
+          // own message stays the message of the thrown exception.
+          LOGGER.error("Failed to fetch the list of tables to stream for stream {}",
+                       connectorConfig.streamId(), e);
           throw new DebeziumException(e);
       }
       return tableIds;
@@ -175,8 +184,14 @@ public class YBClientUtils {
       }
       Collections.sort(tableToTabletIds, (a, b) -> a.getRight().compareTo(b.getRight()));
     }
+    catch (DebeziumException e) {
+        throw e;
+    }
     catch (Exception e) {
-        LOGGER.error("Error while fetching all the tablets", e);
+        // The context goes to the log rather than into the exception message so that the cause's
+        // own message stays the message of the thrown exception.
+        LOGGER.error("Error while fetching the tablets of tables {} for stream {}",
+                     tableIds, dbStreamId, e);
         throw new DebeziumException(e);
     }
 
@@ -503,8 +518,12 @@ public class YBClientUtils {
       }
     }
 
-    // In ideal scenarios, this code will never be hit.
-    LOGGER.warn("Returning null as checkpoint (should never happen, check code)");
-    return null;
+    // In ideal scenarios, this code will never be hit: the loop above either returns a
+    // response or rethrows. Throw instead of returning null so that a bug here surfaces
+    // here rather than as a message-less NullPointerException in the caller.
+    throw new IllegalStateException(String.format(
+      "Exhausted the retry loop for GetCheckpoint on tablet %s of stream %s without a "
+        + "response or an error; this indicates a bug in getCheckpointWithRetry",
+      tabletId, connectorConfig.streamId()));
   }
 }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeEventSourceCoordinator.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeEventSourceCoordinator.java
@@ -75,7 +75,7 @@ public class YugabyteDBChangeEventSourceCoordinator extends ChangeEventSourceCoo
                         previousOffset);
             }
             catch (SQLException e) {
-                throw new DebeziumException("Failed to determine catch-up streaming stopping LSN");
+                throw new DebeziumException("Failed to determine catch-up streaming stopping LSN", e);
             }
             LOGGER.info("Previous connector state exists and will stream events until {} then perform snapshot",
                     previousOffset.getStreamingStoppingLsn());

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeRecordEmitter.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeRecordEmitter.java
@@ -299,7 +299,9 @@ public class YugabyteDBChangeRecordEmitter extends RelationalChangeRecordEmitter
 
         }
         catch (SQLException e) {
-            throw new ConnectException("Database error while refresing table schema", e);
+            throw new ConnectException(String.format(
+                    "Database error while refreshing the schema of table %s for tablet %s",
+                    tableId, tabletId), e);
         }
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorTask.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorTask.java
@@ -354,7 +354,8 @@ public class YugabyteDBConnectorTask
                 if (retryCount > maxRetries) {
                     LOGGER.error("Too many errors connecting to server." +
                             " All {} retries failed.", maxRetries);
-                    throw new ConnectException(ex);
+                    throw new ConnectException(String.format(
+                            "Could not create a replication connection after %d retries", maxRetries), ex);
                 }
 
                 LOGGER.warn("Error connecting to server; will attempt retry {} of {} after {} " +

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
@@ -361,7 +361,9 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
                                         message.getTransactionId(), lsn, tabletId, recordsInTransactionalBlock.get(tabletId));
                             }
                         } else if (beginCountForTablet.get(part.getId()).intValue() == 0) {
-                            throw new DebeziumException("COMMIT record encountered without a preceding BEGIN record");
+                            throw new DebeziumException(commitWithoutBeginMessage(
+                                    part.getId(), message.getTransactionId(), lsn,
+                                    message.getRawCommitTime(), false));
                         }
 
                         recordsInTransactionalBlock.remove(part.getId());
@@ -396,7 +398,9 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
                                     message.getTransactionId(), lsn, part.getTabletId(), recordsInTransactionalBlock.get(part.getId()));
                         }
                     } else if (beginCountForTablet.get(part.getId()).intValue() == 0) {
-                        throw new DebeziumException("COMMIT record encountered without a preceding BEGIN record");
+                        throw new DebeziumException(commitWithoutBeginMessage(
+                                part.getId(), message.getTransactionId(), lsn,
+                                message.getRawCommitTime(), true));
                     }
 
                     recordsInTransactionalBlock.remove(part.getId());

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBErrorHandler.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBErrorHandler.java
@@ -26,7 +26,7 @@ public class YugabyteDBErrorHandler extends ErrorHandler {
 
     @Override
     protected boolean isRetriable(Throwable throwable) {
-        LOGGER.info("Received throwable to check for retry: {}", throwable);
+        LOGGER.info("Received throwable to check for retry", throwable);
 
         if (throwable.getMessage() == null) {
             LOGGER.warn("Exception message received in throwable is null");

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -179,7 +179,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
         }
         catch (Exception t) {
             completedSuccessfully = false;
-            throw new DebeziumException(t);
+            throw new DebeziumException("Failed to execute the snapshot phase", t);
         }
         finally {
             LOGGER.info("Snapshot - Final stage");

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -571,7 +571,8 @@ public class YugabyteDBStreamingChangeEventSource implements
                                 }
                             } catch (CDCErrorException cdcException) {
                                 // Check if exception indicates a tablet split.
-                                LOGGER.info("Code received in CDCErrorException: {}", cdcException.getCDCError().getCode());
+                                LOGGER.info("Code received in CDCErrorException: {}",
+                                  cdcException.getCDCError().getCode(), cdcException);
                                 if (cdcException.getCDCError().getCode() == Code.TABLET_SPLIT || cdcException.getCDCError().getCode() == Code.INVALID_REQUEST) {
                                     LOGGER.info("Encountered a tablet split on tablet {}, handling it gracefully", tabletId);
                                     if (LOGGER.isDebugEnabled()) {
@@ -604,7 +605,8 @@ public class YugabyteDBStreamingChangeEventSource implements
                                     // Break out of the loop so that the iteration can start afresh on the modified list.
                                     break;
                                 } else {
-                                    LOGGER.warn("Throwing error with code: {}", cdcException.getCDCError().getCode());
+                                    LOGGER.warn("Throwing unhandled CDC error with code {} for tablet {}",
+                                      cdcException.getCDCError().getCode(), tabletId, cdcException);
                                     throw cdcException;
                                 }
                             }
@@ -684,7 +686,9 @@ public class YugabyteDBStreamingChangeEventSource implements
                                                                 message.getTransactionId(), lsn, part.getId(), recordsInTransactionalBlock.get(part.getId()));
                                                     }
                                                 } else if (beginCountForTablet.get(part.getId()).intValue() == 0) {
-                                                    throw new DebeziumException("COMMIT record encountered without a preceding BEGIN record");
+                                                    throw new DebeziumException(commitWithoutBeginMessage(
+                                                            part.getId(), message.getTransactionId(), lsn,
+                                                            message.getRawCommitTime(), false));
                                                 }
 
                                                 recordsInTransactionalBlock.remove(part.getId());
@@ -717,7 +721,9 @@ public class YugabyteDBStreamingChangeEventSource implements
                                                             message.getTransactionId(), lsn, part.getId(), recordsInTransactionalBlock.get(part.getId()));
                                                 }
                                             } else if (beginCountForTablet.get(part.getId()).intValue() == 0) {
-                                                throw new DebeziumException("COMMIT record encountered without a preceding BEGIN record");
+                                                throw new DebeziumException(commitWithoutBeginMessage(
+                                                        part.getId(), message.getTransactionId(), lsn,
+                                                        message.getRawCommitTime(), true));
                                             }
 
                                             recordsInTransactionalBlock.remove(part.getId());
@@ -890,6 +896,30 @@ public class YugabyteDBStreamingChangeEventSource implements
         }
 
         return explicitCheckpoint;
+    }
+
+    /**
+     * Build the message for a COMMIT record that arrives without a preceding BEGIN record. This
+     * indicates that the stream is not delivering well-formed transaction boundaries, so the
+     * message needs to carry enough identifiers to locate the offending transaction on the server.
+     * <p>
+     * Kept as a single helper so that all the call sites (transaction metadata enabled and
+     * disabled, in both the streaming and the consistent-streaming source) stay in sync.
+     *
+     * @param partitionId the ID of the {@link YBPartition} the COMMIT was received for
+     * @param transactionId the transaction ID carried by the COMMIT record
+     * @param lsn the checkpoint of the COMMIT record
+     * @param commitTime the raw commit time of the COMMIT record
+     * @param transactionMetadataEnabled whether transaction metadata is being provided
+     * @return the message to use for the thrown exception
+     */
+    static String commitWithoutBeginMessage(String partitionId, String transactionId, OpId lsn,
+                                            long commitTime, boolean transactionMetadataEnabled) {
+        return String.format(
+                "COMMIT record encountered without a preceding BEGIN record for partition %s "
+                        + "(transaction %s, LSN %s, commit time %s); transaction metadata is %s",
+                partitionId, transactionId, lsn, commitTime,
+                transactionMetadataEnabled ? "enabled" : "disabled");
     }
 
     protected void maybeEmitTabletHeartbeat(YBPartition part, YugabyteDBOffsetContext offsetContext) {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBTablePoller.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBTablePoller.java
@@ -148,11 +148,13 @@ public class YugabyteDBTablePoller extends Thread {
         if (retryCount > MAX_RETRY_COUNT) {
           LOGGER.error("Retries exceeded the maximum retry count in table poller thread,"
                     + " all {} retries failed", MAX_RETRY_COUNT);
-          throw fail(e);
+          throw fail(e, String.format("getting the DB stream info for stream %s",
+                                      this.connectorConfig.streamId()));
         }
 
-        LOGGER.warn("Exception while trying to get DB stream Info in poller thread,"
-                  + "will retry again", e);
+        LOGGER.warn("Exception while getting the DB stream info for stream {} in the poller "
+                  + "thread; will check again on the next poll interval ({} ms)",
+                  this.connectorConfig.streamId(), pollMs, e);
         return false;
       }
     }
@@ -209,11 +211,13 @@ public class YugabyteDBTablePoller extends Thread {
         if (retryCount > MAX_RETRY_COUNT) {
           LOGGER.error("Retries exceeded the maximum retry count in table poller thread,"
                     + " all {} retries failed", MAX_RETRY_COUNT);
-          throw fail(e);
+          throw fail(e, String.format("reading the table list of publication %s",
+                                      this.connectorConfig.publicationName()));
         }
 
-        LOGGER.warn("Exception while trying to get DB stream Info in poller thread,"
-                  + "will retry again", e);
+        LOGGER.warn("Exception while reading the table list of publication {} in the poller "
+                  + "thread; will check again on the next poll interval ({} ms)",
+                  this.connectorConfig.publicationName(), pollMs, e);
         return false;
       }
     }
@@ -294,10 +298,11 @@ public class YugabyteDBTablePoller extends Thread {
   /**
    * Return a failure with {@link RuntimeException}
    * @param t the throwable object
+   * @param whileDoing description of the operation that failed, used in the error message
    * @return a RuntimeException
    */
-  private RuntimeException fail(Throwable t) {
-    String errorMessage = "Error while trying to get the DB stream Info in poller thread";
+  private RuntimeException fail(Throwable t, String whileDoing) {
+    String errorMessage = "Error in the table poller thread while " + whileDoing;
     LOGGER.error(errorMessage, t);
 
     RuntimeException runtimeException = new ConnectException(errorMessage, t);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBValueConverter.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBValueConverter.java
@@ -936,7 +936,8 @@ public class YugabyteDBValueConverter extends JdbcValueConverters {
                     r.deliver(converted);
                 }
                 catch (SQLException e) {
-                    throw new ConnectException("Failed to read value of array " + column.name());
+                    throw new ConnectException("Failed to read value of array column " + column.name()
+                            + " (type " + column.typeName() + ")", e);
                 }
             }
         });

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBgRPCConnector.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBgRPCConnector.java
@@ -343,7 +343,8 @@ public class YugabyteDBgRPCConnector extends RelationalBaseSourceConnector {
             LOGGER.debug("The master host address is " + hostAddress);
             HostAndPort masterHostPort = ybClient.getLeaderMasterHostAndPort();
             if (masterHostPort == null) {
-                LOGGER.error("Failed testing connection at {}", yugabyteDBConnectorConfig.hostname());
+                LOGGER.error("Could not determine the leader master; failed contacting the master "
+                        + "addresses {}", hostAddress);
             }
 
             // Do a get and check if the streamid exists.
@@ -415,6 +416,12 @@ public class YugabyteDBgRPCConnector extends RelationalBaseSourceConnector {
                 LOGGER.error(errorMessage, e);
                 throw new DebeziumException(errorMessage, e);
             }
+        }
+        catch (DebeziumException e) {
+            // Already carries a specific, user-facing message; rethrow it as-is so that it is not
+            // masked by the generic wrapper below.
+            LOGGER.warn("Connection validation failed", e);
+            throw e;
         }
         catch (Exception e) {
             LOGGER.warn("Exception while validating connection", e);

--- a/src/main/java/io/debezium/connector/yugabytedb/connection/YugabyteDBConnection.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/connection/YugabyteDBConnection.java
@@ -213,7 +213,9 @@ public class YugabyteDBConnection extends JdbcConnection {
      * Obtains the LSN to resume streaming from. On PG 9.5 there is no confirmed_flushed_lsn yet, so restart_lsn will be
      * read instead. This may result in more records to be re-read after a restart.
      */
-    private Lsn parseConfirmedFlushLsn(String slotName, String pluginName, String database, ResultSet rs) {
+    // Package-private rather than private so that the error paths can be unit tested without a
+    // live server; see YugabyteDBConnectionLsnMessageTest.
+    Lsn parseConfirmedFlushLsn(String slotName, String pluginName, String database, ResultSet rs) {
         Lsn confirmedFlushedLsn = null;
 
         try {
@@ -225,26 +227,35 @@ public class YugabyteDBConnection extends JdbcConnection {
                 confirmedFlushedLsn = tryParseLsn(slotName, pluginName, database, rs, "restart_lsn");
             }
             catch (SQLException e2) {
-                throw new ConnectException("Neither confirmed_flush_lsn nor restart_lsn could be found");
+                e2.addSuppressed(e);
+                throw new ConnectException(String.format(
+                        "Neither confirmed_flush_lsn nor restart_lsn could be read from the "
+                                + "pg_replication_slots row for slot = '%s', plugin = '%s', database = '%s'",
+                        slotName, pluginName, database), e2);
             }
         }
 
         return confirmedFlushedLsn;
     }
 
-    private Lsn parseRestartLsn(String slotName, String pluginName, String database, ResultSet rs) {
+    // Package-private for testing; see parseConfirmedFlushLsn.
+    Lsn parseRestartLsn(String slotName, String pluginName, String database, ResultSet rs) {
         Lsn restartLsn = null;
         try {
             restartLsn = tryParseLsn(slotName, pluginName, database, rs, "restart_lsn");
         }
         catch (SQLException e) {
-            throw new ConnectException("restart_lsn could be found");
+            throw new ConnectException(String.format(
+                    "restart_lsn could not be read from the pg_replication_slots row for "
+                            + "slot = '%s', plugin = '%s', database = '%s'",
+                    slotName, pluginName, database), e);
         }
 
         return restartLsn;
     }
 
-    private Lsn tryParseLsn(String slotName, String pluginName, String database, ResultSet rs, String column) throws ConnectException, SQLException {
+    // Package-private for testing; see parseConfirmedFlushLsn.
+    Lsn tryParseLsn(String slotName, String pluginName, String database, ResultSet rs, String column) throws ConnectException, SQLException {
         Lsn lsn = null;
 
         String lsnStr = rs.getString(column);
@@ -255,13 +266,15 @@ public class YugabyteDBConnection extends JdbcConnection {
             lsn = Lsn.valueOf(lsnStr);
         }
         catch (Exception e) {
-            throw new ConnectException("Value " + column + " in the pg_replication_slots table for slot = '"
+            throw new ConnectException("Value " + column + " ('" + lsnStr + "') in the pg_replication_slots table for slot = '"
                     + slotName + "', plugin = '"
                     + pluginName + "', database = '"
-                    + database + "' is not valid. This is an abnormal situation and the database status should be checked.");
+                    + database + "' is not valid. This is an abnormal situation and the database status should be checked.", e);
         }
         if (!lsn.isValid()) {
-            throw new ConnectException("Invalid LSN returned from database");
+            throw new ConnectException("Invalid LSN '" + lsnStr + "' returned from database in column " + column
+                    + " of the pg_replication_slots row for slot = '" + slotName + "', plugin = '"
+                    + pluginName + "', database = '" + database + "'");
         }
         return lsn;
     }

--- a/src/test/java/io/debezium/connector/yugabytedb/CommitWithoutBeginMessageTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/CommitWithoutBeginMessageTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.yugabytedb;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.yugabytedb.connection.OpId;
+
+/**
+ * Unit tests for {@link YugabyteDBStreamingChangeEventSource#commitWithoutBeginMessage}.
+ * <p>
+ * A COMMIT without a preceding BEGIN means the transaction boundaries coming off the stream are
+ * malformed, and the connector fails on it. The message is the only thing an operator gets, so it
+ * has to identify the tablet and the transaction - otherwise there is nothing to correlate against
+ * the server logs. This message is raised from four call sites (transaction metadata enabled and
+ * disabled, in both the streaming and the consistent-streaming source), which is why they all share
+ * one helper.
+ *
+ * @author Yaron Parasol
+ */
+public class CommitWithoutBeginMessageTest {
+
+    private static final String PARTITION_ID = "3fe122ffe3f24ad39c2cf8a57fa124b3.111111ffe3f24ad39c2cf8a57fa124b3";
+    private static final String TRANSACTION_ID = "6f3d8a1e-0000-0000-0000-000000000001";
+
+    private static OpId opId() {
+        return new OpId(3L, 42L, new byte[]{ 55, -6 }, 7, 1234567890L);
+    }
+
+    @Test
+    public void shouldIdentifyThePartitionTransactionAndPosition() {
+        String message = YugabyteDBStreamingChangeEventSource.commitWithoutBeginMessage(
+                PARTITION_ID, TRANSACTION_ID, opId(), 987654321L, false);
+
+        assertTrue(message.contains("COMMIT record encountered without a preceding BEGIN record"),
+                "Message should keep the recognisable summary, was: " + message);
+        assertTrue(message.contains(PARTITION_ID),
+                "Message should name the partition, was: " + message);
+        assertTrue(message.contains(TRANSACTION_ID),
+                "Message should name the transaction, was: " + message);
+        assertTrue(message.contains("index=42"),
+                "Message should carry the checkpoint of the offending record, was: " + message);
+        assertTrue(message.contains("987654321"),
+                "Message should carry the commit time, was: " + message);
+    }
+
+    @Test
+    public void shouldDistinguishTheTransactionMetadataDisabledCallSite() {
+        String message = YugabyteDBStreamingChangeEventSource.commitWithoutBeginMessage(
+                PARTITION_ID, TRANSACTION_ID, opId(), 987654321L, false);
+
+        assertTrue(message.contains("transaction metadata is disabled"),
+                "Message should say which of the two code paths raised it, was: " + message);
+    }
+
+    @Test
+    public void shouldDistinguishTheTransactionMetadataEnabledCallSite() {
+        String message = YugabyteDBStreamingChangeEventSource.commitWithoutBeginMessage(
+                PARTITION_ID, TRANSACTION_ID, opId(), 987654321L, true);
+
+        assertTrue(message.contains("transaction metadata is enabled"),
+                "Message should say which of the two code paths raised it, was: " + message);
+    }
+
+    @Test
+    public void shouldNotBreakOnAMissingTransactionId() {
+        // getTransactionId() can be null for records that carry no transaction, and building the
+        // message must not be the thing that fails while reporting a failure.
+        String message = YugabyteDBStreamingChangeEventSource.commitWithoutBeginMessage(
+                PARTITION_ID, null, opId(), 0L, true);
+
+        assertTrue(message.contains(PARTITION_ID),
+                "Message should still name the partition, was: " + message);
+        assertTrue(message.contains("null"),
+                "A missing transaction ID should be rendered rather than throwing, was: " + message);
+    }
+}

--- a/src/test/java/io/debezium/connector/yugabytedb/connection/YugabyteDBConnectionLsnMessageTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/connection/YugabyteDBConnectionLsnMessageTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.yugabytedb.connection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Map;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.jdbc.JdbcConfiguration;
+
+/**
+ * Unit tests for the failure paths of the replication-slot LSN parsing in
+ * {@link YugabyteDBConnection}. These paths only ever surface as an exception message in a
+ * connector log, so the message is the contract: it has to say which column could not be read,
+ * for which slot, and it has to keep the underlying {@link SQLException} as the cause.
+ * <p>
+ * No server is needed here - {@link YugabyteDBConnection} does not open a connection in its
+ * constructor, and the parsing methods take a {@link ResultSet} that is stubbed below.
+ *
+ * @author Yaron Parasol
+ */
+public class YugabyteDBConnectionLsnMessageTest {
+
+    private static final String SLOT = "test_slot";
+    private static final String PLUGIN = "yboutput";
+    private static final String DATABASE = "test_db";
+
+    /**
+     * A {@link ResultSet} stub that serves {@code getString(String)} from the supplied map. A null
+     * map value means the column is present but null; a column missing from the map throws a
+     * {@link SQLException}, which is how pgjdbc reports a column that is not in the result set.
+     * Every other method is unsupported - the code under test must not need them.
+     */
+    private static ResultSet resultSetReturning(Map<String, String> columns) {
+        InvocationHandler handler = (proxy, method, args) -> {
+            if ("getString".equals(method.getName()) && args != null && args.length == 1) {
+                String column = String.valueOf(args[0]);
+                if (!columns.containsKey(column)) {
+                    throw new SQLException("The column name " + column + " was not found in this ResultSet.");
+                }
+                return columns.get(column);
+            }
+            if ("toString".equals(method.getName())) {
+                return "ResultSetStub" + columns;
+            }
+            throw new UnsupportedOperationException("Unexpected ResultSet call: " + method.getName());
+        };
+
+        return (ResultSet) Proxy.newProxyInstance(
+                YugabyteDBConnectionLsnMessageTest.class.getClassLoader(),
+                new Class<?>[]{ ResultSet.class },
+                handler);
+    }
+
+    private static YugabyteDBConnection newConnection() {
+        // Any host/port will do: no connection is opened by the constructor or by the methods
+        // exercised below.
+        JdbcConfiguration config = JdbcConfiguration.adapt(Configuration.create()
+                .with(JdbcConfiguration.HOSTNAME, "127.0.0.1")
+                .with(JdbcConfiguration.PORT, 5433)
+                .with(JdbcConfiguration.USER, "yugabyte")
+                .with(JdbcConfiguration.PASSWORD, "yugabyte")
+                .with(JdbcConfiguration.DATABASE, DATABASE)
+                .build());
+
+        return new YugabyteDBConnection(config, YugabyteDBConnection.CONNECTION_GENERAL);
+    }
+
+    @Test
+    public void restartLsnFailureShouldReportTheColumnTheSlotAndTheCause() {
+        YugabyteDBConnection connection = newConnection();
+        // restart_lsn absent from the result set, so tryParseLsn will throw a SQLException.
+        ResultSet rs = resultSetReturning(Map.of());
+
+        ConnectException ex = assertThrows(ConnectException.class,
+                () -> connection.parseRestartLsn(SLOT, PLUGIN, DATABASE, rs));
+
+        // Guards against the message regressing to "restart_lsn could be found", which stated the
+        // opposite of the failure.
+        assertTrue(ex.getMessage().contains("restart_lsn could not be read"),
+                "Message should say the value could NOT be read, was: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(SLOT), "Message should name the slot, was: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(PLUGIN), "Message should name the plugin, was: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(DATABASE), "Message should name the database, was: " + ex.getMessage());
+
+        // The JDBC failure must remain reachable, not just be logged.
+        assertTrue(ex.getCause() instanceof SQLException,
+                "The SQLException should be attached as the cause");
+    }
+
+    @Test
+    public void confirmedFlushLsnFailureShouldReportBothColumnsAndKeepBothCauses() {
+        YugabyteDBConnection connection = newConnection();
+        // Neither column is present, so both the primary read and the restart_lsn fallback fail.
+        ResultSet rs = resultSetReturning(Map.of());
+
+        ConnectException ex = assertThrows(ConnectException.class,
+                () -> connection.parseConfirmedFlushLsn(SLOT, PLUGIN, DATABASE, rs));
+
+        assertTrue(ex.getMessage().contains("confirmed_flush_lsn"),
+                "Message should name confirmed_flush_lsn, was: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("restart_lsn"),
+                "Message should name restart_lsn, was: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(SLOT), "Message should name the slot, was: " + ex.getMessage());
+
+        // The fallback failure is the cause and the original failure is kept as suppressed, so no
+        // information about either attempt is lost.
+        assertTrue(ex.getCause() instanceof SQLException, "The fallback SQLException should be the cause");
+        assertEquals(1, ex.getCause().getSuppressed().length,
+                "The confirmed_flush_lsn failure should be retained as a suppressed exception");
+    }
+
+    @Test
+    public void unparseableLsnShouldReportTheOffendingValueAndKeepTheCause() {
+        YugabyteDBConnection connection = newConnection();
+        // "zz/1" has the right shape but is not hexadecimal, so Lsn.valueOf throws.
+        ResultSet rs = resultSetReturning(Map.of("restart_lsn", "zz/1"));
+
+        ConnectException ex = assertThrows(ConnectException.class,
+                () -> connection.tryParseLsn(SLOT, PLUGIN, DATABASE, rs, "restart_lsn"));
+
+        assertTrue(ex.getMessage().contains("zz/1"),
+                "Message should quote the offending value, was: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("restart_lsn"),
+                "Message should name the column, was: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(SLOT), "Message should name the slot, was: " + ex.getMessage());
+
+        // The parse failure must remain reachable rather than being dropped on the floor.
+        assertNotNull(ex.getCause(), "The parse failure should be attached as the cause");
+        assertTrue(ex.getCause() instanceof NumberFormatException,
+                "Expected the NumberFormatException as the cause, got: " + ex.getCause());
+    }
+
+    @Test
+    public void invalidLsnShouldReportTheValueTheColumnAndTheSlot() {
+        YugabyteDBConnection connection = newConnection();
+        // No slash, so Lsn.valueOf returns INVALID_LSN rather than throwing.
+        ResultSet rs = resultSetReturning(Map.of("confirmed_flush_lsn", "not-an-lsn"));
+
+        ConnectException ex = assertThrows(ConnectException.class,
+                () -> connection.tryParseLsn(SLOT, PLUGIN, DATABASE, rs, "confirmed_flush_lsn"));
+
+        // Guards against the message regressing to the bare "Invalid LSN returned from database".
+        assertTrue(ex.getMessage().contains("not-an-lsn"),
+                "Message should quote the invalid value, was: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("confirmed_flush_lsn"),
+                "Message should name the column, was: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(SLOT), "Message should name the slot, was: " + ex.getMessage());
+    }
+
+    @Test
+    public void nullColumnShouldReturnNullWithoutThrowing() throws Exception {
+        YugabyteDBConnection connection = newConnection();
+        ResultSet rs = resultSetReturning(java.util.Collections.singletonMap("restart_lsn", null));
+
+        assertNull(connection.tryParseLsn(SLOT, PLUGIN, DATABASE, rs, "restart_lsn"),
+                "A null column value is not an error and should yield a null Lsn");
+    }
+
+    @Test
+    public void validLsnShouldBeParsed() throws Exception {
+        YugabyteDBConnection connection = newConnection();
+        ResultSet rs = resultSetReturning(Map.of("restart_lsn", "0/15D68C50"));
+
+        Lsn lsn = connection.tryParseLsn(SLOT, PLUGIN, DATABASE, rs, "restart_lsn");
+
+        assertTrue(lsn.isValid(), "A well formed LSN should parse to a valid Lsn");
+    }
+}

--- a/src/test/java/io/debezium/connector/yugabytedb/connection/YugabyteDBConnectionLsnMessageTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/connection/YugabyteDBConnectionLsnMessageTest.java
@@ -126,6 +126,48 @@ public class YugabyteDBConnectionLsnMessageTest {
     }
 
     @Test
+    public void confirmedFlushLsnShouldBeUsedWhenItIsPresent() throws Exception {
+        YugabyteDBConnection connection = newConnection();
+        // Both columns present and valid; the primary one must win and the fallback must not be
+        // consulted.
+        ResultSet rs = resultSetReturning(Map.of(
+                "confirmed_flush_lsn", "0/15D68C50",
+                "restart_lsn", "0/AAAAAAA"));
+
+        Lsn lsn = connection.parseConfirmedFlushLsn(SLOT, PLUGIN, DATABASE, rs);
+
+        assertEquals(Lsn.valueOf("0/15D68C50"), lsn,
+                "confirmed_flush_lsn should be preferred over restart_lsn when it is readable");
+    }
+
+    @Test
+    public void shouldFallBackToRestartLsnWhenConfirmedFlushLsnCannotBeRead() throws Exception {
+        YugabyteDBConnection connection = newConnection();
+        // confirmed_flush_lsn absent (as on a server that does not expose it), restart_lsn present:
+        // the documented fallback should kick in and return the restart_lsn value.
+        ResultSet rs = resultSetReturning(Map.of("restart_lsn", "0/15D68C50"));
+
+        Lsn lsn = connection.parseConfirmedFlushLsn(SLOT, PLUGIN, DATABASE, rs);
+
+        assertNotNull(lsn, "The fallback should return the restart_lsn value, not null");
+        assertEquals(Lsn.valueOf("0/15D68C50"), lsn,
+                "The returned LSN should be the one read from restart_lsn");
+        assertTrue(lsn.isValid(), "The LSN returned by the fallback should be valid");
+    }
+
+    @Test
+    public void shouldFallBackToRestartLsnEvenWhenItIsNull() throws Exception {
+        YugabyteDBConnection connection = newConnection();
+        // confirmed_flush_lsn absent and restart_lsn present but null. tryParseLsn returns null for
+        // a null column rather than throwing, so the fallback succeeds with a null result and must
+        // not be reported as a failure.
+        ResultSet rs = resultSetReturning(java.util.Collections.singletonMap("restart_lsn", null));
+
+        assertNull(connection.parseConfirmedFlushLsn(SLOT, PLUGIN, DATABASE, rs),
+                "A null restart_lsn is not an error once the fallback has been taken");
+    }
+
+    @Test
     public void unparseableLsnShouldReportTheOffendingValueAndKeepTheCause() {
         YugabyteDBConnection connection = newConnection();
         // "zz/1" has the right shape but is not hexadecimal, so Lsn.valueOf throws.


### PR DESCRIPTION
## Why

An audit of every `catch` / `throw` / error-log site under `src/main` turned up a consistent problem on the connector's failure paths: the message an operator gets is frequently too vague to act on, and in several places the underlying exception is discarded entirely, so the real cause survives only in a log line — or not at all.

Two of the messages were actively misleading. `"restart_lsn could be found"` was missing its negation and stated the opposite of what had happened. The master-connection failure reported the YSQL hostname rather than the master addresses it had actually tried to contact.

This PR covers the message-quality findings only. The separate class of findings — non-retriable errors that never reach the connector at all — is not addressed here; see the follow-ups below.

## What changed

- **Attach the cause** wherever a wrapping exception discarded it: the catch-up streaming stopping LSN, the replication-slot LSN reads, and the array value converter.
- **Add the identifiers needed to correlate against the server**: slot, plugin and database on the LSN failures; table and tablet on the schema refresh; stream and table IDs on the tablet fetch; the offending value on an unparseable or invalid LSN.
- **Fix the two misleading messages** described above.
- **Split the table poller's messages** by path. The DB-stream-info path and the publication path previously shared one message that named stream info even when the failure came from `pg_publication_tables`. The `"will retry again"` claim is now stated as what actually happens — a check on the next poll interval.
- **Stop the generic wrapper in `validateConnection`** from masking the specific validation messages underneath it. A `DebeziumException` already carrying a user-facing message is now rethrown as-is.
- **Log the throwable** rather than only its code or its `toString()` in the CDC error paths and in the error handler, so a stack trace is available.
- **Replace the four identical copies** of the COMMIT-without-BEGIN message with one helper that reports the partition, transaction, LSN and commit time, plus which of the two code paths raised it.
- **Throw instead of returning null** from `getCheckpointWithRetry`'s unreachable tail, so a bug there cannot surface as a message-less `NullPointerException` in the caller.

## Compatibility notes

The wraps in `fetchTableList` and `getTabletListMappedToTableIds` deliberately keep their cause-only form. `DebeziumException(Throwable)` copies the cause's `toString()` into the message, and `YugabyteDBConfigTest:169` and `:223` depend on that. Their added context goes to the log instead, leaving the exception chain unchanged.

The LSN parsing helpers in `YugabyteDBConnection` become package-private so their failure paths can be unit tested without a running server.

## Tests

These paths had no coverage. Both new test classes run without a YugabyteDB container, so they add seconds rather than minutes to the build.

- `YugabyteDBConnectionLsnMessageTest` drives the replication-slot LSN parsing through a `Proxy`-based `ResultSet` stub and asserts that each failure names the column, slot, plugin and database, quotes the offending value where there is one, and keeps the `SQLException` reachable as the cause. The `confirmed_flush_lsn` case also checks that the first failure survives as a suppressed exception once the `restart_lsn` fallback fails too. Two happy-path cases pin the behaviour for a null column and a well-formed LSN.
- `CommitWithoutBeginMessageTest` covers the extracted helper: that it identifies the partition, transaction, checkpoint and commit time, that it distinguishes the two call sites, and that a null transaction ID does not make message construction itself throw while it is reporting a failure.

10 tests, all passing locally.

## Follow-ups worth filing

1. **Negative-path assertions in `YugabyteDBConfigTest` cannot fail.** They sit inside `startEngine` completion callbacks, which run on an executor thread whose `Future` `TestBaseClass` discards, so an `AssertionError` raised there never reaches the JUnit thread. Repairing the harness is the highest-value test change available in this repo, but it will turn several currently-green tests red before they are fixed — which is why it is not in this PR.
2. **Four of those assertions test a path the embedded engine never executes.** `EmbeddedEngine` calls `SourceConnector.start(Map)` but never `SourceConnector.validate(Map)`, so `validateConnection` is not invoked in that test path, yet four tests assert on strings that exist only inside it. They need to call `connector.validate(...)` directly.
3. **Non-retriable errors that are never propagated** — a separate set of findings from the same audit, including a dead retry loop in `YugabyteDBTablePoller` that makes `fail()` unreachable, and a swallow-then-`requireNonNull` pattern in `YBClientUtils` that turns real errors into message-less NPEs.
