### PR TITLE
[DBZ][yugabyte/yugabyte-db#33702] Support Kafka Connect 4.x: stop bundling Kafka classes, add ServiceLoader manifests, move base image to Kafka 4.3.1

### DIFF
--- a/base_source_image/Dockerfile
+++ b/base_source_image/Dockerfile
@@ -6,7 +6,7 @@
 # -------
 # Provides a Kafka Connect runtime with Confluent serialization libraries,
 # replacing the upstream `debezium/connect:1.9.5.Final` image. Rolling our
-# own base lets us pin JDK 21, Kafka 3.9.2, Ubuntu 22.04 (Jammy), and a
+# own base lets us pin JDK 21, Kafka 4.3.1, Ubuntu 22.04 (Jammy), and a
 # non-root `kafka` user (UID 1001), and patch CVEs on our own cadence.
 #
 # Image contents
@@ -65,7 +65,7 @@ LABEL maintainer="yugabyte" \
 # Set the Debezium version, Kafka version, and Scala version (needed for download URL).
 #
 ARG DEBEZIUM_VERSION=1.9
-ARG KAFKA_VERSION=3.9.2
+ARG KAFKA_VERSION=4.3.1
 ARG SCALA_VERSION=2.13
 
 #
@@ -175,14 +175,23 @@ RUN mkdir $KAFKA_HOME/config.orig && \
     mv $KAFKA_HOME/config/* $KAFKA_HOME/config.orig && \
     chown -R 1001:kafka $KAFKA_HOME/config.orig
 
-# Pin stdout appender threshold to INFO (matches upstream debezium/connect).
-# Stops PUT /admin/loggers->DEBUG from flooding stdout and stalling the connector,
-# while still letting WARN/ERROR through.
-RUN for f in $KAFKA_HOME/config.orig/log4j.properties $KAFKA_HOME/config.orig/connect-log4j.properties; do \
-        if [ -f "$f" ] && ! grep -q '^log4j.appender.stdout.threshold' "$f"; then \
-            sed -i '/^log4j.appender.stdout=org.apache.log4j.ConsoleAppender/a log4j.appender.stdout.threshold=INFO' "$f"; \
-        fi; \
-    done
+# Kafka 4.x has no log4j.properties, so the fetched Debezium start script would
+# leave the worker with no logging. Point it at our connect-log4j2.yaml instead:
+# stock Kafka's file plus a ThresholdFilter that caps stdout at INFO, so turning
+# on DEBUG at runtime (PUT /admin/loggers) cannot flood stdout and stall the
+# connector. DEBUG still reaches connect.log. CONNECT_LOG4J_* and LOG_LEVEL edit
+# log4j 1.x files and have no effect on 4.x.
+COPY base_source_image/connect-log4j2.yaml /tmp/connect-log4j2.yaml
+RUN set -e; \
+    [ "${KAFKA_VERSION%%.*}" -ge 4 ] || { echo "FATAL: this Dockerfile supports Kafka 4.x only (got ${KAFKA_VERSION})"; exit 1; }; \
+    cp /tmp/connect-log4j2.yaml $KAFKA_HOME/config.orig/connect-log4j2.yaml; \
+    sed -i "s|config/log4j.properties|config/connect-log4j2.yaml|g" /scripts/kafka-connect-start.sh; \
+    sed -i "s|-Dlog4j.configuration=file:|-Dlog4j2.configurationFile=file:|g" /scripts/kafka-connect-start.sh; \
+    grep -q 'log4j2.configurationFile' /scripts/kafka-connect-start.sh \
+        || { echo "FATAL: failed to repoint KAFKA_LOG4J_OPTS at connect-log4j2.yaml"; exit 1; }; \
+    grep -q 'ThresholdFilter' $KAFKA_HOME/config.orig/connect-log4j2.yaml \
+        || { echo "FATAL: connect-log4j2.yaml missing stdout ThresholdFilter"; exit 1; }; \
+    rm -f /tmp/connect-log4j2.yaml
 
 # Remove unnecessary files (sources, javadoc, scaladoc JARs)
 RUN rm -f $KAFKA_HOME/libs/*-{sources,javadoc,scaladoc}.jar*

--- a/base_source_image/connect-log4j2.yaml
+++ b/base_source_image/connect-log4j2.yaml
@@ -1,0 +1,42 @@
+# Kafka Connect logging for Kafka 4.x (log4j2).
+#
+# This is Apache Kafka's stock connect-log4j2.yaml with one addition: a
+# ThresholdFilter that caps the console appender at INFO. A logger raised to
+# DEBUG through PUT /admin/loggers therefore cannot flood stdout and stall the
+# connector. DEBUG output still reaches the connect.log file appender.
+
+Configuration:
+  Properties:
+    Property:
+      - name: "kafka.logs.dir"
+        value: "."
+      - name: "logPattern"
+        value: "[%d] %p %X{connector.context}%m (%c:%L)%n"
+
+  Appenders:
+    Console:
+      name: STDOUT
+      PatternLayout:
+        pattern: "${logPattern}"
+      Filters:
+        ThresholdFilter:
+          level: INFO
+          onMatch: ACCEPT
+          onMismatch: DENY
+
+    RollingFile:
+      - name: ConnectAppender
+        fileName: "${sys:kafka.logs.dir}/connect.log"
+        filePattern: "${sys:kafka.logs.dir}/connect-%d{yyyy-MM-dd-HH}.log"
+        PatternLayout:
+          pattern: "${logPattern}"
+        TimeBasedTriggeringPolicy:
+          modulate: true
+          interval: 1
+
+  Loggers:
+    Root:
+      level: INFO
+      AppenderRef:
+        - ref: STDOUT
+        - ref: ConnectAppender

--- a/base_source_image/docker-entrypoint.sh
+++ b/base_source_image/docker-entrypoint.sh
@@ -7,16 +7,6 @@ set -e
 cp -rn $KAFKA_HOME/config.orig/* $KAFKA_HOME/config
 
 case $1 in
-    zookeeper)
-        shift
-        # Change the Zookeeper snapshot directory in zookeeper.properties file
-        sed -i "s|dataDir=.*|dataDir=${ZK_DATA}|" $KAFKA_HOME/config/zookeeper.properties
-        if [ -z "$1" ]; then
-            exec $KAFKA_HOME/bin/zookeeper-server-start.sh $KAFKA_HOME/config/zookeeper.properties
-        else
-            echo "Zookeeper can not have any arguments"
-        fi
-        ;;
     kafka)
         shift
         # Set the directory where the logs for kafka will be stored
@@ -45,7 +35,7 @@ case $1 in
         fi
         ;;
     *)
-        echo "First argument must be either zookeeper, kafka or kafka-connect."
+        echo "First argument must be either kafka or kafka-connect."
         exit 1
         ;;
 esac

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <!-- Dependency Versions -->
         <version.postgresql.driver>42.7.7</version.postgresql.driver>
         <version.com.google.protobuf>4.30.2</version.com.google.protobuf>
-        <version.kafka>3.9.2</version.kafka>
+        <version.kafka>4.3.1</version.kafka>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.logback>1.2.13</version.logback>
         <version.ybclient>0.8.122-20260819.111006-1</version.ybclient>
@@ -203,11 +203,13 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
             <version>${version.kafka}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-transforms</artifactId>
             <version>${version.kafka}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -490,6 +492,9 @@
                         </goals>
                         <configuration>
                             <minimizeJar>true</minimizeJar>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>

--- a/src/main/resources/META-INF/services/org.apache.kafka.connect.source.SourceConnector
+++ b/src/main/resources/META-INF/services/org.apache.kafka.connect.source.SourceConnector
@@ -1,0 +1,1 @@
+io.debezium.connector.yugabytedb.YugabyteDBgRPCConnector

--- a/src/main/resources/META-INF/services/org.apache.kafka.connect.transforms.Transformation
+++ b/src/main/resources/META-INF/services/org.apache.kafka.connect.transforms.Transformation
@@ -1,0 +1,5 @@
+io.debezium.connector.yugabytedb.transforms.PGCompatible
+io.debezium.connector.yugabytedb.transforms.StriimCompatible
+io.debezium.connector.yugabytedb.transforms.YBExtractNewRecordState
+io.aiven.kafka.connect.transforms.ExtractTopic$Key
+io.aiven.kafka.connect.transforms.ExtractTopic$Value


### PR DESCRIPTION
## Problem

The connector's core CDC path already works on Kafka Connect 4.x, but the shipped jar and image break in three ways:

- `connect-api` and `connect-transforms` are compile-scope, so maven-shade packs ~1,850 `org.apache.kafka` classes into the fat jar, including Kafka's own SMTs. Connect loads `org.apache.kafka.connect.transforms.*` child-first from the plugin, so our bundled 3.9.2 `ReplaceField` runs and calls `ConfigUtils.translateDeprecatedConfigs`, removed in Kafka 4.0. Any connector configured with `ReplaceField` fails at task start on a 4.x worker with `NoSuchMethodError`. Bumping `version.kafka` while still bundling flips the direction: 4.3's `DropHeaders`/`MaskField`/`ReplaceField` call `ConfigDef.ValidList.anyNonDuplicateValues`, missing on 4.1. Upstream Debezium declares these dependencies `provided`; ours were compile-scope only because this pom has no `debezium-parent` to inherit from.
- No ServiceLoader manifests, so under `plugin.discovery=service_load` the connector is silently missing from `/connector-plugins`.
- Kafka 4.x ships only log4j2 configs. The fetched Debezium 1.9 start script hardcodes `-Dlog4j.configuration=<log4j.properties>`, so a 4.x worker starts with no logging (`Reconfiguration failed: No configuration found`), and the stdout INFO cap patched into `log4j.properties` silently no-ops.

## Solution

Connector code is unchanged; changes are packaging and image only.

- `pom.xml`: `connect-api` and `connect-transforms` are `provided` (jar 39 MB -> 26 MB, 0 bundled Kafka classes), so the worker's own SMTs load and always match its internals. `version.kafka` set to 4.3.1, now purely the compile target. Added shade's `ServicesResourceTransformer` so service files merge.
- `META-INF/services`: manifests for `YugabyteDBgRPCConnector` and our transforms, making the plugin discoverable under `service_load`.
- `base_source_image/Dockerfile`: `ARG KAFKA_VERSION=4.3.1`. Installs `connect-log4j2.yaml` (stock Kafka file plus a `ThresholdFilter` capping stdout at INFO; DEBUG still reaches `connect.log`) and repoints the start script to `-Dlog4j2.configurationFile`, both asserted at build time. Targets Kafka 4.x only; a 3.9.x image builds from a pre-4.x release tag.
- `docker-entrypoint.sh`: ZooKeeper branch removed.
- `CONNECT_LOG4J_*` and `LOG_LEVEL` have no effect on 4.x; use `/admin/loggers`.

## Testing

Manual, against a live YugabyteDB 2026.1.1.1 CDC stream, one jar for all stacks.

- Broker + worker at 3.9.2 / 4.1.2 / 4.3.1 (KRaft): 20 SMT configurations (all 16 Kafka built-ins plus our four), each as its own connector with rows driven through `apply()`. 18/20 on every stack; the 2 failures are pre-existing record-shape limits identical on today's release (`Cast$Key`: key is a STRUCT; `TimestampRouter`: records carry no timestamp).
- Core scenarios 8/8 on every stack under `plugin.discovery=service_load`: insert/update/delete with tombstone, `ALTER TABLE ADD COLUMN` mid-stream, task restart, `snapshot.mode=initial` and `initial_only`, `cdc_state` checkpoint advance, worker kill and restart, `/admin/loggers`.
- Cross-version: 4.3.1 worker image against a 3.9.2 broker with `ReplaceField` streams correctly. The current release reproduces the `ReplaceField` failure on 4.1.2 and 4.3.0.
- Image at 4.3.1: logging present, no log4j errors, no ServiceLoader warning. DEBUG via `/admin/loggers`: 0 DEBUG lines on stdout, ~21k in `connect.log`. `CONNECT_PLUGIN_DISCOVERY=service_load` works. Avro against Schema Registry 7.9.0 verified (subjects registered, wire format checked); Confluent 7.9.x libraries need no bump.
- Existing UTs