### PR TITLE
Return the cached tablet schema in newTable instead of rebuilding per record

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeRecordEmitter.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeRecordEmitter.java
@@ -269,6 +269,14 @@ public class YugabyteDBChangeRecordEmitter extends RelationalChangeRecordEmitter
     }
 
     private Optional<DataCollectionSchema> newTable(TableId tableId) {
+        // Schemas are cached per (table, tablet). Return the registered tablet schema on a hit;
+        // only a genuine miss needs the rebuild below. DDL refreshes it via
+        // refreshSchemaWithTabletId.
+        final TableSchema cachedSchema = schema.schemaForTablet(tableId, tabletId);
+        if (cachedSchema != null) {
+            return Optional.of(cachedSchema);
+        }
+
         LOGGER.debug("Creating a new schema entry for table: {} and tablet {}", tableId, tabletId);
         refreshTableFromDatabase(tableId);
         final TableSchema tableSchema = schema.schemaForTablet(tableId, tabletId);


### PR DESCRIPTION
## Problem

`YugabyteDBEventDispatcher.dispatchDataChangeEvent` resolves the schema with the table-keyed `RelationalDatabaseSchema.schemaFor(dataCollectionId)`, but this connector caches schemas per `(table, tablet)` in `YugabyteDBSchema.tabletIdToTableSchema`. Nothing on the streaming path writes the table-keyed map — its only writer is `refreshSchemas`, reachable only from the deprecated and uncalled `refreshWithSchema` — so that lookup returns `null` for every record, and the inconsistent-schema fallback becomes the normal per-record path:

```
dispatchDataChangeEvent -> inconsistentSchemaHandler -> updateSchema -> newTable -> refreshTableFromDatabase
```

There is no log line or warning to indicate this is happening.

## Change

`newTable` returns the registered tablet schema directly, and what remains below it is only the miss case.

- Return `schemaForTablet(tableId, tabletId)` on a hit, skipping `refreshTableFromDatabase`.
- Remove the lookup that followed the refresh and the success branch it fed. Both were unreachable — see below.
- Log the hit at TRACE, and name the tablet in the miss warning, since the cache is keyed per tablet.
- Drop the `refreshed DB schema to include table '{}'` debug line. It fired once per record and announced a refresh that had not contributed to the schema being returned.

One method, one file.

## The removed branch was unreachable

Two disjoint caches with two disjoint writers:

| cache | sole writer | reached from |
| --- | --- | --- |
| `tabletIdToTable` | `readSchemaWithTablet` | `refresh(...)` ← `refreshTableFromDatabase` |
| `tabletIdToTableSchema` | `buildAndRegisterSchemaForTablet` | `refreshSchemaWithTabletId` ← DDL handling |

`schemaForTablet` reads only the second map. `refreshTableFromDatabase` writes only the first: `readSchemaWithTablet` makes no reference to `tabletIdToTableSchema`, and that map has exactly one `put` in the file.

The two `schemaForTablet` calls in the old `newTable` were the same call — same map, same key (`tabletId` is `final`, `tableId` is the unchanged parameter) — with nothing between them that writes that map. The second therefore returned whatever the first would have, and the success branch after the refresh ran if and only if the lookup would already have succeeded before it.

That condition is exactly the new guard, which gives the tightest statement of behaviour preservation: for every input the same branch is taken as before, and the only thing dropped is a refresh that never contributed to the return value.

## Behaviour by case

| case | before | after |
| --- | --- | --- |
| schema registered (every record in practice) | refresh, lookup → `S`, return `S` | return the same `S` |
| no DDL ever received for the tablet | refresh raises on the null cached `schemaPB` | unchanged |
| DDL received, table excluded by `tableFilter` | refresh rewrites an identical `Table`, lookup → null, warn, empty | refresh, warn, empty |

`refreshTableFromDatabase` is deliberately retained on the miss path. Removing it would turn the second row from a failed task into a silently dropped record.

DDL invalidation is unaffected. `refreshSchemaWithTabletId` repopulates `tabletIdToTable` and `tabletIdToTableSchema` together, and DDL messages are handled inline ahead of subsequent DML dispatch in all three sources (`YugabyteDBStreamingChangeEventSource`, `YugabyteDBConsistentStreamingSource`, `YugabyteDBSnapshotChangeEventSource`), so no stale-schema window opens.

The one side effect skipped on a hit is `refreshToastableColumnsMap`, reachable only under `schema.refresh.mode=columns_diff_exclude_unchanged_toast` (default is `columns_diff`). Its output feeds `undeliveredToastableColumns` in `columnValues`/`updatedColumnValues`, which is built and mutated but never read, so emitted records are unchanged.

## A miss is not a steady state

The tablet schema cache is not an eviction cache: no TTL, no size bound, and its only `remove` is immediately followed by a re-`put` in the same method. It is filled by explicit request — `schemaNeeded` starts `TRUE` for every tablet, rides along as `needSchemaInfo` on every `getChangesCDCSDK` call, and is cleared only once a DDL message has arrived and been registered. Tablet splits re-arm it for the new tablets. A miss therefore means a tablet was served DML without ever being sent the DDL it asked for, not that the cache had not warmed up yet.

## Field validation

Deployed for ~8 days on a Kafka Connect fleet running 209 gRPC connectors, with a second fleet of 86 connectors on a build without the change as a control. CPU and TLAB-allocation profiles from both.

`YugabyteDBChangeRecordEmitter.newTable` callees:

| build          | callee                             | share |
| -------------- | ---------------------------------- | ----- |
| without change | `refreshTableFromDatabase`         | 99.8% |
| with change    | `YugabyteDBSchema.schemaForTablet` | 100%  |

`refreshTableFromDatabase` does not appear anywhere in the profile of the fleet carrying the change, across all 15 pods and both ReplicaSets of a rollout that happened inside the measurement window. No schema-related errors, no `cannot load schema for table` warnings, and no change in emitted record contents over that period. The absence of those warnings is also the field evidence that the miss path does not fire in steady state.

## Magnitude, and how it scales with load

The removed work is per-record, so its cost tracks record rate. Measurements across two very different traffic regimes:

| condition                                  | cost                            |
| ------------------------------------------ | ------------------------------- |
| original profile, heavy traffic            | **~9% process CPU, ~16% allocation** |
| ~600 events/s, synthetic peak              | 0.26% CPU                       |
| 21–41 records/s, without change            | 0.09% CPU                       |
| 37–86 records/s, with change               | 0.00% CPU                       |

The ~9% / ~16% figures quoted in the commit message come from the profile that surfaced the bug, taken when the fleet was carrying substantially more traffic than it has since. The lower figures are recent windows at a small fraction of that throughput.

These are not apples-to-apples: different traffic levels, and the recent windows are not a re-run of the original conditions. But they are consistent with per-record work — the cost is proportional to records processed, which is what motivates taking it off the hot path regardless of the rate at any given moment. At high traffic it was a material share of process CPU; at low traffic it is dominated by fixed per-connector overhead (clock reads and JMX scraping).

Two limits on what the field data can attribute to this change specifically:

1. The fleet carrying this change also carries #424 (eager debug/trace log argument evaluation), which the control fleet does not. Aggregate CPU, allocation and lag differences between the two fleets therefore cannot be attributed to this change alone. The `newTable` callee swap above is the part that is specific to it.
2. Profiles are sampled and account for ~7.8% of measured container CPU, uniformly in both fleets. Shares within a profile and ratios between fleets are comparable; absolute byte and second figures are sampled quantities.

## Not addressed here

Two things this PR leaves alone:

- The dispatcher still consults the table-keyed map that nothing populates, so every record continues to take the inconsistent-schema path to reach `newTable`. Fixing that properly means either pointing the dispatcher at the tablet-keyed cache or registering into the table-keyed one, which is a much larger change than this.
- On a miss with no cached `schemaPB`, `refreshTableFromDatabase` raises an NPE from `schemaPB.getColumnInfoList()` in `getColumnsDetailsWithSchema`. It surfaces through the dispatcher's failure-handling mode, so it is not silent, but the message is poor. Happy to open a separate issue.

## Testing

Compiles against current `main`, including the Kafka 4.x changes from #425, with checkstyle enabled.

The correctness risk here is returning a stale or wrong schema, which the existing integration tests cover: `YugabyteDBSchemaEvolutionTest`, `YugabyteDBColocatedTablesTest`, `YugabyteDBTabletSplitTest` and `YugabyteDBPerTabletOffsetTest` all exercise this path. I have not run them locally since they need a live YugabyteDB via testcontainers, so this is a draft pending a CI run.

I have not added a test. The behaviour being changed is a cache hit on a private method, and the repository has no unit-test layer to hang one on, so a new test would mean introducing mocking or reflection that nothing else here uses. Happy to add one if you would rather have it, in whatever form fits your conventions.
